### PR TITLE
Implement profile page with feed list

### DIFF
--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -1,3 +1,37 @@
 import 'package:get/get.dart';
 
-class ProfileController extends GetxController {}
+import '../../../models/feed.dart';
+import '../../../models/user.dart';
+import '../../../services/auth_service.dart';
+
+/// Loads the current user profile data and owned feeds.
+class ProfileController extends GetxController {
+  final AuthService _authService;
+
+  ProfileController({AuthService? authService})
+      : _authService = authService ?? Get.find<AuthService>();
+
+  final Rxn<U> user = Rxn<U>();
+  final RxList<Feed> feeds = <Feed>[].obs;
+  final RxBool isLoading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    loadProfile();
+  }
+
+  /// Fetches the current user and their feeds from [AuthService].
+  Future<void> loadProfile() async {
+    isLoading.value = true;
+    try {
+      final u = await _authService.fetchUser();
+      if (u != null) {
+        user.value = u;
+        feeds.assignAll(u.feeds ?? []);
+      }
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/components/avatar_component.dart';
+import 'package:hoot/components/image_component.dart';
+import 'package:hoot/components/name_component.dart';
+import '../../../util/routes/app_routes.dart';
 import '../controllers/profile_controller.dart';
 
 class ProfileView extends GetView<ProfileController> {
@@ -8,13 +12,118 @@ class ProfileView extends GetView<ProfileController> {
 
   @override
   Widget build(BuildContext context) {
+    Widget _buildFeedItem(int index) {
+      final feed = controller.feeds[index];
+      return ListTile(
+        leading: feed.icon != null
+            ? Image.network(feed.icon!,
+                width: 40, height: 40, fit: BoxFit.cover)
+            : const Icon(Icons.feed_outlined),
+        title: Text(feed.title),
+        subtitle: feed.description != null ? Text(feed.description!) : null,
+      );
+    }
+
+    Widget _buildBody() {
+      if (controller.isLoading.value) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      final user = controller.user.value;
+      if (user == null) {
+        return const SizedBox.shrink();
+      }
+
+      return SingleChildScrollView(
+        padding: const EdgeInsets.only(bottom: 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            if (user.bannerPictureUrl != null &&
+                user.bannerPictureUrl!.isNotEmpty)
+              ImageComponent(
+                url: user.bannerPictureUrl!,
+                height: 150,
+                fit: BoxFit.cover,
+              ),
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ProfileAvatarComponent(
+                    image: user.smallProfilePictureUrl ?? '',
+                    size: 80,
+                    radius: 40,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        NameComponent(
+                          user: user,
+                          showUsername: true,
+                          size: 20,
+                        ),
+                        if (user.bio != null && user.bio!.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(top: 8),
+                            child: Text(user.bio!),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  ElevatedButton.icon(
+                    onPressed: () => Get.toNamed(AppRoutes.editFeed),
+                    icon: const Icon(Icons.edit),
+                    label: Text('editFeed'.tr),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton.icon(
+                    onPressed: () => Get.toNamed(AppRoutes.subscribers),
+                    icon: const Icon(Icons.group),
+                    label: Text('subscribers'.tr),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton.icon(
+                    onPressed: () => Get.toNamed(AppRoutes.createPost),
+                    icon: const Icon(Icons.add),
+                    label: Text('createPost'.tr),
+                  ),
+                ],
+              ),
+            ),
+            const Divider(height: 32),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                'myFeeds'.tr,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: controller.feeds.length,
+              itemBuilder: (_, i) => _buildFeedItem(i),
+            ),
+          ],
+        ),
+      );
+    }
+
     return Scaffold(
       appBar: AppBarComponent(
         title: 'profile'.tr,
       ),
-      body: Center(
-        child: Text('profile'.tr),
-      ),
+      body: Obx(_buildBody),
     );
   }
 }

--- a/test/profile_view_test.dart
+++ b/test/profile_view_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'package:hoot/models/user.dart';
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/pages/profile/controllers/profile_controller.dart';
+import 'package:hoot/pages/profile/views/profile_view.dart';
+import 'package:hoot/services/auth_service.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U _user;
+  FakeAuthService(this._user);
+
+  @override
+  U? get currentUser => _user;
+
+  @override
+  Future<U?> fetchUser() async => _user;
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+}
+
+void main() {
+  testWidgets('ProfileView shows profile information', (tester) async {
+    final user = U(
+      uid: '1',
+      name: 'Tester',
+      username: 'tester',
+      bio: 'Hello',
+      feeds: [Feed(id: 'f1', title: 'Feed 1', description: 'desc')],
+    );
+    final service = FakeAuthService(user);
+    final controller = ProfileController(authService: service);
+    Get.put<AuthService>(service);
+    Get.put<ProfileController>(controller);
+
+    await tester.pumpWidget(const GetMaterialApp(
+      home: Scaffold(body: ProfileView()),
+    ));
+
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tester'), findsOneWidget);
+    expect(find.text('@tester'), findsOneWidget);
+    expect(find.text('Hello'), findsOneWidget);
+    expect(find.text('Feed 1'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- load profile information via ProfileController
- display banner, avatar, bio and feeds in ProfileView
- add navigation buttons for editing feeds, viewing subscribers and creating posts
- test profile view logic

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_688360bfcc5883288c65e47ae4f590d7