### PR TITLE
Add edit feed action button on profile

### DIFF
--- a/lib/pages/edit_feed/controllers/edit_feed_controller.dart
+++ b/lib/pages/edit_feed/controllers/edit_feed_controller.dart
@@ -1,3 +1,13 @@
 import 'package:get/get.dart';
 
-class EditFeedController extends GetxController {}
+import '../../../models/feed.dart';
+
+class EditFeedController extends GetxController {
+  late Feed feed;
+
+  @override
+  void onInit() {
+    super.onInit();
+    feed = Get.arguments as Feed;
+  }
+}

--- a/lib/pages/edit_feed/views/edit_feed_view.dart
+++ b/lib/pages/edit_feed/views/edit_feed_view.dart
@@ -12,7 +12,7 @@ class EditFeedView extends GetView<EditFeedController> {
         title: Text('editFeed'.tr),
       ),
       body: Center(
-        child: Text('editFeed'.tr),
+        child: Text(controller.feed.title),
       ),
     );
   }

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -206,6 +206,22 @@ class ProfileView extends GetView<ProfileController> {
         ],
       ),
       body: buildBody(context),
+      floatingActionButton: buildEditButton(),
     );
+  }
+
+  Widget buildEditButton() {
+    return Obx(() {
+      final feeds = controller.feeds;
+      final user = controller.user.value;
+      if (feeds.isEmpty || user == null) return const SizedBox.shrink();
+      final feed = feeds[controller.selectedFeedIndex.value];
+      if (feed.user?.uid != user.uid) return const SizedBox.shrink();
+      return FloatingActionButton(
+        onPressed: () => Get.toNamed(AppRoutes.editFeed, arguments: feed),
+        tooltip: 'editFeed'.tr,
+        child: const Icon(Icons.edit),
+      );
+    });
   }
 }


### PR DESCRIPTION
## Summary
- allow editing the currently selected feed from the profile page
- wire up EditFeedController to receive the selected feed
- show feed title on EditFeedView

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6883e8788afc8328a937c93ae6394e83