### PR TITLE
Implement image upload on post creation

### DIFF
--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -2,7 +2,11 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 /// Base interface for creating posts in Firestore.
 abstract class BasePostService {
-  Future<void> createPost(Map<String, dynamic> data);
+  /// Generates a new unique identifier for a post document.
+  String newPostId();
+
+  /// Creates a post document with optional [id].
+  Future<void> createPost(Map<String, dynamic> data, {String? id});
 }
 
 /// Default implementation writing to the `posts` collection.
@@ -13,7 +17,13 @@ class PostService implements BasePostService {
       : _firestore = firestore ?? FirebaseFirestore.instance;
 
   @override
-  Future<void> createPost(Map<String, dynamic> data) {
+  String newPostId() => _firestore.collection('posts').doc().id;
+
+  @override
+  Future<void> createPost(Map<String, dynamic> data, {String? id}) {
+    if (id != null) {
+      return _firestore.collection('posts').doc(id).set(data);
+    }
     return _firestore.collection('posts').add(data);
   }
 }

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:firebase_storage/firebase_storage.dart';
+
+/// Interface for uploading post media to Firebase Storage.
+abstract class BaseStorageService {
+  Future<List<String>> uploadPostImages(String postId, List<File> files);
+}
+
+/// Default implementation uploading to the `posts` folder.
+class StorageService implements BaseStorageService {
+  final FirebaseStorage _storage;
+
+  StorageService({FirebaseStorage? storage})
+      : _storage = storage ?? FirebaseStorage.instance;
+
+  @override
+  Future<List<String>> uploadPostImages(String postId, List<File> files) async {
+    final urls = <String>[];
+    for (var i = 0; i < files.length; i++) {
+      final file = files[i];
+      final ref = _storage.ref().child('posts').child(postId).child('$i.jpg');
+      await ref.putFile(file);
+      final url = await ref.getDownloadURL();
+      urls.add(url);
+    }
+    return urls;
+  }
+}

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
@@ -6,6 +8,7 @@ import 'package:toastification/toastification.dart';
 import 'package:hoot/pages/create_post/controllers/create_post_controller.dart';
 import 'package:get/get.dart';
 import 'package:hoot/services/post_service.dart';
+import 'package:hoot/services/storage_service.dart';
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/models/user.dart';
 import 'package:hoot/services/auth_service.dart';
@@ -37,6 +40,18 @@ class FakeAuthService extends GetxService implements AuthService {
   Future<void> deleteAccount() async {}
 }
 
+class FakeStorageService extends GetxService implements BaseStorageService {
+  List<List<File>> calls = [];
+
+  @override
+  Future<List<String>> uploadPostImages(String postId, List<File> files) async {
+    calls.add(files);
+    return files
+        .map((f) => 'https://example.com/${f.path.split('/').last}')
+        .toList();
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -52,9 +67,20 @@ void main() {
           name: 'Tester',
           username: 'tester',
           smallProfilePictureUrl: 'a.png',
-          feeds: [Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue)]));
+          feeds: [
+            Feed(
+                id: 'f1',
+                userId: 'u1',
+                title: 't',
+                description: 'd',
+                color: Colors.blue)
+          ]));
+      final storage = FakeStorageService();
       final controller = CreatePostController(
-          postService: postService, authService: auth, userId: 'u1');
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
       controller.textController.text = 'Hello';
       expect(await controller.publish(), isFalse);
       await tester.pump(const Duration(seconds: 4));
@@ -72,12 +98,27 @@ void main() {
           name: 'Tester',
           username: 'tester',
           smallProfilePictureUrl: 'a.png',
-          feeds: [Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue)]));
+          feeds: [
+            Feed(
+                id: 'f1',
+                userId: 'u1',
+                title: 't',
+                description: 'd',
+                color: Colors.blue)
+          ]));
+      final storage = FakeStorageService();
       final controller = CreatePostController(
-          postService: postService, authService: auth, userId: 'u1');
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
       controller.textController.text = 'a' * 281;
