### PR TITLE
Add widget tests for ToastService and DialogService

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Running Tests
+
+To execute the widget tests run:
+
+```bash
+flutter test
+```
+
+Make sure all dependencies have been fetched with `flutter pub get` before running the tests.

--- a/test/services_test.dart
+++ b/test/services_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:toastification/toastification.dart';
+import 'package:adaptive_dialog/adaptive_dialog.dart';
+
+import 'package:hoot/services/toast_service.dart';
+import 'package:hoot/services/dialog_service.dart';
+
+void main() {
+  testWidgets('ToastService enqueues and removes toast', (tester) async {
+    await tester.pumpWidget(
+      const ToastificationWrapper(
+        child: MaterialApp(
+          home: Scaffold(body: SizedBox()),
+        ),
+      ),
+    );
+
+    ToastService.showSuccess('Hello');
+    await tester.pump();
+
+    expect(toastification.managers.values.first.notifications.length, 1);
+
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pumpAndSettle();
+
+    expect(toastification.managers.values.first.notifications, isEmpty);
+  });
+
+  testWidgets('DialogService confirm returns true on OK', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SizedBox()),
+      ),
+    );
+
+    final context = tester.element(find.byType(Scaffold));
+
+    final future = DialogService.confirm(
+      context: context,
+      title: 'Title',
+      message: 'Message',
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Message'), findsOneWidget);
+
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(await future, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add widget tests for ToastService and DialogService behaviors
- explain how to run tests in README

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6881229f1dd4832886709ff660c1c891