### PR TITLE
Add onboarding and home pages

### DIFF
--- a/lib/pages/avatar/bindings/avatar_binding.dart
+++ b/lib/pages/avatar/bindings/avatar_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/avatar_controller.dart';
+
+class AvatarBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => AvatarController());
+  }
+}

--- a/lib/pages/avatar/controllers/avatar_controller.dart
+++ b/lib/pages/avatar/controllers/avatar_controller.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class AvatarController extends GetxController {}

--- a/lib/pages/avatar/views/avatar_view.dart
+++ b/lib/pages/avatar/views/avatar_view.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../util/routes/app_routes.dart';
+import '../controllers/avatar_controller.dart';
+
+class AvatarView extends GetView<AvatarController> {
+  const AvatarView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('almostThere'.tr)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('profilePictureDescription'.tr),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () => Get.offAllNamed(AppRoutes.home),
+              child: Text('continueButton'.tr),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/create_post/bindings/create_post_binding.dart
+++ b/lib/pages/create_post/bindings/create_post_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/create_post_controller.dart';
+
+class CreatePostBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => CreatePostController());
+  }
+}

--- a/lib/pages/create_post/controllers/create_post_controller.dart
+++ b/lib/pages/create_post/controllers/create_post_controller.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class CreatePostController extends GetxController {}

--- a/lib/pages/create_post/views/create_post_view.dart
+++ b/lib/pages/create_post/views/create_post_view.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/create_post_controller.dart';
+
+class CreatePostView extends GetView<CreatePostController> {
+  const CreatePostView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text('createPost'.tr),
+    );
+  }
+}

--- a/lib/pages/explore/bindings/explore_binding.dart
+++ b/lib/pages/explore/bindings/explore_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/explore_controller.dart';
+
+class ExploreBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => ExploreController());
+  }
+}

--- a/lib/pages/explore/controllers/explore_controller.dart
+++ b/lib/pages/explore/controllers/explore_controller.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class ExploreController extends GetxController {}

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/explore_controller.dart';
+
+class ExploreView extends GetView<ExploreController> {
+  const ExploreView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text('explore'.tr),
+    );
+  }
+}

--- a/lib/pages/feed/bindings/feed_binding.dart
+++ b/lib/pages/feed/bindings/feed_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/feed_controller.dart';
+
+class FeedBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => FeedController());
+  }
+}

--- a/lib/pages/feed/controllers/feed_controller.dart
+++ b/lib/pages/feed/controllers/feed_controller.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class FeedController extends GetxController {}

--- a/lib/pages/feed/views/feed_view.dart
+++ b/lib/pages/feed/views/feed_view.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/feed_controller.dart';
+
+class FeedView extends GetView<FeedController> {
+  const FeedView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text('feed'.tr),
+    );
+  }
+}

--- a/lib/pages/home/bindings/home_binding.dart
+++ b/lib/pages/home/bindings/home_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/home_controller.dart';
+
+class HomeBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => HomeController());
+  }
+}

--- a/lib/pages/home/controllers/home_controller.dart
+++ b/lib/pages/home/controllers/home_controller.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+
+class HomeController extends GetxController {
+  final selectedIndex = 0.obs;
+
+  void changeIndex(int index) {
+    selectedIndex.value = index;
+  }
+}

--- a/lib/pages/home/views/home_view.dart
+++ b/lib/pages/home/views/home_view.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../create_post/views/create_post_view.dart';
+import '../../explore/views/explore_view.dart';
+import '../../feed/views/feed_view.dart';
+import '../../notifications/views/notifications_view.dart';
+import '../../profile/views/profile_view.dart';
+import '../controllers/home_controller.dart';
+
+class HomeView extends GetView<HomeController> {
+  const HomeView({super.key});
+
+  static const List<Widget> _pages = [
+    FeedView(),
+    ExploreView(),
+    CreatePostView(),
+    NotificationsView(),
+    ProfileView(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      final index = controller.selectedIndex.value;
+      return Scaffold(
+        body: _pages[index],
+        bottomNavigationBar: NavigationBar(
+          selectedIndex: index,
+          onDestinationSelected: controller.changeIndex,
+          destinations: [
+            NavigationDestination(
+                icon: Icon(Icons.dynamic_feed), label: 'feed'.tr),
+            NavigationDestination(
+                icon: Icon(Icons.explore), label: 'explore'.tr),
+            NavigationDestination(
+                icon: Icon(Icons.add), label: 'createPost'.tr),
+            NavigationDestination(
+                icon: Icon(Icons.notifications), label: 'notifications'.tr),
+            NavigationDestination(
+                icon: Icon(Icons.person), label: 'profile'.tr),
+          ],
+        ),
+      );
+    });
+  }
+}