-      controller.selectedFeed.value =
-          Feed(id: 'f1', userId: 't', title: 't', description: 'd', color: Colors.blue);
+      controller.selectedFeed.value = Feed(
+          id: 'f1',
+          userId: 't',
+          title: 't',
+          description: 'd',
+          color: Colors.blue);
       expect(await controller.publish(), isFalse);
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
@@ -94,11 +135,26 @@ void main() {
           name: 'Tester',
           username: 'tester',
           smallProfilePictureUrl: 'a.png',
-          feeds: [Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue)]));
+          feeds: [
+            Feed(
+                id: 'f1',
+                userId: 'u1',
+                title: 't',
+                description: 'd',
+                color: Colors.blue)
+          ]));
+      final storage = FakeStorageService();
       final controller = CreatePostController(
-          postService: postService, authService: auth, userId: 'u1');
-      controller.selectedFeed.value =
-          Feed(id: 'f1', userId: 't', title: 't', description: 'd', color: Colors.blue);
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
+      controller.selectedFeed.value = Feed(
+          id: 'f1',
+          userId: 't',
+          title: 't',
+          description: 'd',
+          color: Colors.blue);
       controller.textController.text = 'Hi';
       final result = await controller.publish();
       await tester.pump(const Duration(seconds: 4));
@@ -114,18 +170,74 @@ void main() {
       expect(data['feed']['title'], 't');
     });
 
+    testWidgets('images are uploaded and urls stored', (tester) async {
+      await tester.pumpWidget(const ToastificationWrapper(
+        child: MaterialApp(home: Scaffold(body: SizedBox())),
+      ));
+      final firestore = FakeFirebaseFirestore();
+      final postService = PostService(firestore: firestore);
+      final auth = FakeAuthService(U(
+          uid: 'u1',
+          name: 'Tester',
+          username: 'tester',
+          smallProfilePictureUrl: 'a.png',
+          feeds: [
+            Feed(
+                id: 'f1',
+                userId: 'u1',
+                title: 't',
+                description: 'd',
+                color: Colors.blue)
+          ]));
+      final storage = FakeStorageService();
+      final controller = CreatePostController(
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
+
+      controller.selectedFeed.value = Feed(
+          id: 'f1',
+          userId: 't',
+          title: 't',
+          description: 'd',
+          color: Colors.blue);
+      final file = File('${Directory.systemTemp.path}/img.jpg')
+        ..writeAsBytesSync([0]);
+      addTearDown(() => file.deleteSync());
+      controller.imageFiles.add(file);
+      controller.textController.text = 'Hi';
+      final result = await controller.publish();
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+      expect(result, isTrue);
+      expect(storage.calls.length, 1);
+      final posts = await firestore.collection('posts').get();
+      expect(
+          posts.docs.first.data()['images'][0], 'https://example.com/img.jpg');
+    });
+
     testWidgets('available feeds loaded on init', (tester) async {
       final firestore = FakeFirebaseFirestore();
       final postService = PostService(firestore: firestore);
-      final feed = Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue);
+      final feed = Feed(
+          id: 'f1',
+          userId: 'u1',
+          title: 't',
+          description: 'd',
+          color: Colors.blue);
       final auth = FakeAuthService(U(
           uid: 'u1',
           name: 'Tester',
           username: 'tester',
           smallProfilePictureUrl: 'a.png',
           feeds: [feed]));
+      final storage = FakeStorageService();
       final controller = CreatePostController(
-          postService: postService, authService: auth, userId: 'u1');
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
       Get.put(controller);
       await tester.pump();
       expect(controller.availableFeeds.length, 1);


### PR DESCRIPTION
## Summary
- upload post images to Firebase Storage
- expose post ID generation in PostService
- use storage service in CreatePostController
- test image upload logic

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6884f3063d3c83288a723f9920dd9e9f