### PR TITLE
Add searchable genre dropdown

### DIFF
--- a/lib/pages/create_feed/controllers/create_feed_controller.dart
+++ b/lib/pages/create_feed/controllers/create_feed_controller.dart
@@ -28,6 +28,9 @@ class CreateFeedController extends GetxController {
   /// Chosen feed genre.
   final Rx<FeedType?> selectedType = Rx<FeedType?>(null);
 
+  /// Search controller for genre dropdown.
+  final TextEditingController typeSearchController = TextEditingController();
+
   /// Whether the feed is private.
   final RxBool isPrivate = false.obs;
 
@@ -86,6 +89,7 @@ class CreateFeedController extends GetxController {
   void onClose() {
     titleController.dispose();
     descriptionController.dispose();
+    typeSearchController.dispose();
     super.onClose();
   }
 }

--- a/lib/pages/create_feed/views/create_feed_view.dart
+++ b/lib/pages/create_feed/views/create_feed_view.dart
@@ -2,6 +2,7 @@ import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
+import 'package:dropdown_button2/dropdown_button2.dart';
 import '../controllers/create_feed_controller.dart';
 import '../../../util/enums/feed_types.dart';
 
@@ -69,20 +70,50 @@ class CreateFeedView extends GetView<CreateFeedController> {
                   ],
                 )),
             const SizedBox(height: 16),
-            Obx(() => DropdownButton<FeedType>(
-                  value: controller.selectedType.value,
-                  hint: const Text('Genre'),
-                  isExpanded: true,
-                  onChanged: (value) => controller.selectedType.value = value,
-                  items: FeedType.values
-                      .map((t) => DropdownMenuItem(
-                            value: t,
-                            child: Text('${FeedTypeExtension.toEmoji(t)} ' +
-                                FeedTypeExtension.toTranslatedString(
-                                    context, t)),
-                          ))
-                      .toList(),
-                )),
+            Obx(
+              () => DropdownButton2<FeedType>(
+                value: controller.selectedType.value,
+                hint: const Text('Genre'),
+                isExpanded: true,
+                onChanged: (value) => controller.selectedType.value = value,
+                items: FeedType.values
+                    .map((t) => DropdownMenuItem(
+                          value: t,
+                          child: Text('${FeedTypeExtension.toEmoji(t)} '
+                              '${FeedTypeExtension.toTranslatedString(context, t)}'),
+                        ))
+                    .toList(),
+                dropdownStyleData: DropdownStyleData(
+                  width: MediaQuery.of(context).size.width - 32,
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                ),
+                dropdownSearchData: DropdownSearchData(
+                  searchController: controller.typeSearchController,
+                  searchInnerWidgetHeight: 50,
+                  searchInnerWidget: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: TextFormField(
+                      controller: controller.typeSearchController,
+                      decoration: const InputDecoration(
+                        isDense: true,
+                        hintText: 'Search...',
+                        border: OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                  searchMatchFn: (item, searchValue) {
+                    final value = FeedTypeExtension.toTranslatedString(
+                        context, item.value!);
+                    return value
+                        .toLowerCase()
+                        .contains(searchValue.toLowerCase());
+                  },
+                ),
+                onMenuStateChange: (isOpen) {
+                  if (!isOpen) controller.typeSearchController.clear();
+                },
+              ),
+            ),
             const SizedBox(height: 16),
             Obx(() => SwitchListTile(
                   value: controller.isPrivate.value,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -265,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.6"
+  dropdown_button2:
+    dependency: "direct main"
+    description:
+      name: dropdown_button2
+      sha256: b0fe8d49a030315e9eef6c7ac84ca964250155a6224d491c1365061bc974a9e1
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.9"
   dynamic_color:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -80,6 +80,7 @@ dependencies:
   flutter_native_splash: ^2.4.6
 
   page_transition: any
+  dropdown_button2: ^2.3.9
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Summary
- allow searching feed genres when creating feeds
- use `DropdownButton2` with search support and margins

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6883a64f14948328889411735c0142e7