### PR TITLE
Add model JSON tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Hoot operates like a streamlined community platform:
 
 ## Running Tests
 
-To execute the widget tests run:
+Widget and model tests are located under the `test/` directory. To execute them
+run:
 
 ```bash
 flutter test

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/util/enums/feed_types.dart';
+
+void main() {
+  group('U JSON', () {
+    test('fromJson and toJson round trip', () {
+      final feedJson = {
+        'id': 'feed1',
+        'title': 'Feed',
+        'description': 'desc',
+        'icon': 'i',
+        'color': '123',
+        'type': 'general',
+      };
+      final userJson = {
+        'uid': 'u1',
+        'displayName': 'John',
+        'username': 'john',
+        'smallAvatar': 's.png',
+        'bigAvatar': 'b.png',
+        'banner': 'ban.png',
+        'radius': 1,
+        'color': 'blue',
+        'music': 'm',
+        'bio': 'bio',
+        'location': 'loc',
+        'website': 'w',
+        'phoneNumber': '123',
+        'verified': true,
+        'tester': false,
+        'birthday': DateTime(2020, 1, 1),
+        'subscriptionCount': 2,
+        'feeds': [feedJson]
+      };
+
+      final user = U.fromJson(userJson);
+      expect(user.uid, 'u1');
+      expect(user.name, 'John');
+      expect(user.feeds?.first.title, 'Feed');
+
+      final json = user.toJson();
+      expect(json['displayName'], 'John');
+      expect(json['username'], 'john');
+      expect(json.containsKey('uid'), isFalse);
+    });
+  });
+
+  group('Feed JSON', () {
+    test('fromJson and toJson round trip', () {
+      final color = const Color(0xff0000ff);
+      final json = {
+        'id': 'f1',
+        'title': 'T',
+        'description': 'D',
+        'icon': 'i',
+        'color': color.value.toString(),
+        'type': 'music',
+        'private': true,
+        'nsfw': false,
+        'verified': true,
+        'subscriberCount': 5,
+        'requestCount': 1,
+        'posts': [
+          {'id': 'p1'}
+        ]
+      };
+
+      final feed = Feed.fromJson(json);
+      expect(feed.id, 'f1');
+      expect(feed.color, Color(int.parse(color.value.toString())));
+      expect(feed.type, FeedType.music);
+      expect(feed.posts?.first.id, 'p1');
+
+      final toJson = feed.toJson();
+      expect(toJson['title'], 'T');
+      expect(toJson['color'], feed.color!.hashCode.toString());
+      expect(toJson.containsKey('id'), isFalse);
+    });
+  });
+
+  group('Post JSON', () {
+    test('fromJson handles Firestore timestamps', () {
+      final json = {
+        'id': 'p1',
+        'text': 'hello',
+        'feedId': 'f1',
+        'liked': true,
+        'likes': 2,
+        'reFeeded': false,
+        'reFeeds': 0,
+        'comments': 0,
+        'createdAt': {'_seconds': 10},
+        'updatedAt': {'_seconds': 20},
+      };
+
+      final post = Post.fromJson(json);
+      expect(post.createdAt, DateTime.fromMillisecondsSinceEpoch(10000));
+      expect(post.updatedAt, DateTime.fromMillisecondsSinceEpoch(20000));
+
+      final toJson = post.toJson();
+      expect(toJson['text'], 'hello');
+      expect(toJson['feedId'], 'f1');
+      expect(toJson.containsKey('id'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- cover JSON conversion of user, feed, and post models
- document new model tests in README

## Testing
- `flutter pub get`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_688354b435048328a72e95b3b6fffde2