### PR TITLE
Profile page supports other users

### DIFF
--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -15,10 +15,20 @@ class ProfileController extends GetxController {
   final RxList<Feed> feeds = <Feed>[].obs;
   final RxBool isLoading = false.obs;
   final RxInt selectedFeedIndex = 0.obs;
+  final RxSet<String> subscribedFeedIds = <String>{}.obs;
+  String? uid;
+  bool get isCurrentUser =>
+      uid == null || uid == _authService.currentUser?.uid;
 
   @override
   void onInit() {
     super.onInit();
+    final args = Get.arguments;
+    if (args is String) {
+      uid = args;
+    } else if (args is Map && args['uid'] is String) {
+      uid = args['uid'] as String;
+    }
     loadProfile();
   }
 
@@ -26,7 +36,9 @@ class ProfileController extends GetxController {
   Future<void> loadProfile() async {
     isLoading.value = true;
     try {
-      final u = await _authService.fetchUser();
+      final u = isCurrentUser
+          ? await _authService.fetchUser()
+          : await _authService.fetchUserById(uid!);
       if (u != null) {
         user.value = u;
         feeds.assignAll(u.feeds ?? []);
@@ -35,4 +47,15 @@ class ProfileController extends GetxController {
       isLoading.value = false;
     }
   }
+
+  /// Toggles subscription state for [feedId].
+  void toggleSubscription(String feedId) {
+    if (subscribedFeedIds.contains(feedId)) {
+      subscribedFeedIds.remove(feedId);
+    } else {
+      subscribedFeedIds.add(feedId);
+    }
+  }
+
+  bool isSubscribed(String feedId) => subscribedFeedIds.contains(feedId);
 }

--- a/test/create_feed_controller_test.dart
+++ b/test/create_feed_controller_test.dart
@@ -22,6 +22,9 @@ class FakeAuthService extends GetxService implements AuthService {
   Future<U?> fetchUser() async => _user;
 
   @override
+  Future<U?> fetchUserById(String uid) async => _user;
+
+  @override
   Future<void> signOut() async {}
 
   @override

--- a/test/login_view_test.dart
+++ b/test/login_view_test.dart
@@ -18,6 +18,9 @@ class FakeAuthService extends GetxService implements AuthService {
   Future<U?> fetchUser() async => null;
 
   @override
+  Future<U?> fetchUserById(String uid) async => null;
+
+  @override
   Future<void> signOut() async {}
 
   @override

--- a/test/profile_view_test.dart
+++ b/test/profile_view_test.dart
@@ -20,6 +20,9 @@ class FakeAuthService extends GetxService implements AuthService {
   Future<U?> fetchUser() async => _user;
 
   @override
+  Future<U?> fetchUserById(String uid) async => _user;
+
+  @override
   Future<void> signOut() async {}
 
   @override

--- a/test/theme_toggle_test.dart
+++ b/test/theme_toggle_test.dart
@@ -20,6 +20,9 @@ class FakeAuthService extends GetxService implements AuthService {
   Future<U?> fetchUser() async => null;
 
   @override
+  Future<U?> fetchUserById(String uid) async => null;
+
+  @override
   Future<void> signOut() async {}
 
   @override


### PR DESCRIPTION
## Summary
- add `AuthService.fetchUserById`
- extend `ProfileController` for generic user profiles
- show create feed only on own profile
- add subscribe/unsubscribe actions for other profiles
- show settings or report button according to the profile
- use adaptive dialog for reporting users
- update tests for new auth service API

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6883e90d63c0832897919c1f0b3d5c1d