### PR TITLE
Add Firestore user creation on first sign in

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
@@ -7,6 +8,19 @@ class AuthService {
   AuthService._();
 
   static final FirebaseAuth _auth = FirebaseAuth.instance;
+  static final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  /// Creates a Firestore document for [user] if none exists.
+  static Future<void> _createUserDocumentIfNeeded(User user) async {
+    final docRef = _firestore.collection('users').doc(user.uid);
+    final doc = await docRef.get();
+    if (doc.exists) return;
+    await docRef.set({
+      'uid': user.uid,
+      'displayName': user.displayName,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+  }
 
   /// Signs in the user using Google authentication.
   static Future<UserCredential> signInWithGoogle() async {
@@ -23,7 +37,14 @@ class AuthService {
       accessToken: googleAuth.accessToken,
       idToken: googleAuth.idToken,
     );
-    return _auth.signInWithCredential(credential);
+    final result = await _auth.signInWithCredential(credential);
+    if (result.additionalUserInfo?.isNewUser ?? false) {
+      final firebaseUser = result.user;
+      if (firebaseUser != null) {
+        await _createUserDocumentIfNeeded(firebaseUser);
+      }
+    }
+    return result;
   }
 
   /// Signs in the user using Apple authentication.
@@ -39,6 +60,13 @@ class AuthService {
       idToken: appleIDCredential.identityToken,
       accessToken: appleIDCredential.authorizationCode,
     );
-    return _auth.signInWithCredential(credential);
+    final result = await _auth.signInWithCredential(credential);
+    if (result.additionalUserInfo?.isNewUser ?? false) {
+      final firebaseUser = result.user;
+      if (firebaseUser != null) {
+        await _createUserDocumentIfNeeded(firebaseUser);
+      }
+    }
+    return result;
   }
 }


### PR DESCRIPTION
## Summary
- create `_createUserDocumentIfNeeded` in `AuthService`
- write new Firestore user doc with defaults when signing in the first time
- invoke the helper during Google and Apple sign in flows

## Testing
- `flutter test -rjson`

------
https://chatgpt.com/codex/tasks/task_e_6881d7a585248328a740ef588ad90642