### PR TITLE
Implement edit profile

### DIFF
--- a/lib/pages/edit_profile/controllers/edit_profile_controller.dart
+++ b/lib/pages/edit_profile/controllers/edit_profile_controller.dart
@@ -1,3 +1,133 @@
-import 'package:get/get.dart';
+import 'dart:io';
+import 'dart:typed_data';
 
-class EditProfileController extends GetxController {}
+import 'package:get/get.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:image/image.dart' as img;
+
+import '../../../services/auth_service.dart';
+import '../../../services/error_service.dart';
+import '../../../services/toast_service.dart';
+import '../../../services/user_service.dart';
+import '../../../models/user.dart';
+
+class EditProfileController extends GetxController {
+  final AuthService _authService;
+  final BaseUserService _userService;
+  final ImagePicker _picker = ImagePicker();
+
+  EditProfileController(
+      {AuthService? authService, BaseUserService? userService})
+      : _authService = authService ?? Get.find<AuthService>(),
+        _userService = userService ?? UserService();
+
+  final TextEditingController nameController = TextEditingController();
+  final TextEditingController usernameController = TextEditingController();
+  final TextEditingController bioController = TextEditingController();
+
+  final Rx<File?> bannerFile = Rx<File?>(null);
+  final RxBool saving = false.obs;
+
+  U? get user => _authService.currentUser;
+
+  @override
+  void onInit() {
+    super.onInit();
+    final u = user;
+    if (u != null) {
+      nameController.text = u.name ?? '';
+      usernameController.text = u.username ?? '';
+      bioController.text = u.bio ?? '';
+    }
+  }
+
+  Future<void> pickBanner() async {
+    try {
+      final picked = await _picker.pickImage(source: ImageSource.gallery);
+      if (picked != null) {
+        bannerFile.value = File(picked.path);
+      }
+    } catch (e, s) {
+      await ErrorService.reportError(e, stack: s);
+    }
+  }
+
+  Future<bool> saveProfile() async {
+    if (saving.value) return false;
+
+    final name = nameController.text.trim();
+    final username = usernameController.text.trim();
+    final bio = bioController.text.trim();
+
+    if (name.length < 3) {
+      ToastService.showError('displayNameTooShort'.tr);
+      return false;
+    }
+    if (username.length < 6) {
+      ToastService.showError('usernameTooShort'.tr);
+      return false;
+    }
+    if (!RegExp(r'^[a-zA-Z0-9_]+\$').hasMatch(username)) {
+      ToastService.showError('usernameInvalid'.tr);
+      return false;
+    }
+
+    saving.value = true;
+    try {
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid == null) return false;
+
+      String? bannerUrl;
+      if (bannerFile.value != null) {
+        final file = bannerFile.value!;
+        final bytes = await file.readAsBytes();
+        final decoded = img.decodeImage(bytes);
+        Uint8List data = bytes;
+        if (decoded != null) {
+          final resized = img.copyResize(decoded, height: 256);
+          data = Uint8List.fromList(img.encodeJpg(resized));
+        }
+        final ref = FirebaseStorage.instance
+            .ref()
+            .child('banners')
+            .child(uid)
+            .child('banner.jpg');
+        await ref.putData(data, SettableMetadata(contentType: 'image/jpeg'));
+        bannerUrl = await ref.getDownloadURL();
+      }
+
+      await _userService.updateUserData(uid, {
+        'displayName': name,
+        'username': username,
+        'bio': bio,
+        if (bannerUrl != null) 'banner': bannerUrl,
+      });
+
+      final u = user;
+      if (u != null) {
+        u.name = name;
+        u.username = username;
+        u.bio = bio;
+        if (bannerUrl != null) u.bannerPictureUrl = bannerUrl;
+      }
+
+      ToastService.showSuccess('editProfile'.tr);
+      return true;
+    } catch (e, s) {
+      await ErrorService.reportError(e, stack: s);
+      return false;
+    } finally {
+      saving.value = false;
+    }
+  }
+
+  @override
+  void onClose() {
+    nameController.dispose();
+    usernameController.dispose();
+    bioController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/pages/edit_profile/views/edit_profile_view.dart
+++ b/lib/pages/edit_profile/views/edit_profile_view.dart
@@ -1,5 +1,9 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/components/image_component.dart';
 import '../controllers/edit_profile_controller.dart';
 
 class EditProfileView extends GetView<EditProfileController> {
@@ -8,11 +12,78 @@ class EditProfileView extends GetView<EditProfileController> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text('editProfile'.tr),
+      appBar: AppBarComponent(
+        title: 'editProfile'.tr,
+        actions: [
+          Obx(() => controller.saving.value
+              ? const Padding(
+                  padding: EdgeInsets.all(12),
+                  child: SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2)),
+                )
+              : TextButton(
+                  onPressed: () async {
+                    final result = await controller.saveProfile();
+                    if (result) Get.back();
+                  },
+                  child: Text('done'.tr),
+                ))
+        ],
       ),
-      body: Center(
-        child: Text('editProfile'.tr),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Obx(() {
+              final file = controller.bannerFile.value;
+              final user = controller.user;
+              Widget imageWidget;
+              if (file != null) {
+                imageWidget = Image.file(file, fit: BoxFit.cover);
+              } else if (user?.bannerPictureUrl != null &&
+                  user!.bannerPictureUrl!.isNotEmpty) {
+                imageWidget = ImageComponent(
+                  url: user.bannerPictureUrl!,
+                  fit: BoxFit.cover,
+                  height: 120,
+                );
+              } else {
+                imageWidget = Container(
+                  height: 120,
+                  color: Theme.of(context).colorScheme.primaryContainer,
+                  child: Icon(Icons.photo,
+                      color: Theme.of(context).colorScheme.onPrimaryContainer),
+                );
+              }
+              return GestureDetector(
+                onTap: controller.pickBanner,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: SizedBox(height: 120, child: imageWidget),
+                ),
+              );
+            }),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller.nameController,
+              decoration: InputDecoration(labelText: 'displayName'.tr),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller.usernameController,
+              decoration: InputDecoration(labelText: 'username'.tr),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller.bioController,
+              decoration: InputDecoration(labelText: 'bio'.tr),
+              maxLines: 3,
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add EditProfileController logic to save profile data and banner
- create UI for editing profile including banner picker

## Testing
- `flutter pub get`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6883f299a4d08328b4f5735f7a7c79ae