### PR TITLE
Add route auth middleware

### DIFF
--- a/lib/middleware/auth_middleware.dart
+++ b/lib/middleware/auth_middleware.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../util/routes/app_routes.dart';
+
+/// Middleware that redirects unauthenticated users to the login page.
+class AuthMiddleware extends GetMiddleware {
+  @override
+  RouteSettings? redirect(String? route) {
+    // Routes accessible without authentication
+    const openRoutes = {
+      AppRoutes.login,
+      AppRoutes.terms,
+      AppRoutes.aboutUs,
+    };
+
+    if (openRoutes.contains(route)) {
+      return null;
+    }
+
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      return const RouteSettings(name: AppRoutes.login);
+    }
+    return null;
+  }
+}

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -40,111 +40,130 @@ import 'package:hoot/pages/contacts/views/contacts_view.dart';
 import 'package:hoot/pages/terms.dart';
 import 'package:hoot/pages/about_us.dart';
 import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/middleware/auth_middleware.dart';
 
 class AppPages {
   static final List<GetPage> pages = [
-    GetPage(
-      name: AppRoutes.login,
-      page: () => LoginView(),
-      binding: LoginBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.welcome,
-      page: () => const WelcomeView(),
-      binding: WelcomeBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.username,
-      page: () => const UsernameView(),
-      binding: UsernameBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.avatar,
-      page: () => const AvatarView(),
-      binding: AvatarBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.home,
-      page: () => const HomeView(),
-      binding: HomeBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.createPost,
-      page: () => const CreatePostView(),
-      binding: CreatePostBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.settings,
-      page: () => const SettingsView(),
-      binding: SettingsBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.profile,
-      page: () => const ProfileView(),
-      binding: ProfileBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.editProfile,
-      page: () => const EditProfileView(),
-      binding: EditProfileBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.search,
-      page: () => const SearchView(),
-      binding: SearchBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.searchByGenre,
-      page: () => const SearchByGenreView(),
-      binding: SearchByGenreBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.createFeed,
-      page: () => const CreateFeedView(),
-      binding: CreateFeedBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.editFeed,
-      page: () => const EditFeedView(),
-      binding: EditFeedBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.feedRequests,
-      page: () => const FeedRequestsView(),
-      binding: FeedRequestsBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.subscriptions,
-      page: () => const SubscriptionsView(),
-      binding: SubscriptionsBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.subscribers,
-      page: () => const SubscribersView(),
-      binding: SubscribersBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.post,
-      page: () => const PostView(),
-      binding: PostBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.report,
-      page: () => const ReportView(),
-      binding: ReportBinding(),
-    ),
-    GetPage(
-      name: AppRoutes.terms,
-      page: () => const TermsOfService(),
-    ),
-    GetPage(
-      name: AppRoutes.aboutUs,
-      page: () => const AboutUsPage(),
-    ),
-    GetPage(
-      name: AppRoutes.contacts,
-      page: () => const ContactsView(),
-      binding: ContactsBinding(),
-    ),
+      GetPage(
+        name: AppRoutes.login,
+        page: () => LoginView(),
+        binding: LoginBinding(),
+      ),
+      GetPage(
+        name: AppRoutes.welcome,
+        page: () => const WelcomeView(),
+        binding: WelcomeBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.username,
+        page: () => const UsernameView(),
+        binding: UsernameBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.avatar,
+        page: () => const AvatarView(),
+        binding: AvatarBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.home,
+        page: () => const HomeView(),
+        binding: HomeBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.createPost,
+        page: () => const CreatePostView(),
+        binding: CreatePostBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.settings,
+        page: () => const SettingsView(),
+        binding: SettingsBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.profile,
+        page: () => const ProfileView(),
+        binding: ProfileBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.editProfile,
+        page: () => const EditProfileView(),
+        binding: EditProfileBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.search,
+        page: () => const SearchView(),
+        binding: SearchBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.searchByGenre,
+        page: () => const SearchByGenreView(),
+        binding: SearchByGenreBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.createFeed,
+        page: () => const CreateFeedView(),
+        binding: CreateFeedBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.editFeed,
+        page: () => const EditFeedView(),
+        binding: EditFeedBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.feedRequests,
+        page: () => const FeedRequestsView(),
+        binding: FeedRequestsBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.subscriptions,
+        page: () => const SubscriptionsView(),
+        binding: SubscriptionsBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.subscribers,
+        page: () => const SubscribersView(),
+        binding: SubscribersBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.post,
+        page: () => const PostView(),
+        binding: PostBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.report,
+        page: () => const ReportView(),
+        binding: ReportBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.terms,
+        page: () => const TermsOfService(),
+      ),
+      GetPage(
+        name: AppRoutes.aboutUs,
+        page: () => const AboutUsPage(),
+      ),
+      GetPage(
+        name: AppRoutes.contacts,
+        page: () => const ContactsView(),
+        binding: ContactsBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
   ];
 }


### PR DESCRIPTION
## Summary
- add `AuthMiddleware` to redirect unauthenticated users back to the login page
- apply middleware to all routes except login, terms of service and about us

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6881dbd5869883288b33d05b0bd3c3ec