### PR TITLE
Fix missing controller initialization for HomeView

### DIFF
--- a/lib/pages/home/bindings/home_binding.dart
+++ b/lib/pages/home/bindings/home_binding.dart
@@ -1,9 +1,19 @@
 import 'package:get/get.dart';
 import '../controllers/home_controller.dart';
+import '../../feed/controllers/feed_controller.dart';
+import '../../explore/controllers/explore_controller.dart';
+import '../../create_post/controllers/create_post_controller.dart';
+import '../../notifications/controllers/notifications_controller.dart';
+import '../../profile/controllers/profile_controller.dart';
 
 class HomeBinding extends Bindings {
   @override
   void dependencies() {
     Get.lazyPut(() => HomeController());
+    Get.lazyPut(() => FeedController());
+    Get.lazyPut(() => ExploreController());
+    Get.lazyPut(() => CreatePostController());
+    Get.lazyPut(() => NotificationsController());
+    Get.lazyPut(() => ProfileController());
   }
 }


### PR DESCRIPTION
## Summary
- load controllers for nested HomeView pages so GetX can find them

## Testing
- `flutter test` *(fails: FakeAuthService missing implementation)*

------
https://chatgpt.com/codex/tasks/task_e_6883795f6ab48328a85c207090d04b9a