### PR TITLE
Add edit feed support

### DIFF
--- a/lib/pages/edit_feed/controllers/edit_feed_controller.dart
+++ b/lib/pages/edit_feed/controllers/edit_feed_controller.dart
@@ -1,13 +1,145 @@
+import 'dart:ui';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../../models/feed.dart';
+import '../../../services/auth_service.dart';
+import '../../../services/error_service.dart';
+import '../../../services/toast_service.dart';
+import '../../profile/controllers/profile_controller.dart';
+import '../../../util/enums/feed_types.dart';
+import '../../../services/dialog_service.dart';
 
 class EditFeedController extends GetxController {
+  final FirebaseFirestore _firestore;
+  final AuthService _authService;
+  final ProfileController? _profileController;
   late Feed feed;
+
+  EditFeedController({
+    FirebaseFirestore? firestore,
+    AuthService? authService,
+    ProfileController? profileController,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _authService = authService ?? Get.find<AuthService>(),
+        _profileController = profileController ??
+            (Get.isRegistered<ProfileController>()
+                ? Get.find<ProfileController>()
+                : null);
+
+  final TextEditingController titleController = TextEditingController();
+  final TextEditingController descriptionController = TextEditingController();
+  final TextEditingController typeSearchController = TextEditingController();
+
+  final Rx<Color> selectedColor = Rx<Color>(Colors.blue);
+  final Rx<FeedType?> selectedType = Rx<FeedType?>(null);
+  final RxBool isPrivate = false.obs;
+  final RxBool isNsfw = false.obs;
+  final RxBool saving = false.obs;
+  final RxBool deleting = false.obs;
 
   @override
   void onInit() {
     super.onInit();
     feed = Get.arguments as Feed;
+    titleController.text = feed.title;
+    descriptionController.text = feed.description ?? '';
+    selectedColor.value = feed.color ?? Colors.blue;
+    selectedType.value = feed.type;
+    isPrivate.value = feed.private ?? false;
+    isNsfw.value = feed.nsfw ?? false;
+  }
+
+  Future<bool> save() async {
+    if (saving.value) return false;
+
+    final title = titleController.text.trim();
+    final description = descriptionController.text.trim();
+    final type = selectedType.value;
+
+    if (title.isEmpty) {
+      ToastService.showError('title'.tr);
+      return false;
+    }
+    if (type == null) {
+      ToastService.showError('genre'.tr);
+      return false;
+    }
+
+    saving.value = true;
+    try {
+      await _firestore.collection('feeds').doc(feed.id).update({
+        'title': title,
+        'description': description,
+        'color': selectedColor.value.value.toString(),
+        'type': type.toString().split('.').last,
+        'private': isPrivate.value,
+        'nsfw': isNsfw.value,
+      });
+
+      feed
+        ..title = title
+        ..description = description
+        ..color = selectedColor.value
+        ..type = type
+        ..private = isPrivate.value
+        ..nsfw = isNsfw.value;
+
+      final user = _authService.currentUser;
+      if (user != null && user.feeds != null) {
+        final index = user.feeds!.indexWhere((f) => f.id == feed.id);
+        if (index != -1) user.feeds![index] = feed;
+      }
+
+      if (_profileController != null) {
+        final index =
+            _profileController!.feeds.indexWhere((f) => f.id == feed.id);
+        if (index != -1) _profileController!.feeds[index] = feed;
+      }
+
+      ToastService.showSuccess('editFeed'.tr);
+      return true;
+    } catch (e, s) {
+      await ErrorService.reportError(e, stack: s);
+      return false;
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  Future<bool> deleteFeed(BuildContext context) async {
+    final confirmed = await DialogService.confirm(
+      context: context,
+      title: 'deleteFeed'.tr,
+      message: 'deleteFeedConfirmation'.tr,
+      okLabel: 'delete'.tr,
+      cancelLabel: 'cancel'.tr,
+    );
+    if (!confirmed) return false;
+
+    deleting.value = true;
+    try {
+      await _firestore.collection('feeds').doc(feed.id).delete();
+      _profileController?.feeds.removeWhere((f) => f.id == feed.id);
+      final user = _authService.currentUser;
+      user?.feeds?.removeWhere((f) => f.id == feed.id);
+      ToastService.showSuccess('deleteFeed'.tr);
+      return true;
+    } catch (e, s) {
+      await ErrorService.reportError(e, stack: s);
+      return false;
+    } finally {
+      deleting.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    titleController.dispose();
+    descriptionController.dispose();
+    typeSearchController.dispose();
+    super.onClose();
   }
 }

--- a/lib/pages/edit_feed/views/edit_feed_view.dart
+++ b/lib/pages/edit_feed/views/edit_feed_view.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
+import 'package:flex_color_picker/flex_color_picker.dart';
+import 'package:dropdown_button2/dropdown_button2.dart';
 import '../controllers/edit_feed_controller.dart';
+import '../../../util/enums/feed_types.dart';
 
 class EditFeedView extends GetView<EditFeedController> {
   const EditFeedView({super.key});
@@ -11,9 +14,137 @@ class EditFeedView extends GetView<EditFeedController> {
     return Scaffold(
       appBar: AppBarComponent(
         title: 'editFeed'.tr,
+        actions: [
+          Obx(
+            () => controller.saving.value
+                ? const Padding(
+                    padding: EdgeInsets.all(12),
+                    child: SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2)),
+                  )
+                : TextButton(
+                    onPressed: () async {
+                      final result = await controller.save();
+                      if (result) Get.back();
+                    },
+                    child: Text('done'.tr),
+                  ),
+          ),
+        ],
       ),
-      body: Center(
-        child: Text(controller.feed.title),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: controller.titleController,
+              decoration: InputDecoration(labelText: 'title'.tr),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller.descriptionController,
+              decoration: InputDecoration(labelText: 'description'.tr),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 16),
+            Obx(() => Row(
+                  children: [
+                    Text('${'color'.tr}:'),
+                    const SizedBox(width: 8),
+                    GestureDetector(
+                      onTap: () async {
+                        final color = await showColorPickerDialog(
+                          context,
+                          controller.selectedColor.value,
+                          barrierDismissible: true,
+                        );
+                        controller.selectedColor.value = color;
+                      },
+                      child: ColorIndicator(
+                        color: controller.selectedColor.value,
+                        width: 40,
+                        height: 40,
+                        borderRadius: 20,
+                      ),
+                    ),
+                  ],
+                )),
+            const SizedBox(height: 16),
+            Obx(
+              () => DropdownButton2<FeedType>(
+                value: controller.selectedType.value,
+                hint: Text('genre'.tr),
+                isExpanded: true,
+                onChanged: (value) => controller.selectedType.value = value,
+                items: FeedType.values
+                    .map((t) => DropdownMenuItem(
+                          value: t,
+                          child: Text('${FeedTypeExtension.toEmoji(t)} '
+                              '${FeedTypeExtension.toTranslatedString(context, t)}'),
+                        ))
+                    .toList(),
+                dropdownStyleData: DropdownStyleData(
+                  width: MediaQuery.of(context).size.width - 32,
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                ),
+                dropdownSearchData: DropdownSearchData(
+                  searchController: controller.typeSearchController,
+                  searchInnerWidgetHeight: 50,
+                  searchInnerWidget: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: TextFormField(
+                      controller: controller.typeSearchController,
+                      decoration: InputDecoration(
+                        isDense: true,
+                        hintText: 'searchEllipsis'.tr,
+                        border: const OutlineInputBorder(),
+                      ),
+                    ),
+                  ),
+                  searchMatchFn: (item, searchValue) {
+                    final value = FeedTypeExtension.toTranslatedString(
+                        context, item.value!);
+                    return value
+                        .toLowerCase()
+                        .contains(searchValue.toLowerCase());
+                  },
+                ),
+                onMenuStateChange: (isOpen) {
+                  if (!isOpen) controller.typeSearchController.clear();
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            Obx(() => SwitchListTile(
+                  value: controller.isPrivate.value,
+                  onChanged: (v) => controller.isPrivate.value = v,
+                  title: Text('privateFeed'.tr),
+                )),
+            Obx(() => SwitchListTile(
+                  value: controller.isNsfw.value,
+                  onChanged: (v) => controller.isNsfw.value = v,
+                  title: Text('nsfwFeed'.tr),
+                )),
+            const SizedBox(height: 16),
+            Obx(() => controller.deleting.value
+                ? const Center(child: CircularProgressIndicator())
+                : OutlinedButton(
+                    onPressed: () async {
+                      final result =
+                          await controller.deleteFeed(context);
+                      if (result) Get.back();
+                    },
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor:
+                          Theme.of(context).colorScheme.error,
+                    ),
+                    child: Text('deleteFeed'.tr),
+                  )),
+          ],
+        ),
       ),
     );
   }

--- a/test/explore_view_test.dart
+++ b/test/explore_view_test.dart
@@ -20,6 +20,7 @@ void main() {
       'description': 'D',
       'color': '0',
       'type': 'music',
+      'userId': 'u1',
       'subscriberCount': 1,
       'createdAt': DateTime.now(),
     });

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -14,6 +14,7 @@ void main() {
         'description': 'desc',
         'icon': 'i',
         'color': '123',
+        'userId': 'u1',
         'type': 'general',
       };
       final userJson = {
@@ -58,6 +59,7 @@ void main() {
         'description': 'D',
         'icon': 'i',
         'color': color.value.toString(),
+        'userId': 'u1',
         'type': 'music',
         'private': true,
         'nsfw': false,


### PR DESCRIPTION
## Summary
- implement full logic in `EditFeedController`
- build form UI for editing feeds
- update unit tests to include required `userId` fields

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6883ed9ce69c832890ee1b3fbc4b6ac4