### PR TITLE
Introduce dotenv support for Tenor API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TENOR_API_KEY=your-tenor-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .svn/
 .swiftpm/
 migrate_working_dir/
+.env
 
 # IntelliJ related
 *.iml

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ Hoot operates like a streamlined community platform:
    flutter --version
    ```
 
+## Environment configuration
+
+Create a `.env` file based on `.env.example` and supply your own API keys. The
+app loads this file at startup to configure services like Tenor.
+
 ## Running Tests
 
 Widget and model tests are located under the `test/` directory. Fetch all

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'package:hoot/util/routes/app_pages.dart';
 import 'package:hoot/util/routes/app_routes.dart';
@@ -10,12 +11,15 @@ import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:hoot/theme/theme.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:toastification/toastification.dart';
+import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
 import 'services/theme_service.dart';
 import 'firebase_options.dart';
 
 void main() {
   runZonedGuarded(() async {
     WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+    await dotenv.load(fileName: '.env');
+    TenorGifPicker.init(apiKey: dotenv.env['TENOR_API_KEY'] ?? '');
     FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
 
     await Firebase.initializeApp(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -510,6 +510,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.9+2"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.2.1"
   flutter_inappwebview:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ dependencies:
   toastification: ^3.0.3
   adaptive_dialog: ^2.4.2
   flutter_native_splash: ^2.4.6
+  flutter_dotenv: ^5.2.1
 
   page_transition: any
   dropdown_button2: ^2.3.9
@@ -112,6 +113,7 @@ flutter:
     - assets/login/
     - assets/images/
     - assets/terms/
+    - .env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
## Summary
- add flutter_dotenv dependency and load `.env`
- initialize TenorGifPicker using an API key from env
- document environment file usage
- ignore `.env` file and provide `.env.example`

## Testing
- `flutter pub get`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6884849bef1c8328846879327a8bbd1c