### PR TITLE
Fix new user doc creation on Welcome flow

### DIFF
--- a/lib/pages/welcome/controllers/welcome_controller.dart
+++ b/lib/pages/welcome/controllers/welcome_controller.dart
@@ -25,7 +25,19 @@ class WelcomeController extends GetxController {
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return false;
 
-    await _firestore.collection('users').doc(uid).update({'displayName': name});
+    final user = _auth.currentUser;
+    if (user != null) {
+      user.name = name;
+      await _firestore
+          .collection('users')
+          .doc(uid)
+          .set(user.toCache(), SetOptions(merge: true));
+    } else {
+      await _firestore
+          .collection('users')
+          .doc(uid)
+          .set({'displayName': name}, SetOptions(merge: true));
+    }
     _auth.currentUser?.name = name;
     return true;
   }
@@ -55,10 +67,19 @@ class WelcomeController extends GetxController {
 
     final uid = FirebaseAuth.instance.currentUser?.uid;
     if (uid == null) return false;
-    await _firestore
-        .collection('users')
-        .doc(uid)
-        .update({'username': username});
+    final user = _auth.currentUser;
+    if (user != null) {
+      user.username = username;
+      await _firestore
+          .collection('users')
+          .doc(uid)
+          .set(user.toCache(), SetOptions(merge: true));
+    } else {
+      await _firestore
+          .collection('users')
+          .doc(uid)
+          .set({'username': username}, SetOptions(merge: true));
+    }
     _auth.currentUser?.username = username;
     return true;
   }


### PR DESCRIPTION
## Summary
- update WelcomeController to set fields with merge so missing user docs are automatically created
- when saving name or username, use current user model when available

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: 5 issues)*
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6881f9676ec883288ab06fcc499a0a95