### PR TITLE
Add login page and setup initial route

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:get/get.dart';
 import 'package:hoot/util/routes/app_pages.dart';
+import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/routes/initial_binding.dart';
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -50,6 +51,7 @@ Future<void> main() async {
           title: 'Hoot',
           initialBinding: InitialBinding(),
           getPages: AppPages.pages,
+          initialRoute: AppRoutes.login,
           theme: AppTheme.lightTheme,
           darkTheme: AppTheme.darkTheme,
           translations: AppTranslations(),

--- a/lib/pages/login.dart
+++ b/lib/pages/login.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../components/sign_in_with_google.dart';
+import '../components/sign_in_with_apple.dart';
+
+class LoginPage extends StatelessWidget {
+  const LoginPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('signIn'.tr),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: const [
+            SignInWithGoogleButton(),
+            SizedBox(height: 16),
+            SignInWithAppleButton(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -1,5 +1,9 @@
 import 'package:get/get.dart';
+import 'package:hoot/pages/login.dart';
+import 'app_routes.dart';
 
 class AppPages {
-  static final List<GetPage> pages = [];
+  static final List<GetPage> pages = [
+    GetPage(name: AppRoutes.login, page: () => const LoginPage()),
+  ];
 }


### PR DESCRIPTION
## Summary
- create a simple LoginPage using existing sign in buttons
- register the login route in `AppPages`
- set `initialRoute` in `GetMaterialApp` to show the login page at startup

## Testing
- `flutter analyze`
- `dart format lib/pages/login.dart lib/util/routes/app_pages.dart lib/main.dart`

------
https://chatgpt.com/codex/tasks/task_e_68811d4f44208328be4b7ae632025de1