### PR TITLE
Add locale settings for GetMaterialApp

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,6 +55,8 @@ Future<void> main() async {
           theme: AppTheme.lightTheme,
           darkTheme: AppTheme.darkTheme,
           translations: AppTranslations(),
+          locale: Get.deviceLocale,
+          fallbackLocale: const Locale('en', 'US'),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- configure the GetMaterialApp to use the device locale and fallback to English

## Testing
- `flutter test --no-pub`

------
https://chatgpt.com/codex/tasks/task_e_6881da93b8288328958a57fafd016ed9