### PR TITLE
Add dialog service and refactor dialogs

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -11,6 +11,9 @@ import 'package:hoot/components/shimmer_skeletons.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
+import 'package:hoot/services/dialog_service.dart';
+import 'package:adaptive_dialog/adaptive_dialog.dart';
+
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/app/controllers/feed_controller.dart';
 
@@ -63,57 +66,43 @@ class _PostComponentState extends State<PostComponent> with TickerProviderStateM
 
   Future<void> _deletePost() async {
     if (widget.post.user?.uid != _authProvider.user?.uid) return;
-    await showDialog<bool>(
+    bool confirm = await DialogService.confirm(
       context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Delete'),
-        content: const Text('Are you sure you want to delete this hoot?'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(context).pop(false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () async {
-              Navigator.of(context).pop(true);
-              setState(() => _deleted = true);
-              bool res = await _feedProvider.deletePost(context, widget.post.id, widget.post.feed!.id);
-              if (!res) {
-                // TODO: Handle error and show a toast
-              } else if (widget.onDeleted != null) {
-                widget.onDeleted!();
-              }
-            },
-            child: const Text('Delete'),
-          ),
-        ],
-      ),
+      title: 'delete'.tr,
+      message: 'Are you sure you want to delete this hoot?',
+      okLabel: 'delete'.tr,
+      cancelLabel: 'cancel'.tr,
     );
+    if (!confirm) return;
+    setState(() => _deleted = true);
+    bool res = await _feedProvider.deletePost(context, widget.post.id, widget.post.feed!.id);
+    if (!res) {
+      // TODO: Handle error and show a toast
+    } else if (widget.onDeleted != null) {
+      widget.onDeleted!();
+    }
   }
 
-  void _handleMenuTap() {
-    showModalBottomSheet(
+  Future<void> _handleMenuTap() async {
+    final result = await DialogService.showActionSheet<String>(
       context: context,
-      builder: (context) {
-        return widget.post.user?.uid == _authProvider.user?.uid ? ListTile(
-          contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 30),
-          leading: const Icon(Icons.delete),
-          title: Text('delete'.tr),
-          onTap: () {
-            Navigator.of(context).pop();
-            _deletePost();
-          },
-        ) : ListTile(
-            contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 30),
-            leading: const Icon(Icons.report),
-            title: Text('reportUsername'.trParams({'value': widget.post.user?.username ?? ''})),
-            onTap: () {
-              Navigator.of(context).pop();
-              // TODO: Show a toast
-            }
-        );
-      },
+      actions: widget.post.user?.uid == _authProvider.user?.uid
+          ? [
+              SheetAction(label: 'delete'.tr, key: 'delete', icon: Icons.delete),
+            ]
+          : [
+              SheetAction(
+                label: 'reportUsername'.trParams({'value': widget.post.user?.username ?? ''}),
+                key: 'report',
+                icon: Icons.report,
+              ),
+            ],
     );
+    if (result == 'delete') {
+      await _deletePost();
+    } else if (result == 'report') {
+      // TODO: Show a toast
+    }
   }
 
   Future refeed() async {

--- a/lib/components/subscribe_component.dart
+++ b/lib/components/subscribe_component.dart
@@ -4,6 +4,7 @@ import 'package:hoot/models/feed.dart';
 import 'package:hoot/app/controllers/auth_controller.dart';
 import 'package:hoot/app/controllers/feed_controller.dart';
 import 'package:solar_icons/solar_icons.dart';
+import 'package:hoot/services/dialog_service.dart';
 
 import 'package:hoot/models/user.dart';
 /// A component that allows the user to subscribe to a feed and manage requests
@@ -53,22 +54,12 @@ class _SubscribeComponentState extends State<SubscribeComponent> {
   }
 
   Future _requestToJoinFeed() async {
-    bool confirm = await showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: Text('requestToJoin'.tr),
-          content: Text('requestToJoinConfirmation'.tr),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: Text('cancel'.tr),
-            ),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: Text('requestToJoin'.tr),
-            ),
-          ],
-        )
+    bool confirm = await DialogService.confirm(
+      context: context,
+      title: 'requestToJoin'.tr,
+      message: 'requestToJoinConfirmation'.tr,
+      okLabel: 'requestToJoin'.tr,
+      cancelLabel: 'cancel'.tr,
     );
     if (confirm) {
       if (_requestCooldown) {
@@ -91,22 +82,12 @@ class _SubscribeComponentState extends State<SubscribeComponent> {
       // TODO: Show a toast and handle error 'youAreGoingTooFast'.tr
       return;
     }
-    bool confirm = await showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: Text('subscribe'.tr),
-          content: Text('subscribeConfirmation'.tr),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: Text('cancel'.tr),
-            ),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: Text('subscribe'.tr),
-            ),
-          ],
-        )
+    bool confirm = await DialogService.confirm(
+      context: context,
+      title: 'subscribe'.tr,
+      message: 'subscribeConfirmation'.tr,
+      okLabel: 'subscribe'.tr,
+      cancelLabel: 'cancel'.tr,
     );
     if (confirm) {
       setState(() =>  widget.feed.subscribers!.add(_authProvider.user!.uid));
@@ -121,22 +102,12 @@ class _SubscribeComponentState extends State<SubscribeComponent> {
   }
 
   Future _unsubscribeFromFeed() async {
-    bool confirm = await showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: Text('unsubscribe'.tr),
-          content: Text('unsubscribeConfirmation'.tr),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: Text('cancel'.tr),
-            ),
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: Text('unsubscribe'.tr),
-            ),
-          ],
-        )
+    bool confirm = await DialogService.confirm(
+      context: context,
+      title: 'unsubscribe'.tr,
+      message: 'unsubscribeConfirmation'.tr,
+      okLabel: 'unsubscribe'.tr,
+      cancelLabel: 'cancel'.tr,
     );
     if (confirm) {
       setState(() => widget.feed.subscribers!.remove(_authProvider.user!.uid));

--- a/lib/services/dialog_service.dart
+++ b/lib/services/dialog_service.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:adaptive_dialog/adaptive_dialog.dart';
+
+/// Provides wrappers around common dialog patterns using the
+/// [adaptive_dialog] package so dialogs look appropriate on each platform.
+class DialogService {
+  /// Shows a confirmation dialog returning true when the user accepts.
+  static Future<bool> confirm({
+    required BuildContext context,
+    required String title,
+    required String message,
+    required String okLabel,
+    required String cancelLabel,
+  }) async {
+    final result = await showOkCancelAlertDialog(
+      context: context,
+      title: title,
+      message: message,
+      okLabel: okLabel,
+      cancelLabel: cancelLabel,
+    );
+    return result == OkCancelResult.ok;
+  }
+
+  /// Shows a modal action sheet with the provided [actions].
+  /// Returns the value associated with the selected action.
+  static Future<T?> showActionSheet<T>({
+    required BuildContext context,
+    String? title,
+    String? message,
+    required List<SheetAction<T>> actions,
+  }) {
+    return showModalActionSheet<T>(
+      context: context,
+      title: title,
+      message: message,
+      actions: actions,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- wrap common dialog flows with `DialogService`
- refactor `SubscribeComponent` confirmation dialogs
- update `PostComponent` to use the new service for delete confirmation and menu sheet

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68811d55b838832891e127c5f448e809