### PR TITLE
Migrate subscription fields to counts

### DIFF
--- a/lib/models/feed.dart
+++ b/lib/models/feed.dart
@@ -15,8 +15,8 @@ class Feed {
   bool? nsfw;
   bool? verified;
   FeedType? type;
-  final List<String>? subscribers;
-  final List<String>? requests;
+  final int? subscriberCount;
+  final int? requestCount;
   List<Post>? posts;
 
   Feed({
@@ -30,8 +30,8 @@ class Feed {
     this.nsfw,
     this.verified,
     this.type,
-    this.subscribers,
-    this.requests,
+    this.subscriberCount,
+    this.requestCount,
     this.posts
   });
 
@@ -47,8 +47,8 @@ class Feed {
       private: json['private'],
       nsfw: json['nsfw'],
       verified: json['verified'],
-      subscribers: json['subscribers'] != null ? List<String>.from(json['subscribers']) : null,
-      requests: json['requests'] != null ? List<String>.from(json['requests']) : null,
+      subscriberCount: json['subscriberCount'],
+      requestCount: json['requestCount'],
       posts: json['posts'] != null ? (json['posts'] as List).map((i) => Post.fromJson(i)).toList() : null,
     );
   }
@@ -73,7 +73,7 @@ class Feed {
     'private': private,
     'nsfw': nsfw,
     'verified': verified,
-    'subscribers': subscribers,
-    'requests': requests
+    'subscriberCount': subscriberCount,
+    'requestCount': requestCount
   };
 }

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -20,7 +20,7 @@ class U {
   bool? verified;
   bool? tester;
   DateTime? birthday;
-  List<String?> subscriptions = [];
+  int? subscriptionCount;
   List<Feed>? feeds;
 
   U({
@@ -37,7 +37,7 @@ class U {
     this.verified = false,
     this.tester = false,
     this.birthday,
-    this.subscriptions = const [],
+    this.subscriptionCount,
     this.feeds,
   });
 
@@ -64,7 +64,7 @@ class U {
       verified: json['verified'],
       tester: json['tester'],
       birthday: json['birthday'],
-      subscriptions: json['subscriptions'] != null ? List<String>.from(json['subscriptions'].map((x) => x)) : [],
+      subscriptionCount: json['subscriptionCount'],
       feeds: json['feeds'] != null ? List<Feed>.from(json['feeds'].map((x) => Feed.fromJson(x))) : [],
     );
   }
@@ -105,7 +105,7 @@ class U {
     'birthday': birthday,
     'verified': verified,
     'tester': tester,
-    'subscriptions': subscriptions,
+    'subscriptionCount': subscriptionCount,
     'feeds': feeds?.map((e) => e.toCache()).toList(),
   };
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -26,6 +26,12 @@ class AuthService {
         await _firestore.collection('users').doc(firebaseUser.uid).get();
     if (doc.exists) {
       _currentUser = U.fromJson(doc.data()!);
+      final subs = await _firestore
+          .collection('users')
+          .doc(firebaseUser.uid)
+          .collection('subscriptions')
+          .get();
+      _currentUser!.subscriptionCount = subs.docs.length;
     } else {
       _currentUser = null;
     }


### PR DESCRIPTION
## Summary
- simplify user and feed models to use counts
- read subscription counts from the subscriptions subcollection

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68834ef4933483289e6b5f0eccb3cc85