### PR TITLE
Refactor feed forms into reusable widget

### DIFF
--- a/lib/pages/create_feed/views/create_feed_view.dart
+++ b/lib/pages/create_feed/views/create_feed_view.dart
@@ -1,10 +1,8 @@
-import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
-import 'package:dropdown_button2/dropdown_button2.dart';
 import '../controllers/create_feed_controller.dart';
-import '../../../util/enums/feed_types.dart';
+import '../../feed/widgets/feed_form.dart';
 
 class CreateFeedView extends GetView<CreateFeedController> {
   const CreateFeedView({super.key});
@@ -36,99 +34,18 @@ class CreateFeedView extends GetView<CreateFeedController> {
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            TextField(
-              controller: controller.titleController,
-              decoration: InputDecoration(labelText: 'title'.tr),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: controller.descriptionController,
-              decoration: InputDecoration(labelText: 'description'.tr),
-              maxLines: 3,
-            ),
-            const SizedBox(height: 16),
-            Obx(() => Row(
-                  children: [
-                    Text('${'color'.tr}:'),
-                    const SizedBox(width: 8),
-                    GestureDetector(
-                      onTap: () async {
-                        final color = await showColorPickerDialog(
-                          context,
-                          controller.selectedColor.value,
-                          barrierDismissible: true,
-                        );
-                        controller.selectedColor.value = color;
-                      },
-                      child: ColorIndicator(
-                        color: controller.selectedColor.value,
-                        width: 40,
-                        height: 40,
-                        borderRadius: 20,
-                      ),
-                    ),
-                  ],
-                )),
-            const SizedBox(height: 16),
-            Obx(
-              () => DropdownButton2<FeedType>(
-                value: controller.selectedType.value,
-                hint: Text('genre'.tr),
-                isExpanded: true,
-                onChanged: (value) => controller.selectedType.value = value,
-                items: FeedType.values
-                    .map((t) => DropdownMenuItem(
-                          value: t,
-                          child: Text('${FeedTypeExtension.toEmoji(t)} '
-                              '${FeedTypeExtension.toTranslatedString(context, t)}'),
-                        ))
-                    .toList(),
-                dropdownStyleData: DropdownStyleData(
-                  width: MediaQuery.of(context).size.width - 32,
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                ),
-                dropdownSearchData: DropdownSearchData(
-                  searchController: controller.typeSearchController,
-                  searchInnerWidgetHeight: 50,
-                  searchInnerWidget: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextFormField(
-                      controller: controller.typeSearchController,
-                      decoration: InputDecoration(
-                        isDense: true,
-                        hintText: 'searchEllipsis'.tr,
-                        border: OutlineInputBorder(),
-                      ),
-                    ),
-                  ),
-                  searchMatchFn: (item, searchValue) {
-                    final value = FeedTypeExtension.toTranslatedString(
-                        context, item.value!);
-                    return value
-                        .toLowerCase()
-                        .contains(searchValue.toLowerCase());
-                  },
-                ),
-                onMenuStateChange: (isOpen) {
-                  if (!isOpen) controller.typeSearchController.clear();
-                },
-              ),
-            ),
-            const SizedBox(height: 16),
-            Obx(() => SwitchListTile(
-                  value: controller.isPrivate.value,
-                  onChanged: (v) => controller.isPrivate.value = v,
-                  title: Text('privateFeed'.tr),
-                )),
-            Obx(() => SwitchListTile(
-                  value: controller.isNsfw.value,
-                  onChanged: (v) => controller.isNsfw.value = v,
-                  title: Text('nsfwFeed'.tr),
-                )),
-          ],
+        child: FeedForm(
+          titleController: controller.titleController,
+          descriptionController: controller.descriptionController,
+          typeSearchController: controller.typeSearchController,
+          selectedColor: controller.selectedColor,
+          onColorChanged: (c) => controller.selectedColor.value = c,
+          selectedType: controller.selectedType,
+          onTypeChanged: (t) => controller.selectedType.value = t,
+          isPrivate: controller.isPrivate,
+          onPrivateChanged: (v) => controller.isPrivate.value = v,
+          isNsfw: controller.isNsfw,
+          onNsfwChanged: (v) => controller.isNsfw.value = v,
         ),
       ),
     );

--- a/lib/pages/edit_feed/views/edit_feed_view.dart
+++ b/lib/pages/edit_feed/views/edit_feed_view.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
-import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:dropdown_button2/dropdown_button2.dart';
 import '../controllers/edit_feed_controller.dart';