--- a/lib/pages/notifications/bindings/notifications_binding.dart
+++ b/lib/pages/notifications/bindings/notifications_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/notifications_controller.dart';
+
+class NotificationsBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => NotificationsController());
+  }
+}

--- a/lib/pages/notifications/controllers/notifications_controller.dart
+++ b/lib/pages/notifications/controllers/notifications_controller.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class NotificationsController extends GetxController {}

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/notifications_controller.dart';
+
+class NotificationsView extends GetView<NotificationsController> {
+  const NotificationsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text('notifications'.tr),
+    );
+  }
+}

--- a/lib/pages/profile/bindings/profile_binding.dart
+++ b/lib/pages/profile/bindings/profile_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/profile_controller.dart';
+
+class ProfileBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => ProfileController());
+  }
+}

--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class ProfileController extends GetxController {}

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/profile_controller.dart';
+
+class ProfileView extends GetView<ProfileController> {
+  const ProfileView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text('profile'.tr),
+    );
+  }
+}

--- a/lib/pages/username/bindings/username_binding.dart
+++ b/lib/pages/username/bindings/username_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/username_controller.dart';
+
+class UsernameBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => UsernameController());
+  }
+}

--- a/lib/pages/username/controllers/username_controller.dart
+++ b/lib/pages/username/controllers/username_controller.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class UsernameController extends GetxController {}

--- a/lib/pages/username/views/username_view.dart
+++ b/lib/pages/username/views/username_view.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../util/routes/app_routes.dart';
+import '../controllers/username_controller.dart';
+
+class UsernameView extends GetView<UsernameController> {
+  const UsernameView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('letsSpiceItUp'.tr)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('usernameDescription'.tr),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () => Get.toNamed(AppRoutes.avatar),
+              child: Text('continueButton'.tr),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/welcome/bindings/welcome_binding.dart
+++ b/lib/pages/welcome/bindings/welcome_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/welcome_controller.dart';
+
+class WelcomeBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => WelcomeController());
+  }
+}

--- a/lib/pages/welcome/controllers/welcome_controller.dart
+++ b/lib/pages/welcome/controllers/welcome_controller.dart
@@ -1,0 +1,3 @@
+import 'package:get/get.dart';
+
+class WelcomeController extends GetxController {}

--- a/lib/pages/welcome/views/welcome_view.dart
+++ b/lib/pages/welcome/views/welcome_view.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../util/routes/app_routes.dart';
+import '../controllers/welcome_controller.dart';
+
+class WelcomeView extends GetView<WelcomeController> {
+  const WelcomeView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('whatsYourName'.tr)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text('displayNameDescription'.tr),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () => Get.toNamed(AppRoutes.username),
+              child: Text('continueButton'.tr),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -1,6 +1,14 @@
 import 'package:get/get.dart';
 import 'package:hoot/pages/login/bindings/login_binding.dart';
 import 'package:hoot/pages/login/views/login_view.dart';
+import 'package:hoot/pages/welcome/bindings/welcome_binding.dart';
+import 'package:hoot/pages/welcome/views/welcome_view.dart';
+import 'package:hoot/pages/username/bindings/username_binding.dart';
+import 'package:hoot/pages/username/views/username_view.dart';
+import 'package:hoot/pages/avatar/bindings/avatar_binding.dart';
+import 'package:hoot/pages/avatar/views/avatar_view.dart';
+import 'package:hoot/pages/home/bindings/home_binding.dart';
+import 'package:hoot/pages/home/views/home_view.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 
 class AppPages {
@@ -9,6 +17,26 @@ class AppPages {
       name: AppRoutes.login,
       page: () => LoginView(),
       binding: LoginBinding(),
+    ),
+    GetPage(
+      name: AppRoutes.welcome,
+      page: () => const WelcomeView(),
+      binding: WelcomeBinding(),
+    ),
+    GetPage(
+      name: AppRoutes.username,
+      page: () => const UsernameView(),
+      binding: UsernameBinding(),
+    ),
+    GetPage(
+      name: AppRoutes.avatar,
+      page: () => const AvatarView(),
+      binding: AvatarBinding(),
+    ),
+    GetPage(
+      name: AppRoutes.home,
+      page: () => const HomeView(),
+      binding: HomeBinding(),
     ),
   ];
 }


### PR DESCRIPTION
## Summary
- add GetX onboarding flow for display name, username, and avatar
- implement home navigation with Feed, Explore, Create Post, Notifications and Profile sections
- register the new routes in `AppPages`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_688138ff561c832892b26fb1f9fd1c0f