### PR TITLE
Add pagination and refresh

### DIFF
--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -1,24 +1,30 @@
 import 'package:get/get.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../../../models/feed.dart';
 import '../../../models/user.dart';
 import '../../../services/auth_service.dart';
+import '../../../services/feed_service.dart';
 
 /// Loads the current user profile data and owned feeds.
 class ProfileController extends GetxController {
   final AuthService _authService;
+  final BaseFeedService _feedService;
 
-  ProfileController({AuthService? authService})
-      : _authService = authService ?? Get.find<AuthService>();
+  ProfileController({AuthService? authService, BaseFeedService? feedService})
+      : _authService = authService ?? Get.find<AuthService>(),
+        _feedService = feedService ?? Get.find<BaseFeedService>();
 
   final Rxn<U> user = Rxn<U>();
   final RxList<Feed> feeds = <Feed>[].obs;
   final RxBool isLoading = false.obs;
+  final RxBool isLoadingMore = false.obs;
   final RxInt selectedFeedIndex = 0.obs;
   final RxSet<String> subscribedFeedIds = <String>{}.obs;
+  final Map<String, DocumentSnapshot?> _feedLastDocs = {};
+  final Map<String, bool> _feedHasMore = {};
   String? uid;
-  bool get isCurrentUser =>
-      uid == null || uid == _authService.currentUser?.uid;
+  bool get isCurrentUser => uid == null || uid == _authService.currentUser?.uid;
 
   @override
   void onInit() {
@@ -43,9 +49,54 @@ class ProfileController extends GetxController {
         user.value = u;
         feeds.assignAll(u.feeds ?? []);
       }
+      if (feeds.isNotEmpty) {
+        await loadFeedPosts(feeds.first.id, refresh: true);
+      }
+      ever<int>(selectedFeedIndex, (i) {
+        final feed = feeds[i];
+        if (feed.posts == null || feed.posts!.isEmpty) {
+          loadFeedPosts(feed.id, refresh: true);
+        }
+      });
     } finally {
       isLoading.value = false;
     }
+  }
+
+  Future<void> loadFeedPosts(
+    String feedId, {
+    bool refresh = false,
+  }) async {
+    final feed = feeds.firstWhere((f) => f.id == feedId);
+    if (refresh) {
+      _feedLastDocs[feedId] = null;
+      _feedHasMore[feedId] = true;
+      feed.posts = [];
+    }
+    if (_feedHasMore[feedId] == false) return;
+    isLoadingMore.value = true;
+    try {
+      final page = await _feedService.fetchFeedPosts(
+        feedId,
+        startAfter: _feedLastDocs[feedId],
+      );
+      feed.posts = [...(feed.posts ?? []), ...page.posts];
+      feeds.refresh();
+      _feedLastDocs[feedId] = page.lastDoc;
+      _feedHasMore[feedId] = page.hasMore;
+    } finally {
+      isLoadingMore.value = false;
+    }
+  }
+
+  Future<void> refreshSelectedFeed() async {
+    final feedId = feeds[selectedFeedIndex.value].id;
+    await loadFeedPosts(feedId, refresh: true);
+  }
+
+  Future<void> loadMoreSelectedFeed() async {
+    final feedId = feeds[selectedFeedIndex.value].id;
+    await loadFeedPosts(feedId);
   }
 
   /// Toggles subscription state for [feedId].

--- a/lib/services/feed_service.dart
+++ b/lib/services/feed_service.dart
@@ -4,9 +4,27 @@ import 'package:get/get.dart';
 import '../models/post.dart';
 import 'auth_service.dart';
 
+/// Page of posts along with pagination data.
+class PostPage {
+  PostPage({required this.posts, this.lastDoc, this.hasMore = false});
+
+  final List<Post> posts;
+  final DocumentSnapshot? lastDoc;
+  final bool hasMore;
+}
+
 /// Service retrieving posts from feeds the current user is subscribed to.
 abstract class BaseFeedService {
-  Future<List<Post>> fetchSubscribedPosts();
+  Future<PostPage> fetchSubscribedPosts({
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  });
+
+  Future<PostPage> fetchFeedPosts(
+    String feedId, {
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  });
 }
 
 /// Default implementation retrieving posts from feeds the current user is subscribed to.
