### PR TITLE
Implement avatar resizing for user profile

### DIFF
--- a/lib/pages/avatar/controllers/avatar_controller.dart
+++ b/lib/pages/avatar/controllers/avatar_controller.dart
@@ -58,8 +58,8 @@ class AvatarController extends GetxController {
         final bytes = await file.readAsBytes();
         final decoded = img.decodeImage(bytes);
         if (decoded != null) {
-          final small = img.copyResize(decoded, width: 32, height: 32);
-          final big = img.copyResize(decoded, width: 128, height: 128);
+          final small = img.copyResizeCropSquare(decoded, size: 32);
+          final big = img.copyResizeCropSquare(decoded, size: 128);
 
           final smallData = Uint8List.fromList(img.encodeJpg(small));
           final bigData = Uint8List.fromList(img.encodeJpg(big));


### PR DESCRIPTION
## Summary
- resize uploaded avatars to 32x32 and 128x128 using `package:image`
- store each size in Firebase Storage and user model

## Testing
- `dart analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68834341527083288ffa4e087af4a1ef