-import '../../../util/enums/feed_types.dart';
+import '../../feed/widgets/feed_form.dart';
 
 class EditFeedView extends GetView<EditFeedController> {
   const EditFeedView({super.key});
@@ -39,107 +37,29 @@ class EditFeedView extends GetView<EditFeedController> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            TextField(
-              controller: controller.titleController,
-              decoration: InputDecoration(labelText: 'title'.tr),
+            FeedForm(
+              titleController: controller.titleController,
+              descriptionController: controller.descriptionController,
+              typeSearchController: controller.typeSearchController,
+              selectedColor: controller.selectedColor,
+              onColorChanged: (c) => controller.selectedColor.value = c,
+              selectedType: controller.selectedType,
+              onTypeChanged: (t) => controller.selectedType.value = t,
+              isPrivate: controller.isPrivate,
+              onPrivateChanged: (v) => controller.isPrivate.value = v,
+              isNsfw: controller.isNsfw,
+              onNsfwChanged: (v) => controller.isNsfw.value = v,
             ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: controller.descriptionController,
-              decoration: InputDecoration(labelText: 'description'.tr),
-              maxLines: 3,
-            ),
-            const SizedBox(height: 16),
-            Obx(() => Row(
-                  children: [
-                    Text('${'color'.tr}:'),
-                    const SizedBox(width: 8),
-                    GestureDetector(
-                      onTap: () async {
-                        final color = await showColorPickerDialog(
-                          context,
-                          controller.selectedColor.value,
-                          barrierDismissible: true,
-                        );
-                        controller.selectedColor.value = color;
-                      },
-                      child: ColorIndicator(
-                        color: controller.selectedColor.value,
-                        width: 40,
-                        height: 40,
-                        borderRadius: 20,
-                      ),
-                    ),
-                  ],
-                )),
-            const SizedBox(height: 16),
-            Obx(
-              () => DropdownButton2<FeedType>(
-                value: controller.selectedType.value,
-                hint: Text('genre'.tr),
-                isExpanded: true,
-                onChanged: (value) => controller.selectedType.value = value,
-                items: FeedType.values
-                    .map((t) => DropdownMenuItem(
-                          value: t,
-                          child: Text('${FeedTypeExtension.toEmoji(t)} '
-                              '${FeedTypeExtension.toTranslatedString(context, t)}'),
-                        ))
-                    .toList(),
-                dropdownStyleData: DropdownStyleData(
-                  width: MediaQuery.of(context).size.width - 32,
-                  padding: const EdgeInsets.symmetric(vertical: 4),
-                ),
-                dropdownSearchData: DropdownSearchData(
-                  searchController: controller.typeSearchController,
-                  searchInnerWidgetHeight: 50,
-                  searchInnerWidget: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: TextFormField(
-                      controller: controller.typeSearchController,
-                      decoration: InputDecoration(
-                        isDense: true,
-                        hintText: 'searchEllipsis'.tr,
-                        border: const OutlineInputBorder(),
-                      ),
-                    ),
-                  ),
-                  searchMatchFn: (item, searchValue) {
-                    final value = FeedTypeExtension.toTranslatedString(
-                        context, item.value!);
-                    return value
-                        .toLowerCase()
-                        .contains(searchValue.toLowerCase());
-                  },
-                ),
-                onMenuStateChange: (isOpen) {
-                  if (!isOpen) controller.typeSearchController.clear();
-                },
-              ),
-            ),
-            const SizedBox(height: 16),
-            Obx(() => SwitchListTile(
-                  value: controller.isPrivate.value,
-                  onChanged: (v) => controller.isPrivate.value = v,
-                  title: Text('privateFeed'.tr),
-                )),
-            Obx(() => SwitchListTile(
-                  value: controller.isNsfw.value,
-                  onChanged: (v) => controller.isNsfw.value = v,
-                  title: Text('nsfwFeed'.tr),
-                )),
             const SizedBox(height: 16),
             Obx(() => controller.deleting.value
                 ? const Center(child: CircularProgressIndicator())
                 : OutlinedButton(
                     onPressed: () async {
-                      final result =
-                          await controller.deleteFeed(context);
+                      final result = await controller.deleteFeed(context);
                       if (result) Get.back();
                     },
                     style: OutlinedButton.styleFrom(
-                      foregroundColor:
-                          Theme.of(context).colorScheme.error,
+                      foregroundColor: Theme.of(context).colorScheme.error,
                     ),
                     child: Text('deleteFeed'.tr),
                   )),

--- a/lib/pages/feed/widgets/feed_form.dart
+++ b/lib/pages/feed/widgets/feed_form.dart
@@ -1,0 +1,163 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:flex_color_picker/flex_color_picker.dart';
+import 'package:dropdown_button2/dropdown_button2.dart';
+
+import '../../../util/enums/feed_types.dart';
+
+/// Reusable form widget for creating or editing feeds.
+class FeedForm extends StatelessWidget {
+  const FeedForm({
+    super.key,
+    required this.titleController,
+    required this.descriptionController,
+    required this.typeSearchController,
+    required this.selectedColor,
+    required this.onColorChanged,
+    required this.selectedType,
+    required this.onTypeChanged,
+    required this.isPrivate,
+    required this.onPrivateChanged,
+    required this.isNsfw,
+    required this.onNsfwChanged,
+  });
+
+  /// Controller for the feed title field.
+  final TextEditingController titleController;
+
+  /// Controller for the feed description field.
+  final TextEditingController descriptionController;
+
+  /// Controller used for searching in the genre dropdown.
+  final TextEditingController typeSearchController;
+
+  /// Currently selected color.
+  final Rx<Color> selectedColor;
+
+  /// Callback when the color changes.
+  final ValueChanged<Color> onColorChanged;
+
+  /// Currently selected feed type.
+  final Rx<FeedType?> selectedType;
+
+  /// Callback when the feed type changes.
+  final ValueChanged<FeedType?> onTypeChanged;
+
+  /// Whether the feed is private.
+  final RxBool isPrivate;
+
+  /// Callback when the private flag changes.
+  final ValueChanged<bool> onPrivateChanged;
+
+  /// Whether the feed is marked NSFW.
+  final RxBool isNsfw;
+
+  /// Callback when the NSFW flag changes.
+  final ValueChanged<bool> onNsfwChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        TextField(
+          controller: titleController,
+          decoration: InputDecoration(labelText: 'title'.tr),
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: descriptionController,
+          decoration: InputDecoration(labelText: 'description'.tr),
+          maxLines: 3,
+        ),
+        const SizedBox(height: 16),
+        Obx(() => Row(
+              children: [
+                Text('${'color'.tr}:'),
+                const SizedBox(width: 8),
+                GestureDetector(
+                  onTap: () async {
+                    final color = await showColorPickerDialog(
+                      context,
+                      selectedColor.value,
+                      barrierDismissible: true,
+                    );
+                    onColorChanged(color);
+                  },
+                  child: ColorIndicator(
+                    color: selectedColor.value,
+                    width: 40,
+                    height: 40,
+                    borderRadius: 20,
+                  ),
+                ),
+              ],
+            )),
+        const SizedBox(height: 16),
+        Obx(
+          () => DropdownButton2<FeedType>(
+            value: selectedType.value,
+            hint: Text('genre'.tr),
+            isExpanded: true,
+            onChanged: onTypeChanged,
+            items: FeedType.values
+                .map(
+                  (t) => DropdownMenuItem(
+                    value: t,
+                    child: Text(
+                      '${FeedTypeExtension.toEmoji(t)} '
+                      '${FeedTypeExtension.toTranslatedString(context, t)}',
+                    ),
+                  ),
+                )
+                .toList(),
+            dropdownStyleData: DropdownStyleData(
+              width: MediaQuery.of(context).size.width - 32,
+              padding: const EdgeInsets.symmetric(vertical: 4),
+            ),
+            dropdownSearchData: DropdownSearchData(
+              searchController: typeSearchController,
+              searchInnerWidgetHeight: 50,
+              searchInnerWidget: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: TextFormField(
+                  controller: typeSearchController,
+                  decoration: InputDecoration(
+                    isDense: true,
+                    hintText: 'searchEllipsis'.tr,
+                    border: const OutlineInputBorder(),
+                  ),
+                ),
+              ),
+              searchMatchFn: (item, searchValue) {
+                final value = FeedTypeExtension.toTranslatedString(
+                  context,
+                  item.value!,
+                );
+                return value.toLowerCase().contains(searchValue.toLowerCase());
+              },
+            ),
+            onMenuStateChange: (isOpen) {
+              if (!isOpen) typeSearchController.clear();
+            },
+          ),
+        ),
+        const SizedBox(height: 16),
+        Obx(
+          () => SwitchListTile(
+            value: isPrivate.value,
+            onChanged: onPrivateChanged,
+            title: Text('privateFeed'.tr),
+          ),
+        ),
+        Obx(
+          () => SwitchListTile(
+            value: isNsfw.value,
+            onChanged: onNsfwChanged,
+            title: Text('nsfwFeed'.tr),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add FeedForm widget with reusable fields and switches
- simplify CreateFeedView to use FeedForm
- simplify EditFeedView to use FeedForm

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6885413eb5848328bbd0e0827b1200a4