### PR TITLE
Add pull to refresh on profile and feed pages

### DIFF
--- a/lib/pages/feed/views/feed_view.dart
+++ b/lib/pages/feed/views/feed_view.dart
@@ -88,27 +88,41 @@ class _FeedViewState extends State<FeedView> {
     if (controller.isLoading.value) {
       return ListView.builder(
         controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
         itemCount: 3,
         itemBuilder: (_, __) => const ShimmerListTile(hasSubtitle: true),
       );
     }
 
     if (controller.error.value != null) {
-      return NothingToShowComponent(
-        icon: const Icon(Icons.error_outline),
-        text: controller.error.value!,
+      return ListView(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          NothingToShowComponent(
+            icon: const Icon(Icons.error_outline),
+            text: controller.error.value!,
+          ),
+        ],
       );
     }
 
     if (controller.posts.isEmpty) {
-      return NothingToShowComponent(
-        icon: const Icon(Icons.feed_outlined),
-        text: 'subscribeToSeeHoots'.tr,
+      return ListView(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: [
+          NothingToShowComponent(
+            icon: const Icon(Icons.feed_outlined),
+            text: 'subscribeToSeeHoots'.tr,
+          ),
+        ],
       );
     }
 
     return ListView.builder(
       controller: _scrollController,
+      physics: const AlwaysScrollableScrollPhysics(),
       itemCount:
           controller.posts.length + (controller.isLoadingMore.value ? 1 : 0),
       itemBuilder: (context, index) {

--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -94,6 +94,22 @@ class ProfileController extends GetxController {
     await loadFeedPosts(feedId, refresh: true);
   }
 
+  Future<void> refreshProfile() async {
+    final u = isCurrentUser
+        ? await _authService.fetchUser()
+        : await _authService.fetchUserById(uid!);
+    if (u != null) {
+      user.value = u;
+      feeds.assignAll(u.feeds ?? []);
+    }
+    if (feeds.isNotEmpty) {
+      if (selectedFeedIndex.value >= feeds.length) {
+        selectedFeedIndex.value = 0;
+      }
+      await loadFeedPosts(feeds[selectedFeedIndex.value].id, refresh: true);
+    }
+  }
+
   Future<void> loadMoreSelectedFeed() async {
     final feedId = feeds[selectedFeedIndex.value].id;
     await loadFeedPosts(feedId);

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -177,7 +177,7 @@ class _ProfileViewState extends State<ProfileView> {
       }
 
       return RefreshIndicator(
-        onRefresh: controller.refreshSelectedFeed,
+        onRefresh: controller.refreshProfile,
         child: SingleChildScrollView(
           controller: _scrollController,
           physics: const AlwaysScrollableScrollPhysics(),


### PR DESCRIPTION
## Summary
- allow refreshing feed even when list isn't scrollable
- refresh profile feed and feed list

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6884e39c12208328bb37f7524aa57833