### PR TITLE
Ensure user exists before navigating

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:hoot/theme/theme.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:toastification/toastification.dart';
 import 'firebase_options.dart';
+import 'package:hoot/services/auth_service.dart';
 
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   await Firebase.initializeApp();
@@ -23,6 +24,7 @@ Future<void> main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  await AuthService.fetchUser();
   await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
 

--- a/lib/middleware/auth_middleware.dart
+++ b/lib/middleware/auth_middleware.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../services/auth_service.dart';
 
 import '../util/routes/app_routes.dart';
 
 /// Middleware that redirects unauthenticated users to the login page.
 class AuthMiddleware extends GetMiddleware {
   @override
-  RouteSettings? redirect(String? route) {
+  Future<GetNavConfig?> redirectDelegate(GetNavConfig route) async {
     // Routes accessible without authentication
     const openRoutes = {
       AppRoutes.login,
@@ -15,14 +16,20 @@ class AuthMiddleware extends GetMiddleware {
       AppRoutes.aboutUs,
     };
 
-    if (openRoutes.contains(route)) {
-      return null;
+    if (openRoutes.contains(route.location)) {
+      return route;
     }
 
     final user = FirebaseAuth.instance.currentUser;
     if (user == null) {
-      return const RouteSettings(name: AppRoutes.login);
+      return GetNavConfig.fromRoute(AppRoutes.login);
     }
-    return null;
+
+    final u = await AuthService.fetchUser();
+    if (u == null) {
+      return GetNavConfig.fromRoute(AppRoutes.welcome);
+    }
+
+    return route;
   }
 }

--- a/lib/pages/login/controllers/login_controller.dart
+++ b/lib/pages/login/controllers/login_controller.dart
@@ -2,7 +2,6 @@ import 'package:get/get.dart';
 
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/services/error_service.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import '../../../util/routes/app_routes.dart';
 
@@ -28,11 +27,8 @@ class LoginController extends GetxController {
   }
 
   Future<void> _handleUserCredential(UserCredential credential) async {
-    final uid = credential.user?.uid;
-    if (uid == null) return;
-    final doc =
-        await FirebaseFirestore.instance.collection('users').doc(uid).get();
-    if (doc.exists) {
+    await AuthService.fetchUser();
+    if (AuthService.currentUser != null) {
       Get.offAllNamed(AppRoutes.home);
     } else {
       Get.offAllNamed(AppRoutes.welcome);


### PR DESCRIPTION
## Summary
- cache the current user in `AuthService` and fetch it once
- use cached user in `LoginController`
- update `AuthMiddleware` to redirect to welcome if user document is missing
- load cached user on app start

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6881e1e3c0d083288e569eeaffc850c3