### PR TITLE
Implement infinite scrolling for feeds and profiles

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -298,7 +298,7 @@ packages:
     source: hosted
     version: "1.3.3"
   fake_cloud_firestore:
-    dependency: "direct dev"
+    dependency: "direct overridden"
     description:
       name: fake_cloud_firestore
       sha256: "804bfb59108fc93b93c28b61e8142c477bd6f188a12d06875310f0b2f01b3974"
@@ -615,13 +615,13 @@ packages:
     source: hosted
     version: "2.0.0"
   flutter_staggered_grid_view:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: flutter_staggered_grid_view
-      sha256: "1312314293acceb65b92754298754801b0e1f26a1845833b740b30415bbbcf07"
+      sha256: "19e7abb550c96fbfeb546b23f3ff356ee7c59a019a651f8f102a4ba9b7349395"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.2"
+    version: "0.7.0"
   flutter_tenor_gif_picker:
     dependency: "direct main"
     description:
@@ -856,6 +856,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  infinite_scroll_pagination:
+    dependency: "direct main"
+    description:
+      name: infinite_scroll_pagination
+      sha256: "9b8f95362928a1de835658835194b435c40f2bfc386f6545c1fd706203df0cd4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   intersperse:
     dependency: transitive
     description:
@@ -1325,6 +1333,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  sliver_tools:
+    dependency: transitive
+    description:
+      name: sliver_tools
+      sha256: eae28220badfb9d0559207badcbbc9ad5331aac829a88cb0964d330d2a4636a6
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.12"
   solar_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -82,6 +82,7 @@ dependencies:
 
   page_transition: any
   dropdown_button2: ^2.3.9
+  infinite_scroll_pagination: ^5.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -92,6 +93,9 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
+
+dependency_overrides:
+  flutter_staggered_grid_view: ^0.7.0
   fake_cloud_firestore: ^3.1.0
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
## Summary
- add `infinite_scroll_pagination` dependency
- override `flutter_staggered_grid_view` to satisfy dependencies
- refactor feed controller and view to use `PagingState` and `PagedListView`
- refactor profile controller and view to use `PagedSliverList` with `RefreshIndicator`

## Testing
- `flutter pub get`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6884e58873a48328bc9ffd52961927fb