### PR TITLE
Implement multi-image posts with zoom

### DIFF
--- a/lib/components/image_component.dart
+++ b/lib/components/image_component.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:full_screen_image_null_safe/full_screen_image_null_safe.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:photo_view/photo_view.dart';
 
 class ImageComponent extends StatefulWidget {
   final String url;
@@ -26,39 +26,49 @@ class ImageComponent extends StatefulWidget {
 }
 
 class _ImageComponentState extends State<ImageComponent> {
+  void _openViewer(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => Scaffold(
+          backgroundColor: Colors.black,
+          body: GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: PhotoView(
+              imageProvider: CachedNetworkImageProvider(widget.url),
+              backgroundDecoration: const BoxDecoration(color: Colors.black),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return FullScreenWidget(
-      backgroundColor: Colors.black,
-      child: Center(
-        child: Hero(
-          tag: widget.url +
-              widget.width.toString() +
-              widget.height.toString() +
-              DateTime.now().toString(),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(widget.radius),
-            child: CachedNetworkImage(
-              imageUrl: widget.url,
-              width: widget.width,
-              height: widget.height,
-              fit: widget.fit,
-              alignment: widget.alignment ?? Alignment.center,
-              repeat: widget.repeat ?? ImageRepeat.noRepeat,
-              placeholder: (context, url) => Container(
-                color: Theme.of(context).colorScheme.secondaryContainer,
-                child: Center(
-                  child: LoadingAnimationWidget.inkDrop(
-                    color: Theme.of(context).colorScheme.onSecondaryContainer,
-                    size: 50,
-                  ),
-                ),
-              ),
-              errorWidget: (context, url, error) => Container(
-                color: Colors.grey.shade800,
-                child: const Icon(Icons.error, color: Colors.white),
+    return GestureDetector(
+      onTap: () => _openViewer(context),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(widget.radius),
+        child: CachedNetworkImage(
+          imageUrl: widget.url,
+          width: widget.width,
+          height: widget.height,
+          fit: widget.fit,
+          alignment: widget.alignment ?? Alignment.center,
+          repeat: widget.repeat ?? ImageRepeat.noRepeat,
+          placeholder: (context, url) => Container(
+            color: Theme.of(context).colorScheme.secondaryContainer,
+            child: Center(
+              child: LoadingAnimationWidget.inkDrop(
+                color: Theme.of(context).colorScheme.onSecondaryContainer,
+                size: 50,
               ),
             ),
+          ),
+          errorWidget: (context, url, error) => Container(
+            color: Colors.grey.shade800,
+            child: const Icon(Icons.error, color: Colors.white),
           ),
         ),
       ),

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -43,7 +43,11 @@ class Post {
     return Post(
       id: json['id'],
       text: json['text'],
-      media: json['images'] != null ? List<String>.from(json['images']) : null,
+      media: json['images'] != null
+          ? List<String>.from(json['images'])
+          : json['gifs'] != null
+              ? List<String>.from(json['gifs'])
+              : null,
       feedId: json['feedId'],
       feed: json['feed'] != null ? Feed.fromJson(json['feed']) : null,
       user: json['user'] != null ? U.fromJson(json['user']) : null,
@@ -51,17 +55,22 @@ class Post {
       likes: json['likes'],
       reFeeded: json['reFeeded'] ?? false,
       reFeeds: json['reFeeds'],
-      reFeededFrom: json['reFeededFrom'] != null && json['reFeededFrom'].runtimeType != String ? Post.fromJson(json['reFeededFrom']) : null,
+      reFeededFrom: json['reFeededFrom'] != null &&
+              json['reFeededFrom'].runtimeType != String
+          ? Post.fromJson(json['reFeededFrom'])
+          : null,
       comments: json['comments'],
       createdAt: json['createdAt'] != null
           ? json['createdAt'] is Timestamp
               ? (json['createdAt'] as Timestamp).toDate()
-              : DateTime.fromMillisecondsSinceEpoch(json['createdAt']['_seconds'] * 1000)
+              : DateTime.fromMillisecondsSinceEpoch(
+                  json['createdAt']['_seconds'] * 1000)
           : null,
       updatedAt: json['updatedAt'] != null
           ? json['updatedAt'] is Timestamp
               ? (json['updatedAt'] as Timestamp).toDate()
-              : DateTime.fromMillisecondsSinceEpoch(json['updatedAt']['_seconds'] * 1000)
+              : DateTime.fromMillisecondsSinceEpoch(
+                  json['updatedAt']['_seconds'] * 1000)
           : null,
     );
   }
@@ -124,10 +133,17 @@ class Post {
       likes: json['likes'],
       reFeeded: json['reFeeded'] ?? false,
       reFeeds: json['reFeeds'],
-      reFeededFrom: json['reFeededFrom'] != null && json['reFeededFrom'].runtimeType != String ? Post.fromCache(json['reFeededFrom']) : null,
+      reFeededFrom: json['reFeededFrom'] != null &&
+              json['reFeededFrom'].runtimeType != String
+          ? Post.fromCache(json['reFeededFrom'])
+          : null,
       comments: json['comments'],
-      createdAt: json['createdAt'] != null ? DateTime.fromMillisecondsSinceEpoch(int.parse(json['createdAt'])) : null,
-      updatedAt: json['updatedAt'] != null ? DateTime.fromMillisecondsSinceEpoch(int.parse(json['updatedAt'])) : null,
+      createdAt: json['createdAt'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(int.parse(json['createdAt']))
+          : null,
+      updatedAt: json['updatedAt'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(int.parse(json['updatedAt']))
+          : null,
     );
   }
 }

--- a/lib/pages/create_post/views/create_post_view.dart
+++ b/lib/pages/create_post/views/create_post_view.dart
@@ -1,13 +1,33 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
+import 'package:photo_view/photo_view.dart';
 import '../controllers/create_post_controller.dart';
 import '../../../components/url_preview_component.dart';
 import '../../../models/feed.dart';
 
 class CreatePostView extends GetView<CreatePostController> {
   const CreatePostView({super.key});
+
+  void _openViewer(BuildContext context, ImageProvider provider) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => Scaffold(
+          backgroundColor: Colors.black,
+          body: GestureDetector(
+            onTap: () => Navigator.pop(context),
+            child: PhotoView(
+              imageProvider: provider,
+              backgroundDecoration: const BoxDecoration(color: Colors.black),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
 
   Future<void> pickGif(BuildContext context) async {
     final tenor = await TenorGifPickerPage.openAsPage(
@@ -53,10 +73,86 @@ class CreatePostView extends GetView<CreatePostController> {
             ),
             const SizedBox(height: 8),
             Obx(() {
-              if (controller.imageFile.value != null) {
-                return Image.file(controller.imageFile.value!);
+              if (controller.imageFiles.isNotEmpty) {
+                return SizedBox(
+                  height: 100,
+                  child: ListView.builder(
+                    scrollDirection: Axis.horizontal,
+                    itemCount: controller.imageFiles.length,
+                    itemBuilder: (context, i) {
+                      final file = controller.imageFiles[i];
+                      return Stack(
+                        children: [
+                          GestureDetector(
+                            onTap: () => _openViewer(context, FileImage(file)),
+                            child: Container(
+                              margin: const EdgeInsets.only(right: 8),
+                              width: 100,
+                              height: 100,
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(8),
+                                image: DecorationImage(
+                                  image: FileImage(file),
+                                  fit: BoxFit.cover,
+                                ),
+                              ),
+                            ),
+                          ),
+                          Positioned(
+                            top: 4,
+                            right: 4,
+                            child: GestureDetector(
+                              onTap: () => controller.removeImage(i),
+                              child: Container(
+                                decoration: const BoxDecoration(
+                                  color: Colors.black54,
+                                  shape: BoxShape.circle,
+                                ),
+                                child: const Icon(Icons.close,
+                                    size: 16, color: Colors.white),
+                              ),
+                            ),
+                          ),
+                        ],
+                      );
+                    },
+                  ),
+                );
               } else if (controller.gifUrl.value != null) {
-                return Image.network(controller.gifUrl.value!);
+                return Stack(
+                  children: [
+                    GestureDetector(
+                      onTap: () => _openViewer(
+                          context, NetworkImage(controller.gifUrl.value!)),
+                      child: Container(
+                        width: 100,
+                        height: 100,
+                        decoration: BoxDecoration(
+                          borderRadius: BorderRadius.circular(8),
+                          image: DecorationImage(
+                            image: NetworkImage(controller.gifUrl.value!),
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Positioned(
+                      top: 4,
+                      right: 4,
+                      child: GestureDetector(
+                        onTap: () => controller.gifUrl.value = null,
+                        child: Container(
+                          decoration: const BoxDecoration(
+                            color: Colors.black54,
+                            shape: BoxShape.circle,
+                          ),
+                          child: const Icon(Icons.close,
+                              size: 16, color: Colors.white),
+                        ),
+                      ),
+                    ),
+                  ],
+                );
               }
               return const SizedBox.shrink();
             }),

--- a/lib/pages/feed/views/feed_view.dart
+++ b/lib/pages/feed/views/feed_view.dart
@@ -52,13 +52,32 @@ class _FeedViewState extends State<FeedView> {
             ],
             if (post.media != null && post.media!.isNotEmpty) ...[
               const SizedBox(height: 8),
-              ImageComponent(
-                url: post.media!.first,
-                height: 200,
-                width: double.infinity,
-                fit: BoxFit.cover,
-                radius: 10,
-              ),
+              if (post.media!.length == 1)
+                ImageComponent(
+                  url: post.media!.first,
+                  height: 200,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                  radius: 10,
+                )
+              else
+                GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 4,
+                    mainAxisSpacing: 4,
+                  ),
+                  itemCount: post.media!.length,
+                  itemBuilder: (context, i) {
+                    return ImageComponent(
+                      url: post.media![i],
+                      fit: BoxFit.cover,
+                      radius: 8,
+                    );
+                  },
+                ),
             ],
           ],
         ),

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -77,13 +77,32 @@ class _ProfileViewState extends State<ProfileView> {
             ],
             if (post.media != null && post.media!.isNotEmpty) ...[
               const SizedBox(height: 8),
-              ImageComponent(
-                url: post.media!.first,
-                height: 200,
-                width: double.infinity,
-                fit: BoxFit.cover,
-                radius: 10,
-              ),
+              if (post.media!.length == 1)
+                ImageComponent(
+                  url: post.media!.first,
+                  height: 200,
+                  width: double.infinity,
+                  fit: BoxFit.cover,
+                  radius: 10,
+                )
+              else
+                GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 4,
+                    mainAxisSpacing: 4,
+                  ),
+                  itemCount: post.media!.length,
+                  itemBuilder: (context, i) {
+                    return ImageComponent(
+                      url: post.media![i],
+                      fit: BoxFit.cover,
+                      radius: 8,
+                    );
+                  },
+                ),
             ],
           ],
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1136,6 +1136,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  photo_view:
+    dependency: "direct main"
+    description:
+      name: photo_view
+      sha256: "8036802a00bae2a78fc197af8a158e3e2f7b500561ed23b4c458107685e645bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.14.0"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -71,6 +71,7 @@ dependencies:
   uri_content: ^3.0.0
   ogp_data_extract: ^0.2.2
   url_launcher: ^6.1.12
+  photo_view: ^0.14.0
   get: ^4.6.5
   shake: ^2.2.0
   solar_icons: ^0.0.5


### PR DESCRIPTION
## Summary
- allow picking up to 4 images and one gif when creating posts
- display selected media horizontally with delete controls
- show attached images/gifs in a grid on posts
- support gif field when parsing posts
- open images in zoomable viewer
- add photo_view dependency

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6884ef759bd8832883a7f60877eafc9c