### PR TITLE
Color chips match feed colors

### DIFF
--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -6,6 +6,7 @@ import 'package:hoot/components/image_component.dart';
 import 'package:hoot/components/name_component.dart';
 import 'package:hoot/components/empty_message.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../../util/color_utils.dart';
 import '../controllers/profile_controller.dart';
 
 class ProfileView extends GetView<ProfileController> {
@@ -179,12 +180,22 @@ class ProfileView extends GetView<ProfileController> {
                     final feed = controller.feeds[i];
                     return Padding(
                       padding: const EdgeInsets.only(left: 8),
-                      child: Obx(() => ChoiceChip(
-                            label: Text(feed.title),
-                            selected: controller.selectedFeedIndex.value == i,
-                            onSelected: (_) =>
-                                controller.selectedFeedIndex.value = i,
-                          )),
+                      child: Obx(() {
+                        final color =
+                            feed.color ?? Theme.of(context).colorScheme.primary;
+                        final textColor = foregroundForBackground(color);
+                        return ChoiceChip(
+                          label: Text(
+                            feed.title,
+                            style: TextStyle(color: textColor),
+                          ),
+                          selected: controller.selectedFeedIndex.value == i,
+                          onSelected: (_) =>
+                              controller.selectedFeedIndex.value = i,
+                          selectedColor: color,
+                          backgroundColor: color,
+                        );
+                      }),
                     );
                   }),
                 ],

--- a/lib/util/color_utils.dart
+++ b/lib/util/color_utils.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+
+/// Returns either [Colors.white] or [Colors.black] depending on the luminance
+/// of the given [background] color. Colors with a luminance greater than 0.5
+/// are considered light and will use [Colors.black] as the foreground color,
+/// otherwise [Colors.white] is used.
+Color foregroundForBackground(Color background) {
+  return background.computeLuminance() > 0.5 ? Colors.black : Colors.white;
+}


### PR DESCRIPTION
## Summary
- use feed color in profile feed row chips
- compute foreground color automatically using luminance

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6883c53c64e48328874021c9a26fdf33