### PR TITLE
Improve feed creation workflow

### DIFF
--- a/lib/pages/create_feed/views/create_feed_view.dart
+++ b/lib/pages/create_feed/views/create_feed_view.dart
@@ -25,7 +25,10 @@ class CreateFeedView extends GetView<CreateFeedController> {
                         child: CircularProgressIndicator(strokeWidth: 2)),
                   )
                 : TextButton(
-                    onPressed: controller.createFeed,
+                    onPressed: () async {
+                      final result = await controller.createFeed();
+                      if (result) Get.back();
+                    },
                     child: Text('done'.tr),
                   ),
           ),


### PR DESCRIPTION
## Summary
- update CreateFeedController with AuthService and ProfileController
- update feed creation to add new feed to profile data
- close create feed view on success
- test validation and profile updates when creating feeds

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6883ad1c46148328afc869e9263e075c