### PR TITLE
Replace skeletons with shimmer placeholders

### DIFF
--- a/lib/components/list_item_component.dart
+++ b/lib/components/list_item_component.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:skeletons/skeletons.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
+import 'package:hoot/components/shimmer_skeletons.dart';
 
 class ListItemComponent extends StatelessWidget {
   final Widget? leading;
@@ -24,7 +25,7 @@ class ListItemComponent extends StatelessWidget {
             left: 0,
             right: 0,
             bottom: 0,
-            child: Skeleton(
+            child: ShimmerLoading(
               isLoading: isLoading,
               skeleton: Container(
                 decoration: BoxDecoration(
@@ -69,7 +70,7 @@ class ListItemComponent extends StatelessWidget {
           leading != null ? Positioned(
             top: 0,
             left: 20,
-            child: Skeleton(
+            child: ShimmerLoading(
               isLoading: isLoading,
               skeleton: Container(
                 width: 100,

--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -8,7 +8,8 @@ import 'package:hoot/models/post.dart';
 import 'package:hoot/app/controllers/auth_controller.dart';
 import 'package:hoot/services/error_service.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
-import 'package:skeletons/skeletons.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
+import 'package:hoot/components/shimmer_skeletons.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
@@ -231,41 +232,30 @@ class _PostComponentState extends State<PostComponent> with TickerProviderStateM
         children: [
           Row(
             children: [
-              const SkeletonAvatar(
-                style: SkeletonAvatarStyle(
-                  borderRadius: BorderRadius.all(Radius.circular(20)),
-                  width: 40,
-                  height: 40,
-                ),
+              const ShimmerBox(
+                width: 40,
+                height: 40,
+                shape: BoxShape.circle,
               ),
               const SizedBox(width: 16),
               Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  SkeletonLine(
-                    style: SkeletonLineStyle(
-                      width: MediaQuery.of(context).size.width * 0.25,
-                      height: 20,
-                    ),
+                  ShimmerBox(
+                    width: MediaQuery.of(context).size.width * 0.25,
+                    height: 20,
                   ),
                   const SizedBox(height: 5),
-                  SkeletonLine(
-                    style: SkeletonLineStyle(
-                      width: MediaQuery.of(context).size.width * 0.10,
-                      height: 20,
-                    ),
+                  ShimmerBox(
+                    width: MediaQuery.of(context).size.width * 0.10,
+                    height: 20,
                   ),
                 ],
               )
             ],
           ),
           const SizedBox(height: 10),
-          SkeletonParagraph(
-            style: const SkeletonParagraphStyle(
-              spacing: 10,
-              lines: 2,
-            ),
-          ),
+          const ShimmerParagraph(lines: 2, spacing: 10),
         ],
       ),
     ) :

--- a/lib/components/shimmer_skeletons.dart
+++ b/lib/components/shimmer_skeletons.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer_animation/shimmer_animation.dart';
+
+/// Basic shimmer box used for placeholders.
+class ShimmerBox extends StatelessWidget {
+  final double width;
+  final double height;
+  final BoxShape shape;
+  final BorderRadius? borderRadius;
+  const ShimmerBox({
+    super.key,
+    this.width = double.infinity,
+    required this.height,
+    this.shape = BoxShape.rectangle,
+    this.borderRadius,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer(
+      child: Container(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceVariant,
+          shape: shape,
+          borderRadius: shape == BoxShape.circle ? null : borderRadius ?? BorderRadius.circular(8),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shimmer paragraph consisting of multiple lines.
+class ShimmerParagraph extends StatelessWidget {
+  final int lines;
+  final double spacing;
+  final double height;
+  const ShimmerParagraph({
+    super.key,
+    this.lines = 2,
+    this.spacing = 8,
+    this.height = 10,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(lines, (index) {
+        return Padding(
+          padding: EdgeInsets.only(bottom: index == lines - 1 ? 0 : spacing),
+          child: ShimmerBox(height: height, width: double.infinity),
+        );
+      }),
+    );
+  }
+}
+
+/// Simple list tile skeleton.
+class ShimmerListTile extends StatelessWidget {
+  final bool hasLeading;
+  final bool hasSubtitle;
+  final double leadingSize;
+  const ShimmerListTile({
+    super.key,
+    this.hasLeading = true,
+    this.hasSubtitle = false,
+    this.leadingSize = 50,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          if (hasLeading)
+            ShimmerBox(
+              height: leadingSize,
+              width: leadingSize,
+              shape: BoxShape.circle,
+            ),
+          if (hasLeading) const SizedBox(width: 8),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ShimmerBox(height: 22, width: double.infinity),
+                if (hasSubtitle) ...[
+                  const SizedBox(height: 8),
+                  ShimmerBox(height: 16, width: double.infinity),
+                ]
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Utility widget to switch between skeleton and child.
+class ShimmerLoading extends StatelessWidget {
+  final bool isLoading;
+  final Widget skeleton;
+  final Widget child;
+  const ShimmerLoading({
+    super.key,
+    required this.isLoading,
+    required this.skeleton,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return isLoading ? skeleton : child;
+  }
+}

--- a/lib/components/type_box_component.dart
+++ b/lib/components/type_box_component.dart
@@ -1,7 +1,7 @@
 import 'package:get/get.dart';
 import 'package:flutter/material.dart';
 import 'package:hoot/models/feed_types.dart';
-import 'package:skeletons/skeletons.dart';
+import 'package:hoot/components/shimmer_skeletons.dart';
 
 class TypeBoxComponent extends StatefulWidget {
   final FeedType type;
@@ -25,7 +25,7 @@ class _TypeBoxComponentState extends State<TypeBoxComponent> {
   Widget build(BuildContext context) {
     return ClipRRect(
       borderRadius: BorderRadius.circular(15),
-      child: widget.isSkeleton ? Skeleton(
+      child: widget.isSkeleton ? ShimmerLoading(
           isLoading: widget.isSkeleton,
           skeleton: Container(
             width: 200,

--- a/lib/components/url_preview_component.dart
+++ b/lib/components/url_preview_component.dart
@@ -2,7 +2,7 @@ import 'package:get/get.dart';
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:ogp_data_extract/ogp_data_extract.dart';
-import 'package:skeletons/skeletons.dart';
+import 'package:hoot/components/shimmer_skeletons.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -53,15 +53,13 @@ class _UrlPreviewComponentState extends State<UrlPreviewComponent> {
               child: Row(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  const SkeletonAvatar(
-                    style: SkeletonAvatarStyle(
-                      width: 100,
-                      height: 100,
-                      shape: BoxShape.rectangle,
-                      borderRadius: BorderRadius.only(
-                        topLeft: Radius.circular(10),
-                        bottomLeft: Radius.circular(10),
-                      ),
+                  const ShimmerBox(
+                    width: 100,
+                    height: 100,
+                    shape: BoxShape.rectangle,
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(10),
+                      bottomLeft: Radius.circular(10),
                     ),
                   ),
                   Expanded(
@@ -71,27 +69,9 @@ class _UrlPreviewComponentState extends State<UrlPreviewComponent> {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          SkeletonParagraph(
-                            style: const SkeletonParagraphStyle(
-                              lines: 1,
-                              spacing: 10,
-                              lineStyle: SkeletonLineStyle(
-                                height: 10,
-                                width: double.infinity,
-                              ),
-                            ),
-                          ),
+                          const ShimmerParagraph(lines: 1, spacing: 10, height: 10),
                           const SizedBox(height: 10),
-                          SkeletonParagraph(
-                            style: const SkeletonParagraphStyle(
-                              lines: 2,
-                              spacing: 10,
-                              lineStyle: SkeletonLineStyle(
-                                height: 10,
-                                width: double.infinity,
-                              ),
-                            ),
-                          ),
+                          const ShimmerParagraph(lines: 2, spacing: 10, height: 10),
                         ],
                       ),
                     ),

--- a/lib/components/user_suggestions.dart
+++ b/lib/components/user_suggestions.dart
@@ -2,7 +2,7 @@ import 'package:get/get.dart';
 import 'package:flutter/material.dart';
 import 'package:hoot/components/avatar_component.dart';
 import 'package:hoot/app/controllers/auth_controller.dart';
-import 'package:skeletons/skeletons.dart';
+import 'package:hoot/components/shimmer_skeletons.dart';
 import '../app/utils/logger.dart';
 
 import 'package:hoot/models/user.dart';
@@ -54,13 +54,14 @@ class _UserSuggestionsState extends State<UserSuggestions> {
                 return Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: _isLoading
-                      ? SizedBox(
+                      ? const SizedBox(
                           width: 60,
                           height: 60,
-                          child: SkeletonAvatar(
-                            style: SkeletonAvatarStyle(
-                              borderRadius: BorderRadius.circular(15),
-                            ),
+                          child: ShimmerBox(
+                            width: 60,
+                            height: 60,
+                            shape: BoxShape.rectangle,
+                            borderRadius: BorderRadius.all(Radius.circular(15)),
                           ),
                         )
                       : Column(

--- a/lib/pages/feed.dart
+++ b/lib/pages/feed.dart
@@ -8,7 +8,6 @@ import 'package:hoot/pages/post.dart';
 import 'package:hoot/services/error_service.dart';
 import 'package:hoot/app/controllers/feed_controller.dart';
 import 'package:pull_to_refresh/pull_to_refresh.dart';
-import 'package:skeletons/skeletons.dart';
 import '../app/utils/logger.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:hoot/components/post_component.dart';
@@ -72,7 +71,7 @@ class _FeedPageState extends State<FeedPage> {
         ],
       ),
       body: _isLoading
-          ? SkeletonListView(
+          ? ListView.builder(
               padding: const EdgeInsets.symmetric(vertical: 10),
               itemCount: 10,
               itemBuilder: (context, index) =>

--- a/lib/pages/notifications.dart
+++ b/lib/pages/notifications.dart
@@ -5,7 +5,7 @@ import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/components/list_item_component.dart';
 import 'package:hoot/models/notification.dart' as Notif;
 import 'package:pull_to_refresh/pull_to_refresh.dart';
-import 'package:skeletons/skeletons.dart';
+import 'package:hoot/components/shimmer_skeletons.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:hoot/services/error_service.dart';
 import 'package:get/get.dart';
@@ -133,7 +133,11 @@ class _NotificationsPageState extends State<NotificationsPage> {
           ? ListView.builder(
               itemCount: 10,
               itemBuilder: (context, index) => const ListItemComponent(
-                    leading: SkeletonAvatar(),
+                    leading: ShimmerBox(
+                      width: 40,
+                      height: 40,
+                      shape: BoxShape.circle,
+                    ),
                     title: '',
                     subtitle: '',
                     isLoading: true,

--- a/lib/pages/post.dart
+++ b/lib/pages/post.dart
@@ -5,7 +5,7 @@ import 'package:hoot/components/avatar_component.dart';
 import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/components/post_component.dart';
 import 'package:hoot/app/controllers/feed_controller.dart';
-import 'package:skeletons/skeletons.dart';
+import 'package:hoot/components/shimmer_skeletons.dart';
 import '../app/utils/logger.dart';
 import 'package:solar_icons/solar_icons.dart';
 
@@ -114,33 +114,21 @@ class _PostPageState extends State<PostPage> {
                         padding: const EdgeInsets.symmetric(horizontal: 20),
                         child: Column(
                           children: [
-                            SkeletonListTile(
-                              leadingStyle: const SkeletonAvatarStyle(
-                                shape: BoxShape.circle,
-                                width: 50,
-                                height: 50,
-                              ),
+                            ShimmerListTile(
+                              leadingSize: 50,
+                              hasSubtitle: false,
                             ),
-                            SkeletonListTile(
-                              leadingStyle: const SkeletonAvatarStyle(
-                                shape: BoxShape.circle,
-                                width: 50,
-                                height: 50,
-                              ),
+                            ShimmerListTile(
+                              leadingSize: 50,
+                              hasSubtitle: false,
                             ),
-                            SkeletonListTile(
-                              leadingStyle: const SkeletonAvatarStyle(
-                                shape: BoxShape.circle,
-                                width: 50,
-                                height: 50,
-                              ),
+                            ShimmerListTile(
+                              leadingSize: 50,
+                              hasSubtitle: false,
                             ),
-                            SkeletonListTile(
-                              leadingStyle: const SkeletonAvatarStyle(
-                                shape: BoxShape.circle,
-                                width: 50,
-                                height: 50,
-                              ),
+                            ShimmerListTile(
+                              leadingSize: 50,
+                              hasSubtitle: false,
                             ),
                           ],
                         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1133,6 +1133,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  shimmer_animation:
+    dependency: "direct main"
+    description:
+      name: shimmer_animation
+      sha256: "9357080b7dd892aae837d569e1fbbcbe7f9a02ca994e558561d90e35e92f1101"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
   sign_in_with_apple:
     dependency: "direct main"
     description:
@@ -1157,14 +1165,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  skeletons:
-    dependency: "direct main"
-    description:
-      name: skeletons
-      sha256: "5b2d08ae7f908ee1f7007ca99f8dcebb4bfc1d3cb2143dec8d112a5be5a45c8f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,7 +68,7 @@ dependencies:
   vibration: ^1.9.0
   youtube_player_flutter: ^9.1.1
   material_segmented_control: ^5.0.0
-  skeletons: ^0.0.3
+  shimmer_animation: ^2.2.2
   shared_preferences: ^2.2.0
   flutter_animated_icons: ^1.0.1
   webview_flutter: ^4.2.2


### PR DESCRIPTION
## Summary
- remove `skeletons` package
- add `shimmer_animation` dependency
- implement `ShimmerBox`, `ShimmerParagraph`, `ShimmerListTile`, and `ShimmerLoading`
- swap out skeleton usages with new shimmer-based widgets

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e602a5c483288fe36c87f7818ac1