### PR TITLE
Fix deprecated color alpha helper

### DIFF
--- a/lib/components/appbar_component.dart
+++ b/lib/components/appbar_component.dart
@@ -24,7 +24,7 @@ class AppBarComponent extends StatelessWidget implements PreferredSizeWidget {
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
       scrolledUnderElevation: elevationDuringScroll,
-      shadowColor: Theme.of(context).colorScheme.surface.withValues(alpha: .25),
+      shadowColor: Theme.of(context).colorScheme.surface.withOpacity(.25),
       title: title != null ? PreferredSize(
         preferredSize: preferredSize,
         child: Text(

--- a/lib/components/empty_message.dart
+++ b/lib/components/empty_message.dart
@@ -17,14 +17,14 @@ class NothingToShowComponent extends StatelessWidget {
           Icon(
             icon.icon,
             size: 100.0,
-            color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5)
+            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5)
           ),
           const SizedBox(height: 10.0),
           Text(
             text,
             textAlign: TextAlign.center,
             style: TextStyle(
-              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5)
+              color: Theme.of(context).colorScheme.onSurface.withOpacity(0.5)
             ),
           ),
           const SizedBox(height: 20.0),

--- a/lib/components/list_item_component.dart
+++ b/lib/components/list_item_component.dart
@@ -35,7 +35,7 @@ class ListItemComponent extends StatelessWidget {
               child: Container(
                 padding: const EdgeInsets.all(20),
                 decoration: BoxDecoration(
-                  color: backgroundColor ?? Theme.of(context).colorScheme.secondary.withValues(alpha: 0.1),
+                  color: backgroundColor ?? Theme.of(context).colorScheme.secondary.withOpacity(0.1),
                   borderRadius: BorderRadius.circular(20),
                 ),
                 child: Column(
@@ -47,9 +47,9 @@ class ListItemComponent extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                       style: small ? Theme.of(context).textTheme.titleSmall!.copyWith(
                           fontWeight: FontWeight.bold,
-                          color: foregroundColor ?? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.8)
+                          color: foregroundColor ?? Theme.of(context).colorScheme.onSurface.withOpacity(0.8)
                       ) : Theme.of(context).textTheme.titleLarge!.copyWith(
-                        color: foregroundColor ?? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.8)
+                        color: foregroundColor ?? Theme.of(context).colorScheme.onSurface.withOpacity(0.8)
                       ),
                     ),
                     const SizedBox(height: 5),
@@ -58,7 +58,7 @@ class ListItemComponent extends StatelessWidget {
                       overflow: TextOverflow.ellipsis,
                       maxLines: 2,
                       style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.75)
+                        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.75)
                       ),
                     ),
                   ],

--- a/lib/components/type_box_component.dart
+++ b/lib/components/type_box_component.dart
@@ -36,8 +36,8 @@ class _TypeBoxComponentState extends State<TypeBoxComponent> {
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
                 colors: [
-                  color.withValues(alpha: 0.6),
-                  color.withValues(alpha: 0.9),
+                  color.withOpacity(0.6),
+                  color.withOpacity(0.9),
                 ],
               ),
             ),
@@ -51,8 +51,8 @@ class _TypeBoxComponentState extends State<TypeBoxComponent> {
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
             colors: [
-              color.withValues(alpha: 0.6),
-              color.withValues(alpha: 0.9),
+              color.withOpacity(0.6),
+              color.withOpacity(0.9),
             ],
           ),
         ),
@@ -63,7 +63,7 @@ class _TypeBoxComponentState extends State<TypeBoxComponent> {
               left: -25,
               child: Icon(
                 widget.isLast ? Icons.more_vert_rounded : FeedTypeExtension.toIcon(widget.type),
-                color: Colors.white.withValues(alpha: 0.2),
+                color: Colors.white.withOpacity(0.2),
                 size: 150,
               ),
             ),
@@ -76,7 +76,7 @@ class _TypeBoxComponentState extends State<TypeBoxComponent> {
                   widget.isLast ? 'discoverMoreFeeds'.tr : FeedTypeExtension.toTranslatedString(context, widget.type),
                   textAlign: TextAlign.right,
                   style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                    color: Colors.white.withValues(alpha: 0.9),
+                    color: Colors.white.withOpacity(0.9),
                     fontSize: MediaQuery.of(context).size.width * 0.06,
                     fontWeight: FontWeight.w400,
                   ),

--- a/lib/components/url_preview_component.dart
+++ b/lib/components/url_preview_component.dart
@@ -47,7 +47,7 @@ class _UrlPreviewComponentState extends State<UrlPreviewComponent> {
                     color: Theme.of(context)
                         .colorScheme
                         .secondary
-                        .withValues(alpha: 0.5)),
+                        .withOpacity(0.5)),
                 borderRadius: BorderRadius.circular(10),
               ),
               child: Row(
@@ -91,14 +91,14 @@ class _UrlPreviewComponentState extends State<UrlPreviewComponent> {
                     color: Theme.of(context)
                         .colorScheme
                         .secondary
-                        .withValues(alpha: 0.1)),
+                        .withOpacity(0.1)),
                 borderRadius: BorderRadius.circular(15),
                 boxShadow: [
                   BoxShadow(
                     color: Theme.of(context)
                         .colorScheme
                         .secondary
-                        .withValues(alpha: 0.1),
+                        .withOpacity(0.1),
                     blurRadius: 10,
                     offset: const Offset(0, 5),
                   ),
@@ -151,7 +151,7 @@ class _UrlPreviewComponentState extends State<UrlPreviewComponent> {
                                     color: Theme.of(context)
                                         .colorScheme
                                         .secondary
-                                        .withValues(alpha: 0.5),
+                                        .withOpacity(0.5),
                                   )),
                         ],
                       ),

--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -122,7 +122,7 @@ class AppTheme {
       borderRadius: BorderRadius.all(Radius.circular(100)),
     ),
     side: BorderSide.none,
-    backgroundColor: lightColorScheme.primary.withValues(alpha: 0.25),
+    backgroundColor: lightColorScheme.primary.withOpacity(0.25),
     labelStyle: TextStyle(
       fontSize: 12,
       color: lightColorScheme.primary,


### PR DESCRIPTION
## Summary
- swap deprecated `withValues` color calls for `withOpacity`

## Testing
- `flutter analyze`
- `flutter pub get`


------
https://chatgpt.com/codex/tasks/task_e_688138eba48c83289e2a30597c1ffae0