### PR TITLE
Add Firebase auth sign-in buttons

### DIFF
--- a/lib/pages/login/controllers/login_controller.dart
+++ b/lib/pages/login/controllers/login_controller.dart
@@ -1,5 +1,24 @@
 import 'package:get/get.dart';
 
-class LoginController extends GetxController {
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/error_service.dart';
 
+class LoginController extends GetxController {
+  /// Initiates Google sign in using [AuthService].
+  Future<void> signInWithGoogle() async {
+    try {
+      await AuthService.signInWithGoogle();
+    } catch (e, s) {
+      await ErrorService.reportError(e, message: 'signInFailed'.tr, stack: s);
+    }
+  }
+
+  /// Initiates Apple sign in using [AuthService].
+  Future<void> signInWithApple() async {
+    try {
+      await AuthService.signInWithApple();
+    } catch (e, s) {
+      await ErrorService.reportError(e, message: 'signInFailed'.tr, stack: s);
+    }
+  }
 }

--- a/lib/pages/login/views/login_view.dart
+++ b/lib/pages/login/views/login_view.dart
@@ -1,10 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_signin_button/flutter_signin_button.dart' as buttons;
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:get/get.dart';
 
-class LoginView extends StatelessWidget {
+import '../controllers/login_controller.dart';
+
+class LoginView extends GetView<LoginController> {
   const LoginView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Placeholder();
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            buttons.SignInButton(
+              buttons.Buttons.google,
+              onPressed: controller.signInWithGoogle,
+            ),
+            const SizedBox(height: 16),
+            SignInWithAppleButton(
+              onPressed: controller.signInWithApple,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,1 +1,44 @@
-class AuthService {}
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+/// Provides authentication helpers for the application.
+class AuthService {
+  AuthService._();
+
+  static final FirebaseAuth _auth = FirebaseAuth.instance;
+
+  /// Signs in the user using Google authentication.
+  static Future<UserCredential> signInWithGoogle() async {
+    final user = await GoogleSignIn().signIn();
+    if (user == null) {
+      throw FirebaseAuthException(
+        code: 'ABORTED',
+        message: 'Google sign in aborted',
+      );
+    }
+
+    final googleAuth = await user.authentication;
+    final credential = GoogleAuthProvider.credential(
+      accessToken: googleAuth.accessToken,
+      idToken: googleAuth.idToken,
+    );
+    return _auth.signInWithCredential(credential);
+  }
+
+  /// Signs in the user using Apple authentication.
+  static Future<UserCredential> signInWithApple() async {
+    final appleIDCredential = await SignInWithApple.getAppleIDCredential(
+      scopes: [
+        AppleIDAuthorizationScopes.email,
+        AppleIDAuthorizationScopes.fullName,
+      ],
+    );
+
+    final credential = OAuthProvider('apple.com').credential(
+      idToken: appleIDCredential.identityToken,
+      accessToken: appleIDCredential.authorizationCode,
+    );
+    return _auth.signInWithCredential(credential);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AuthService.signInWithGoogle` and `signInWithApple`
- handle sign in requests from `LoginController`
- show sign in buttons in `LoginView`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_688138f1d7f8832890fcda592dbc3960