### PR TITLE
Implement create feed page

### DIFF
--- a/lib/pages/create_feed/controllers/create_feed_controller.dart
+++ b/lib/pages/create_feed/controllers/create_feed_controller.dart
@@ -1,3 +1,91 @@
+import 'dart:ui';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
-class CreateFeedController extends GetxController {}
+import '../../../services/toast_service.dart';
+import '../../../services/error_service.dart';
+import '../../../util/enums/feed_types.dart';
+
+/// Controller handling the create feed form.
+class CreateFeedController extends GetxController {
+  final FirebaseFirestore _firestore;
+  final String _userId;
+
+  CreateFeedController({FirebaseFirestore? firestore, String? userId})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _userId = userId ?? FirebaseAuth.instance.currentUser?.uid ?? '';
+
+  /// Controllers for title and description fields.
+  final TextEditingController titleController = TextEditingController();
+  final TextEditingController descriptionController = TextEditingController();
+
+  /// Selected feed color.
+  final Rx<Color> selectedColor = Colors.blue.obs;
+
+  /// Chosen feed genre.
+  final Rx<FeedType?> selectedType = Rx<FeedType?>(null);
+
+  /// Whether the feed is private.
+  final RxBool isPrivate = false.obs;
+
+  /// Whether the feed is marked NSFW.
+  final RxBool isNsfw = false.obs;
+
+  /// Whether a feed is currently being created.
+  final RxBool creating = false.obs;
+
+  /// Creates the feed in Firestore after validating input.
+  Future<bool> createFeed() async {
+    if (creating.value) return false;
+
+    final title = titleController.text.trim();
+    final description = descriptionController.text.trim();
+    final type = selectedType.value;
+
+    if (title.isEmpty) {
+      ToastService.showError('title'.tr);
+      return false;
+    }
+    if (type == null) {
+      ToastService.showError('genre');
+      return false;
+    }
+
+    creating.value = true;
+    try {
+      await _firestore.collection('feeds').add({
+        'title': title,
+        'description': description,
+        'color': selectedColor.value.value.toString(),
+        'type': type.toString().split('.').last,
+        'private': isPrivate.value,
+        'nsfw': isNsfw.value,
+        'userId': _userId,
+        'subscriberCount': 0,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+      ToastService.showSuccess('createFeed'.tr);
+      titleController.clear();
+      descriptionController.clear();
+      selectedType.value = null;
+      isPrivate.value = false;
+      isNsfw.value = false;
+      return true;
+    } catch (e, s) {
+      await ErrorService.reportError(e, stack: s);
+      return false;
+    } finally {
+      creating.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    titleController.dispose();
+    descriptionController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/pages/create_feed/views/create_feed_view.dart
+++ b/lib/pages/create_feed/views/create_feed_view.dart
@@ -1,6 +1,8 @@
+import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/create_feed_controller.dart';
+import '../../../util/enums/feed_types.dart';
 
 class CreateFeedView extends GetView<CreateFeedController> {
   const CreateFeedView({super.key});
@@ -10,9 +12,88 @@ class CreateFeedView extends GetView<CreateFeedController> {
     return Scaffold(
       appBar: AppBar(
         title: Text('createFeed'.tr),
+        actions: [
+          Obx(() => controller.creating.value
+              ? const Padding(
+                  padding: EdgeInsets.all(12),
+                  child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2)),
+                )
+              : TextButton(
+                  onPressed: controller.createFeed,
+                  child: Text('done'.tr),
+                ))
+        ],
       ),
-      body: Center(
-        child: Text('createFeed'.tr),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: controller.titleController,
+              decoration: InputDecoration(labelText: 'title'.tr),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller.descriptionController,
+              decoration: InputDecoration(labelText: 'description'.tr),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 16),
+            Obx(() => Row(
+                  children: [
+                    Text('Color:'),
+                    const SizedBox(width: 8),
+                    GestureDetector(
+                      onTap: () async {
+                        final color = await showColorPickerDialog(
+                          context,
+                          controller.selectedColor.value,
+                          barrierDismissible: true,
+                        );
+                        if (color != null) {
+                          controller.selectedColor.value = color;
+                        }
+                      },
+                      child: ColorIndicator(
+                        color: controller.selectedColor.value,
+                        width: 40,
+                        height: 40,
+                        borderRadius: 20,
+                      ),
+                    ),
+                  ],
+                )),
+            const SizedBox(height: 16),
+            Obx(() => DropdownButton<FeedType>(
+                  value: controller.selectedType.value,
+                  hint: const Text('Genre'),
+                  isExpanded: true,
+                  onChanged: (value) => controller.selectedType.value = value,
+                  items: FeedType.values
+                      .map((t) => DropdownMenuItem(
+                            value: t,
+                            child: Text(FeedTypeExtension.toTranslatedString(
+                                context, t)),
+                          ))
+                      .toList(),
+                )),
+            const SizedBox(height: 16),
+            Obx(() => SwitchListTile(
+                  value: controller.isPrivate.value,
+                  onChanged: (v) => controller.isPrivate.value = v,
+                  title: Text('privateFeed'.tr),
+                )),
+            Obx(() => SwitchListTile(
+                  value: controller.isNsfw.value,
+                  onChanged: (v) => controller.isNsfw.value = v,
+                  title: Text('nsfwFeed'.tr),
+                )),
+          ],
+        ),
       ),
     );
   }

--- a/test/create_feed_controller_test.dart
+++ b/test/create_feed_controller_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:toastification/toastification.dart';
+
+import 'package:hoot/pages/create_feed/controllers/create_feed_controller.dart';
+import 'package:hoot/util/enums/feed_types.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('successful create writes document', (tester) async {
+    await tester.pumpWidget(const ToastificationWrapper(
+      child: MaterialApp(home: Scaffold(body: SizedBox())),
+    ));
+
+    final firestore = FakeFirebaseFirestore();
+    final controller =
+        CreateFeedController(firestore: firestore, userId: 'u1');
+    controller.titleController.text = 'My Feed';
+    controller.descriptionController.text = 'Desc';
+    controller.selectedType.value = FeedType.music;
+
+    final result = await controller.createFeed();
+    await tester.pump(const Duration(seconds: 4));
+    await tester.pumpAndSettle();
+
+    expect(result, isTrue);
+    final feeds = await firestore.collection('feeds').get();
+    expect(feeds.docs.length, 1);
+    expect(feeds.docs.first.get('title'), 'My Feed');
+    expect(feeds.docs.first.get('type'), 'music');
+  });
+}


### PR DESCRIPTION
## Summary
- implement CreateFeedController with Firestore integration and form state
- build CreateFeedView with color picker, genre dropdown and switches for privacy/NSFW
- add tests for creating a feed

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6883560623ec8328a752504de0341e4d