### PR TITLE
Add Flutter setup instructions and CI workflow

### DIFF
--- a/.github/workflows/flutter-tests.yml
+++ b/.github/workflows/flutter-tests.yml
@@ -1,0 +1,17 @@
+name: Flutter Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - run: flutter pub get
+      - run: flutter test

--- a/README.md
+++ b/README.md
@@ -48,16 +48,26 @@ Hoot operates like a streamlined community platform:
 
 - This structure delivers a classic social-network experience—connecting people through posts and feeds—with an emphasis on simplicity and user privacy.
 
+## Installing Flutter
+
+1. Download the [Flutter SDK](https://docs.flutter.dev/get-started/install) for your platform and extract it.
+2. Add the `flutter/bin` directory to your `PATH`.
+3. Verify installation with:
+
+   ```bash
+   flutter --version
+   ```
+
 ## Running Tests
 
-Widget and model tests are located under the `test/` directory. To execute them
-run:
+Widget and model tests are located under the `test/` directory. Fetch all
+dependencies and run the tests with:
 
 ```bash
+flutter pub get
 flutter test
 ```
 
-Make sure all dependencies have been fetched with `flutter pub get` before running the tests.
 
 ## License
 


### PR DESCRIPTION
## Summary
- document how to install Flutter and run the tests
- add a GitHub Actions workflow that runs `flutter pub get` and `flutter test`

## Testing
- `flutter pub get`
- `flutter test` *(fails: FakeAuthService missing implementations)*

------
https://chatgpt.com/codex/tasks/task_e_68836f1b4db48328914afd40088f2c86