### PR TITLE
Add dark mode options and settings improvements

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -1,6 +1,7 @@
 import 'package:get/get.dart';
 import 'services/auth_service.dart';
 import 'services/feed_service.dart';
+import 'services/theme_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -11,5 +12,7 @@ class DependencyInjector {
     final auth = Get.put(AuthService(), permanent: true);
     await auth.fetchUser();
     Get.put<BaseFeedService>(FeedService(), permanent: true);
+    final theme = Get.put(ThemeService(), permanent: true);
+    await theme.loadThemeMode();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:hoot/theme/theme.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:toastification/toastification.dart';
+import 'services/theme_service.dart';
 import 'firebase_options.dart';
 
 
@@ -25,20 +26,23 @@ Future<void> main() async {
   FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
 
 
+  final themeService = Get.find<ThemeService>();
+
   runZonedGuarded(() {
     runApp(
       ToastificationWrapper(
-        child: GetMaterialApp(
+        child: Obx(() => GetMaterialApp(
           title: 'Hoot',
           debugShowCheckedModeBanner: false,
           getPages: AppPages.pages,
           initialRoute: AppRoutes.home,
           theme: AppTheme.lightTheme,
           darkTheme: AppTheme.darkTheme,
+          themeMode: themeService.themeMode.value,
           translations: AppTranslations(),
           locale: Get.deviceLocale,
           fallbackLocale: const Locale('en', 'US'),
-        ),
+        )),
       ),
     );
     FlutterNativeSplash.remove();

--- a/lib/pages/settings/controllers/settings_controller.dart
+++ b/lib/pages/settings/controllers/settings_controller.dart
@@ -1,13 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:flutter_contacts/flutter_contacts.dart';
+
 import '../../../services/auth_service.dart';
 import '../../../services/dialog_service.dart';
 import '../../../services/error_service.dart';
+import '../../../services/toast_service.dart';
+import '../../../services/theme_service.dart';
 import '../../../util/routes/app_routes.dart';
 
 class SettingsController extends GetxController {
   final _auth = Get.find<AuthService>();
+  final _theme = Get.find<ThemeService>();
+
+  final version = ''.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadVersion();
+  }
+
+  Future<void> _loadVersion() async {
+    final info = await PackageInfo.fromPlatform();
+    version.value = info.version;
+  }
+
+  bool get isDarkMode => _theme.themeMode.value == ThemeMode.dark;
+
+  Future<void> toggleDarkMode(bool val) => _theme.toggleDarkMode(val);
 
   /// Signs out the user after confirmation.
   Future<void> signOut(BuildContext context) async {
@@ -24,6 +47,37 @@ class SettingsController extends GetxController {
       Get.offAllNamed(AppRoutes.login);
     } catch (e, s) {
       await ErrorService.reportError(e, stack: s);
+    }
+  }
+
+  void goToEditProfile() {
+    Get.toNamed(AppRoutes.editProfile);
+  }
+
+  Future<void> findFriends() async {
+    final granted = await FlutterContacts.requestPermission();
+    if (!granted) {
+      ToastService.showError('contactsPermission'.tr);
+      return;
+    }
+    Get.toNamed(AppRoutes.contacts);
+  }
+
+  Future<void> deleteAccount(BuildContext context) async {
+    final confirmed = await DialogService.confirm(
+      context: context,
+      title: 'deleteAccount'.tr,
+      message: 'deleteAccountDescription'.tr,
+      okLabel: 'delete'.tr,
+      cancelLabel: 'cancel'.tr,
+    );
+    if (!confirmed) return;
+    try {
+      await _auth.deleteAccount();
+      ToastService.showSuccess('deleteAccountSuccess'.tr);
+      Get.offAllNamed(AppRoutes.login);
+    } catch (e, s) {
+      await ErrorService.reportError(e, message: 'deleteAccountFailed'.tr, stack: s);
     }
   }
 }

--- a/lib/pages/settings/views/settings_view.dart
+++ b/lib/pages/settings/views/settings_view.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/settings_controller.dart';
+import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/util/routes/app_routes.dart';
 
 class SettingsView extends GetView<SettingsController> {
   const SettingsView({super.key});
@@ -8,14 +10,48 @@ class SettingsView extends GetView<SettingsController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text('settings'.tr),
+      appBar: AppBarComponent(
+        title: 'settings'.tr,
       ),
-      body: Center(
-        child: ElevatedButton(
-          onPressed: () => controller.signOut(context),
-          child: Text('signOut'.tr),
-        ),
+      body: ListView(
+        children: [
+          Obx(() => SwitchListTile(
+                title: Text('darkMode'.tr),
+                value: controller.isDarkMode,
+                onChanged: controller.toggleDarkMode,
+              )),
+          ListTile(
+            title: Text('editProfile'.tr),
+            onTap: controller.goToEditProfile,
+          ),
+          ListTile(
+            title: Text('findFriends'.tr),
+            subtitle: Text('findFriendsFromContacts'.tr),
+            onTap: controller.findFriends,
+          ),
+          ListTile(
+            title: Text('termsOfService'.tr),
+            onTap: () => Get.toNamed(AppRoutes.terms),
+          ),
+          ListTile(
+            title: Text('deleteAccount'.tr),
+            subtitle: Text('deleteAccountDescription'.tr),
+            onTap: () => controller.deleteAccount(context),
+          ),
+          ListTile(
+            title: Text('signOut'.tr),
+            onTap: () => controller.signOut(context),
+          ),
+          const Divider(),
+          ListTile(
+            title: Text('messageFromCreator'.tr),
+            subtitle: Text('hootMightBeBuggy'.tr),
+          ),
+          Obx(() => ListTile(
+                title: Text('version'.tr),
+                subtitle: Text(controller.version.value),
+              )),
+        ],
       ),
     );
   }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -110,4 +110,14 @@ class AuthService {
     await fetchUser();
     return result;
   }
+
+  /// Deletes the current user's account and Firestore data.
+  Future<void> deleteAccount() async {
+    final user = _auth.currentUser;
+    if (user == null) return;
+    await _firestore.collection('users').doc(user.uid).delete();
+    await user.delete();
+    _currentUser = null;
+    _fetched = false;
+  }
 }

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Service that manages theme mode and persists the user's preference.
+class ThemeService extends GetxService {
+  static const _prefKey = 'darkMode';
+
+  final themeMode = ThemeMode.light.obs;
+
+  /// Loads the saved theme mode from [SharedPreferences].
+  Future<void> loadThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final isDark = prefs.getBool(_prefKey) ?? false;
+    themeMode.value = isDark ? ThemeMode.dark : ThemeMode.light;
+  }
+
+  /// Toggles between light and dark mode and saves the preference.
+  Future<void> toggleDarkMode(bool isDark) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_prefKey, isDark);
+    themeMode.value = isDark ? ThemeMode.dark : ThemeMode.light;
+  }
+}