@@ -20,9 +38,12 @@ class FeedService implements BaseFeedService {
 
   /// Returns the latest posts from the user's subscriptions ordered by creation.
   @override
-  Future<List<Post>> fetchSubscribedPosts() async {
+  Future<PostPage> fetchSubscribedPosts({
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  }) async {
     final user = _authService.currentUser;
-    if (user == null) return [];
+    if (user == null) return PostPage(posts: [], hasMore: false);
 
     final subsSnapshot = await _firestore
         .collection('users')
@@ -31,16 +52,56 @@ class FeedService implements BaseFeedService {
         .get();
 
     final feedIds = subsSnapshot.docs.map((d) => d.id).toList();
-    if (feedIds.isEmpty) return [];
-
-    final postsSnapshot = await _firestore
+    if (feedIds.isEmpty) return PostPage(posts: [], hasMore: false);
+    var query = _firestore
         .collection('posts')
         .where('feedId', whereIn: feedIds)
         .orderBy('createdAt', descending: true)
-        .get();
+        .limit(limit);
 
-    return postsSnapshot.docs
+    if (startAfter != null) {
+      query = query.startAfterDocument(startAfter);
+    }
+
+    final postsSnapshot = await query.get();
+
+    final posts = postsSnapshot.docs
         .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
         .toList();
+
+    return PostPage(
+      posts: posts,
+      lastDoc: postsSnapshot.docs.isNotEmpty ? postsSnapshot.docs.last : null,
+      hasMore: postsSnapshot.docs.length == limit,
+    );
+  }
+
+  @override
+  Future<PostPage> fetchFeedPosts(
+    String feedId, {
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  }) async {
+    var query = _firestore
+        .collection('posts')
+        .where('feedId', isEqualTo: feedId)
+        .orderBy('createdAt', descending: true)
+        .limit(limit);
+
+    if (startAfter != null) {
+      query = query.startAfterDocument(startAfter);
+    }
+
+    final snapshot = await query.get();
+
+    final posts = snapshot.docs
+        .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
+        .toList();
+
+    return PostPage(
+      posts: posts,
+      lastDoc: snapshot.docs.isNotEmpty ? snapshot.docs.last : null,
+      hasMore: snapshot.docs.length == limit,
+    );
   }
 }

--- a/test/create_feed_controller_test.dart
+++ b/test/create_feed_controller_test.dart
@@ -10,6 +10,8 @@ import 'package:hoot/util/enums/feed_types.dart';
 import 'package:hoot/pages/profile/controllers/profile_controller.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/models/user.dart';
+import 'package:hoot/services/feed_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class FakeAuthService extends GetxService implements AuthService {
   final U _user;
@@ -35,6 +37,22 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<void> deleteAccount() async {}
+}
+
+class FakeFeedService implements BaseFeedService {
+  @override
+  Future<PostPage> fetchSubscribedPosts({
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  }) async {
+    return PostPage(posts: []);
+  }
+
+  @override
+  Future<PostPage> fetchFeedPosts(String feedId,
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
+    return PostPage(posts: []);
+  }
 }
 
 void main() {
@@ -112,7 +130,10 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     final user = U(uid: 'u1', feeds: []);
     final auth = FakeAuthService(user);
-    final profile = ProfileController(authService: auth);
+    final profile = ProfileController(
+      authService: auth,
+      feedService: FakeFeedService(),
+    );
     Get.put<AuthService>(auth);
     Get.put<ProfileController>(profile);
 
@@ -142,8 +163,8 @@ void main() {
 
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
-    final controller =
-        CreateFeedController(firestore: firestore, userId: 'u1', authService: auth);
+    final controller = CreateFeedController(
+        firestore: firestore, userId: 'u1', authService: auth);
     controller.titleController.text = 'My Feed';
     controller.selectedType.value = FeedType.music;
 

--- a/test/feed_view_test.dart
+++ b/test/feed_view_test.dart
@@ -6,18 +6,28 @@ import 'package:hoot/models/user.dart';
 import 'package:hoot/pages/feed/controllers/feed_controller.dart';
 import 'package:hoot/pages/feed/views/feed_view.dart';
 import 'package:hoot/services/feed_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class FakeFeedService implements BaseFeedService {
   @override
-  Future<List<Post>> fetchSubscribedPosts() async {
-    return [
+  Future<PostPage> fetchSubscribedPosts({
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  }) async {
+    return PostPage(posts: [
       Post(
         id: '1',
         text: 'Hello world',
         user: U(uid: 'u1', name: 'Tester'),
         media: [],
       ),
-    ];
+    ]);
+  }
+
+  @override
+  Future<PostPage> fetchFeedPosts(String feedId,
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
+    throw UnimplementedError();
   }
 }
 

--- a/test/profile_view_test.dart
+++ b/test/profile_view_test.dart
@@ -8,6 +8,8 @@ import 'package:hoot/models/feed.dart';
 import 'package:hoot/pages/profile/controllers/profile_controller.dart';
 import 'package:hoot/pages/profile/views/profile_view.dart';
 import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/feed_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 class FakeAuthService extends GetxService implements AuthService {
   final U _user;
@@ -38,6 +40,22 @@ class FakeAuthService extends GetxService implements AuthService {
   }
 }
 
+class FakeFeedService implements BaseFeedService {
+  @override
+  Future<PostPage> fetchSubscribedPosts({
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  }) async {
+    return PostPage(posts: []);
+  }
+
+  @override
+  Future<PostPage> fetchFeedPosts(String feedId,
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
+    return PostPage(posts: []);
+  }
+}
+
 void main() {
   testWidgets('ProfileView shows profile information', (tester) async {
     final user = U(
@@ -45,10 +63,15 @@ void main() {
       name: 'Tester',
       username: 'tester',
       bio: 'Hello',
-      feeds: [Feed(id: 'f1', userId: 't', title: 'Feed 1', description: 'desc')],
+      feeds: [
+        Feed(id: 'f1', userId: 't', title: 'Feed 1', description: 'desc')
+      ],
     );
     final service = FakeAuthService(user);
-    final controller = ProfileController(authService: service);
+    final controller = ProfileController(
+      authService: service,
+      feedService: FakeFeedService(),
+    );
     Get.put<AuthService>(service);
     Get.put<ProfileController>(controller);
 


### PR DESCRIPTION
## Summary
- add `PostPage` and pagination helpers to feed service
- load posts in pages on feed screen and profile feed
- refresh posts with `RefreshIndicator`
- update tests for new service API

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68848da745c083288a1452ad43c23165