### PR TITLE
Implement feed listing

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import 'services/auth_service.dart';
+import 'services/feed_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -9,5 +10,6 @@ class DependencyInjector {
   static Future<void> init() async {
     final auth = Get.put(AuthService(), permanent: true);
     await auth.fetchUser();
+    Get.put<BaseFeedService>(FeedService(), permanent: true);
   }
 }

--- a/lib/pages/feed/controllers/feed_controller.dart
+++ b/lib/pages/feed/controllers/feed_controller.dart
@@ -1,3 +1,36 @@
 import 'package:get/get.dart';
 
-class FeedController extends GetxController {}
+import '../../../models/post.dart';
+import '../../../services/feed_service.dart';
+
+/// Controller responsible for fetching posts for the feed view.
+class FeedController extends GetxController {
+  FeedController({BaseFeedService? service})
+      : _feedService = service ?? Get.find<BaseFeedService>();
+
+  final BaseFeedService _feedService;
+
+  final RxList<Post> posts = <Post>[].obs;
+  final RxBool isLoading = false.obs;
+  final RxnString error = RxnString();
+
+  @override
+  void onInit() {
+    super.onInit();
+    loadPosts();
+  }
+
+  /// Loads posts from the service and updates the observable list.
+  Future<void> loadPosts() async {
+    isLoading.value = true;
+    error.value = null;
+    try {
+      final result = await _feedService.fetchSubscribedPosts();
+      posts.assignAll(result);
+    } catch (e) {
+      error.value = 'somethingWentWrong'.tr;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}

--- a/lib/pages/feed/views/feed_view.dart
+++ b/lib/pages/feed/views/feed_view.dart
@@ -1,10 +1,89 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/components/avatar_component.dart';
+import 'package:hoot/components/empty_message.dart';
+import 'package:hoot/components/image_component.dart';
+import 'package:hoot/components/name_component.dart';
+import 'package:hoot/components/shimmer_skeletons.dart';
 import '../controllers/feed_controller.dart';
 
 class FeedView extends GetView<FeedController> {
   const FeedView({super.key});
+
+  Widget _buildPost(BuildContext context, int index) {
+    final post = controller.posts[index];
+    return Card(
+      margin: const EdgeInsets.all(8),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                ProfileAvatarComponent(
+                  image: post.user?.smallProfilePictureUrl ?? '',
+                  size: 40,
+                  radius: 20,
+                ),
+                const SizedBox(width: 8),
+                if (post.user != null)
+                  NameComponent(
+                    user: post.user!,
+                    showUsername: true,
+                    size: 16,
+                    feedName: post.feed?.title ?? '',
+                  ),
+              ],
+            ),
+            if (post.text != null && post.text!.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(post.text!),
+            ],
+            if (post.media != null && post.media!.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              ImageComponent(
+                url: post.media!.first,
+                height: 200,
+                width: double.infinity,
+                fit: BoxFit.cover,
+                radius: 10,
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    if (controller.isLoading.value) {
+      return ListView.builder(
+        itemCount: 3,
+        itemBuilder: (_, __) => const ShimmerListTile(hasSubtitle: true),
+      );
+    }
+
+    if (controller.error.value != null) {
+      return NothingToShowComponent(
+        icon: const Icon(Icons.error_outline),
+        text: controller.error.value!,
+      );
+    }
+
+    if (controller.posts.isEmpty) {
+      return NothingToShowComponent(
+        icon: const Icon(Icons.feed_outlined),
+        text: 'subscribeToSeeHoots'.tr,
+      );
+    }
+
+    return ListView.builder(
+      itemCount: controller.posts.length,
+      itemBuilder: _buildPost,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -12,9 +91,7 @@ class FeedView extends GetView<FeedController> {
       appBar: AppBarComponent(
         title: 'feed'.tr,
       ),
-      body: Center(
-        child: Text('feed'.tr),
-      ),
+      body: Obx(() => _buildBody(context)),
     );
   }
 }

--- a/lib/services/feed_service.dart
+++ b/lib/services/feed_service.dart
@@ -1,0 +1,45 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:get/get.dart';
+
+import '../models/post.dart';
+import 'auth_service.dart';
+
+/// Service retrieving posts from feeds the current user is subscribed to.
+abstract class BaseFeedService {
+  Future<List<Post>> fetchSubscribedPosts();
+}
+
+/// Default implementation retrieving posts from feeds the current user is subscribed to.
+class FeedService implements BaseFeedService {
+  final FirebaseFirestore _firestore;
+  final AuthService _authService;
+
+  FeedService({FirebaseFirestore? firestore, AuthService? authService})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _authService = authService ?? Get.find<AuthService>();
+
+  /// Returns the latest posts from the user's subscriptions ordered by creation.
+  Future<List<Post>> fetchSubscribedPosts() async {
+    final user = _authService.currentUser;
+    if (user == null) return [];
+
+    final subsSnapshot = await _firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('subscriptions')
+        .get();
+
+    final feedIds = subsSnapshot.docs.map((d) => d.id).toList();
+    if (feedIds.isEmpty) return [];
+
+    final postsSnapshot = await _firestore
+        .collection('posts')
+        .where('feedId', whereIn: feedIds)
+        .orderBy('createdAt', descending: true)
+        .get();
+
+    return postsSnapshot.docs
+        .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
+        .toList();
+  }
+}

--- a/test/feed_view_test.dart
+++ b/test/feed_view_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/pages/feed/controllers/feed_controller.dart';
+import 'package:hoot/pages/feed/views/feed_view.dart';
+import 'package:hoot/services/feed_service.dart';
+
+class FakeFeedService implements BaseFeedService {
+  @override
+  Future<List<Post>> fetchSubscribedPosts() async {
+    return [
+      Post(
+        id: '1',
+        text: 'Hello world',
+        user: U(uid: 'u1', name: 'Tester'),
+        media: [],
+      ),
+    ];
+  }
+}
+
+void main() {
+  testWidgets('FeedView shows posts from controller', (tester) async {
+    final controller = FeedController(service: FakeFeedService());
+    Get.put<FeedController>(controller);
+
+    await tester.pumpWidget(
+      const GetMaterialApp(
+        home: Scaffold(body: FeedView()),
+      ),
+    );
+
+    // Wait for posts to load
+    await tester.pumpAndSettle();
+
+    expect(find.text('Hello world'), findsOneWidget);
+    expect(find.text('Tester'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `FeedService` to load posts from subscribed feeds
- register `FeedService` in dependency injector
- extend `FeedController` to load posts and expose observables
- display posts in `FeedView` with loading and error states
- add widget test covering post rendering

## Testing
- `flutter test -j 1`

------
https://chatgpt.com/codex/tasks/task_e_688356da0c80832895ba0f4f14120a42