--- a/test/login_view_test.dart
+++ b/test/login_view_test.dart
@@ -25,6 +25,9 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAccount() async {}
 }
 
 void main() {

--- a/test/theme_toggle_test.dart
+++ b/test/theme_toggle_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:hoot/pages/settings/controllers/settings_controller.dart';
+import 'package:hoot/pages/settings/views/settings_view.dart';
+import 'package:hoot/services/theme_service.dart';
+import 'package:hoot/theme/theme.dart';
+import 'package:hoot/util/translations/app_translations.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hoot/models/user.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  @override
+  U? get currentUser => null;
+
+  @override
+  Future<U?> fetchUser() async => null;
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAccount() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Toggling dark mode updates theme', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final themeService = ThemeService();
+    await themeService.loadThemeMode();
+    Get.put(themeService);
+    Get.put<AuthService>(FakeAuthService());
+    Get.put(SettingsController());
+
+    await tester.pumpWidget(
+      Obx(() => GetMaterialApp(
+            translations: AppTranslations(),
+            locale: const Locale('en'),
+            theme: AppTheme.lightTheme,
+            darkTheme: AppTheme.darkTheme,
+            themeMode: themeService.themeMode.value,
+            home: const SettingsView(),
+          )),
+    );
+    await tester.pumpAndSettle();
+
+    expect(
+        Theme.of(tester.element(find.byType(SettingsView))).brightness,
+        Brightness.light);
+
+    await tester.tap(find.byType(SwitchListTile));
+    await tester.pumpAndSettle();
+
+    expect(themeService.themeMode.value, ThemeMode.dark);
+    expect(
+        Theme.of(tester.element(find.byType(SettingsView))).brightness,
+        Brightness.dark);
+  });
+}


### PR DESCRIPTION
## Summary
- allow theme switching with `ThemeService`
- initialize theme on startup
- enhance settings page with dark mode toggle, profile editing, contacts, terms, deletion, sign out, creator note, and version
- persist theme choice
- support account deletion
- cover dark mode toggle in tests

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_688360c0a9988328b775964e9593497a