### PR TITLE
Implement ExploreController and view

### DIFF
--- a/lib/pages/explore/controllers/explore_controller.dart
+++ b/lib/pages/explore/controllers/explore_controller.dart
@@ -1,3 +1,131 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-class ExploreController extends GetxController {}
+import '../../../models/feed.dart';
+import '../../../models/user.dart';
+import '../../../util/enums/feed_types.dart';
+
+/// Controller in charge of fetching data for the explore page.
+class ExploreController extends GetxController {
+  final FirebaseFirestore _firestore;
+
+  ExploreController({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  /// Text editing controller used by the search field.
+  final TextEditingController searchController = TextEditingController();
+  final RxString query = ''.obs;
+
+  /// Search results for users and feeds.
+  final RxList<U> userSuggestions = <U>[].obs;
+  final RxList<Feed> feedSuggestions = <Feed>[].obs;
+  final RxBool searching = false.obs;
+
+  /// Top feeds ordered by subscriber count.
+  final RxList<Feed> topFeeds = <Feed>[].obs;
+
+  /// Recently created feeds.
+  final RxList<Feed> newFeeds = <Feed>[].obs;
+
+  /// Popular feed genres.
+  final RxList<FeedType> genres = <FeedType>[].obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadExploreData();
+  }
+
+  /// Loads initial explore data.
+  Future<void> _loadExploreData() async {
+    await Future.wait([
+      loadTopFeeds(),
+      loadNewFeeds(),
+      loadGenres(),
+    ]);
+  }
+
+  /// Queries the ten feeds with most subscribers.
+  Future<void> loadTopFeeds() async {
+    final snapshot = await _firestore
+        .collection('feeds')
+        .orderBy('subscriberCount', descending: true)
+        .limit(10)
+        .get();
+    topFeeds.assignAll(snapshot.docs
+        .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
+        .toList());
+  }
+
+  /// Queries the ten newest feeds.
+  Future<void> loadNewFeeds() async {
+    final snapshot = await _firestore
+        .collection('feeds')
+        .orderBy('createdAt', descending: true)
+        .limit(10)
+        .get();
+    newFeeds.assignAll(snapshot.docs
+        .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
+        .toList());
+  }
+
+  /// Retrieves the most popular feed genres from Firestore.
+  Future<void> loadGenres() async {
+    final snapshot = await _firestore
+        .collection('feed_types')
+        .orderBy('count', descending: true)
+        .limit(10)
+        .get();
+    genres.assignAll(snapshot.docs
+        .map((d) => FeedTypeExtension.fromString(d.id))
+        .toList());
+  }
+
+  /// Searches for users and feeds matching [query].
+  Future<void> search(String value) async {
+    query.value = value;
+    if (value.isEmpty) {
+      userSuggestions.clear();
+      feedSuggestions.clear();
+      return;
+    }
+
+    searching.value = true;
+    try {
+      final futures = await Future.wait([
+        _firestore
+            .collection('users')
+            .where('username', isGreaterThanOrEqualTo: value)
+            .where('username', isLessThanOrEqualTo: '$value\uf8ff')
+            .limit(5)
+            .get(),
+        _firestore
+            .collection('feeds')
+            .where('title', isGreaterThanOrEqualTo: value)
+            .where('title', isLessThanOrEqualTo: '$value\uf8ff')
+            .limit(5)
+            .get(),
+      ]);
+
+      final userSnap = futures[0] as QuerySnapshot<Map<String, dynamic>>;
+      final feedSnap = futures[1] as QuerySnapshot<Map<String, dynamic>>;
+
+      userSuggestions.assignAll(
+        userSnap.docs.map((d) => U.fromJson(d.data())).toList(),
+      );
+      feedSuggestions.assignAll(feedSnap.docs
+          .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
+          .toList());
+    } finally {
+      searching.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    searchController.dispose();
+    super.onClose();
+  }
+}
+

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/components/list_item_component.dart';
+import 'package:hoot/components/type_box_component.dart';
+import '../../../util/enums/feed_types.dart';
+import '../../../util/routes/app_routes.dart';
 import '../controllers/explore_controller.dart';
 
 class ExploreView extends GetView<ExploreController> {
@@ -8,12 +12,91 @@ class ExploreView extends GetView<ExploreController> {
 
   @override
   Widget build(BuildContext context) {
+    Widget _buildSuggestions() {
+      return Obx(() {
+        if (controller.query.value.isEmpty) return const SizedBox();
+        if (controller.searching.value) {
+          return const Padding(
+            padding: EdgeInsets.all(16),
+            child: CircularProgressIndicator(),
+          );
+        }
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ...controller.userSuggestions.map(
+              (u) => ListTile(
+                title: Text(u.name ?? ''),
+                subtitle: Text('@${u.username ?? ''}'),
+              ),
+            ),
+            ...controller.feedSuggestions.map(
+              (f) => ListTile(
+                title: Text(f.title),
+                subtitle: Text('feed'.tr),
+              ),
+            ),
+          ],
+        );
+      });
+    }
+
     return Scaffold(
       appBar: AppBarComponent(
         title: 'explore'.tr,
       ),
-      body: Center(
-        child: Text('explore'.tr),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: controller.searchController,
+              decoration: InputDecoration(
+                hintText: 'searchPlaceholder'.tr,
+                prefixIcon: const Icon(Icons.search),
+              ),
+              onChanged: controller.search,
+            ),
+            const SizedBox(height: 16),
+            _buildSuggestions(),
+            const SizedBox(height: 16),
+            Text('top10MostSubscribed'.tr,
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Obx(() => Column(
+                  children: controller.topFeeds
+                      .map((f) => ListItemComponent(
+                            title: f.title,
+                            subtitle:
+                                '${f.subscriberCount ?? 0} ${'followers'.tr}',
+                          ))
+                      .toList(),
+                )),
+            const SizedBox(height: 16),
+            Text('popularTypes'.tr,
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 100,
+              child: Obx(() => ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: controller.genres.length,
+                    separatorBuilder: (_, __) => const SizedBox(width: 12),
+                    itemBuilder: (context, index) {
+                      final type = controller.genres[index];
+                      return GestureDetector(
+                        onTap: () => Get.toNamed(
+                          AppRoutes.searchByGenre,
+                          arguments: type,
+                        ),
+                        child: TypeBoxComponent(type: type),
+                      );
+                    },
+                  )),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/pages/search_by_genre/controllers/search_by_genre_controller.dart
+++ b/lib/pages/search_by_genre/controllers/search_by_genre_controller.dart
@@ -1,3 +1,37 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get/get.dart';
 
-class SearchByGenreController extends GetxController {}
+import '../../../models/feed.dart';
+import '../../../util/enums/feed_types.dart';
+
+/// Controller that loads feeds for a specific [FeedType].
+class SearchByGenreController extends GetxController {
+  final FirebaseFirestore _firestore;
+
+  SearchByGenreController({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  late FeedType type;
+  final RxList<Feed> feeds = <Feed>[].obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    type = Get.arguments as FeedType;
+    loadFeeds();
+  }
+
+  /// Loads feeds of the selected [type].
+  Future<void> loadFeeds() async {
+    final snapshot = await _firestore
+        .collection('feeds')
+        .where('type', isEqualTo: type.toString().split('.').last)
+        .orderBy('subscriberCount', descending: true)
+        .limit(20)
+        .get();
+    feeds.assignAll(snapshot.docs
+        .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
+        .toList());
+  }
+}
+

--- a/lib/pages/search_by_genre/views/search_by_genre_view.dart
+++ b/lib/pages/search_by_genre/views/search_by_genre_view.dart
@@ -1,19 +1,31 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/search_by_genre_controller.dart';
+import '../../../components/list_item_component.dart';
+import '../../../util/enums/feed_types.dart';
 
 class SearchByGenreView extends GetView<SearchByGenreController> {
   const SearchByGenreView({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final title = FeedTypeExtension.toTranslatedString(context, controller.type);
+
     return Scaffold(
       appBar: AppBar(
-        title: Text('searchByGenre'.tr),
+        title: Text(title),
       ),
-      body: Center(
-        child: Text('searchByGenre'.tr),
-      ),
+      body: Obx(() => ListView.builder(
+            itemCount: controller.feeds.length,
+            itemBuilder: (context, index) {
+              final feed = controller.feeds[index];
+              return ListItemComponent(
+                title: feed.title,
+                subtitle:
+                    '${feed.subscriberCount ?? 0} ${'followers'.tr}',
+              );
+            },
+          )),
     );
   }
 }

--- a/test/explore_view_test.dart
+++ b/test/explore_view_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+
+import 'package:hoot/pages/explore/controllers/explore_controller.dart';
+import 'package:hoot/pages/explore/views/explore_view.dart';
+import 'package:hoot/util/translations/app_translations.dart';
+
+void main() {
+  testWidgets('ExploreView shows search suggestions', (tester) async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('users').doc('u1').set({
+      'uid': 'u1',
+      'displayName': 'Tester',
+      'username': 'tester',
+    });
+    await firestore.collection('feeds').doc('f1').set({
+      'title': 'test feed',
+      'description': 'D',
+      'color': '0',
+      'type': 'music',
+      'subscriberCount': 1,
+      'createdAt': DateTime.now(),
+    });
+    await firestore.collection('feed_types').doc('music').set({'count': 1});
+
+    Get.put(ExploreController(firestore: firestore));
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        translations: AppTranslations(),
+        locale: const Locale('en'),
+        home: const Scaffold(body: ExploreView()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'test');
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    final controller = Get.find<ExploreController>();
+    expect(controller.userSuggestions.length, 1);
+    expect(controller.feedSuggestions.length, 1);
+
+    expect(find.text('Tester'), findsOneWidget);
+    expect(find.text('test feed'), findsWidgets);
+
+    Get.reset();
+  });
+}


### PR DESCRIPTION
## Summary
- populate ExploreController with Firestore queries for feeds and genres
- flesh out ExploreView with search, top feeds and genre navigation
- implement SearchByGenre flow
- add widget test verifying search suggestions

## Testing
- `flutter test -j 1`

------
https://chatgpt.com/codex/tasks/task_e_688360be15a0832889170c1357745f91