### PR TITLE
Implement persistent post interactions

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -5,13 +5,20 @@ import 'package:hoot/components/name_component.dart';
 import 'package:hoot/models/post.dart';
 import 'package:get/get.dart';
 import 'package:solar_icons/solar_icons.dart';
+import 'package:adaptive_dialog/adaptive_dialog.dart';
 import '../util/routes/app_routes.dart';
+import '../services/post_service.dart';
+import '../services/auth_service.dart';
+import '../services/dialog_service.dart';
+import '../services/toast_service.dart';
 
 class PostComponent extends StatefulWidget {
   final Post post;
+  final BasePostService? postService;
 
   const PostComponent({
     required this.post,
+    this.postService,
     super.key,
   });
 
@@ -21,25 +28,63 @@ class PostComponent extends StatefulWidget {
 
 class _PostComponentState extends State<PostComponent> {
   late Post _post;
+  late BasePostService _postService;
+  late AuthService _authService;
 
   @override
   void initState() {
     _post = widget.post;
+    _postService =
+        widget.postService ?? (Get.isRegistered<BasePostService>()
+            ? Get.find<BasePostService>()
+            : PostService());
+    _authService =
+        Get.isRegistered<AuthService>() ? Get.find<AuthService>() : AuthService();
     super.initState();
   }
 
-  void _toggleLike() {
+  Future<void> _toggleLike() async {
+    final user = _authService.currentUser;
+    if (user == null) return;
+    final newLiked = !_post.liked;
     setState(() {
-      if (_post.liked) {
-        _post
-          ..liked = false
-          ..likes = (_post.likes ?? 1) - 1;
-      } else {
-        _post
-          ..liked = true
-          ..likes = (_post.likes ?? 0) + 1;
-      }
+      _post
+        ..liked = newLiked
+        ..likes = (_post.likes ?? 0) + (newLiked ? 1 : -1);
     });
+    try {
+      await _postService.toggleLike(_post.id, user.uid, newLiked);
+    } catch (_) {
+      setState(() {
+        _post
+          ..liked = !newLiked
+          ..likes = (_post.likes ?? 0) + (newLiked ? -1 : 1);
+      });
+    }
+  }
+
+  Future<void> _reFeed() async {
+    final user = _authService.currentUser;
+    if (user == null) return;
+    final feeds = user.feeds ?? [];
+    if (feeds.isEmpty) {
+      ToastService.showError('youNeedToCreateAFeedFirst'.tr);
+      return;
+    }
+    final feed = await DialogService.showActionSheet<Feed>(
+      context: context,
+      title: 'selectAFeedToRefeedTo'.tr,
+      actions: [
+        for (final f in feeds)
+          SheetAction(value: f, label: f.title),
+      ],
+    );
+    if (feed == null) return;
+    await _postService.reFeed(original: _post, targetFeed: feed, user: user);
+    setState(() {
+      _post.reFeeds = (_post.reFeeds ?? 0) + 1;
+    });
+    ToastService.showSuccess('newReHoot'.tr);
   }
 
   void _openPostDetails() {
@@ -137,8 +182,13 @@ class _PostComponentState extends State<PostComponent> {
                 IconButton(
                   visualDensity: VisualDensity.compact,
                   icon: const Icon(SolarIconsOutline.refreshSquare),
-                  onPressed: () {},
+                  onPressed: _reFeed,
                 ),
+                if ((_post.reFeeds ?? 0) > 0)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 8.0),
+                    child: Text('${_post.reFeeds ?? 0}'),
+                  ),
                 const Spacer(
                   flex: 2,
                 ),

--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -2,6 +2,7 @@ import 'package:get/get.dart';
 import 'services/auth_service.dart';
 import 'services/feed_service.dart';
 import 'services/theme_service.dart';
+import 'services/post_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -12,6 +13,7 @@ class DependencyInjector {
     final auth = Get.put(AuthService(), permanent: true);
     await auth.fetchUser();
     Get.put<BaseFeedService>(FeedService(), permanent: true);
+    Get.put<BasePostService>(PostService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeMode();
   }

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -1,4 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/post.dart';
+import '../models/user.dart';
+import '../models/feed.dart';
 
 /// Base interface for creating posts in Firestore.
 abstract class BasePostService {
@@ -7,6 +10,17 @@ abstract class BasePostService {
 
   /// Creates a post document with optional [id].
   Future<void> createPost(Map<String, dynamic> data, {String? id});
+
+  /// Toggles like state for [postId] by [userId].
+  Future<void> toggleLike(String postId, String userId, bool like);
+
+  /// Creates a reFeed of [original] into [targetFeed] by [user].
+  /// Returns the new post id.
+  Future<String> reFeed({
+    required Post original,
+    required Feed targetFeed,
+    required U user,
+  });
 }
 
 /// Default implementation writing to the `posts` collection.
@@ -25,5 +39,53 @@ class PostService implements BasePostService {
       return _firestore.collection('posts').doc(id).set(data);
     }
     return _firestore.collection('posts').add(data);
+  }
+
+  @override
+  Future<void> toggleLike(String postId, String userId, bool like) async {
+    final postRef = _firestore.collection('posts').doc(postId);
+    final likeRef = postRef.collection('likes').doc(userId);
+    await _firestore.runTransaction((txn) async {
+      if (like) {
+        txn.set(likeRef, {'createdAt': FieldValue.serverTimestamp()});
+        txn.update(postRef, {'likes': FieldValue.increment(1)});
+      } else {
+        txn.delete(likeRef);
+        txn.update(postRef, {'likes': FieldValue.increment(-1)});
+      }
+    });
+  }
+
+  @override
+  Future<String> reFeed({
+    required Post original,
+    required Feed targetFeed,
+    required U user,
+  }) async {
+    final newId = newPostId();
+
+    final feedData = targetFeed.toJson()
+      ..addAll({'id': targetFeed.id, 'userId': targetFeed.userId});
+    final userData = user.toJson()..addAll({'uid': user.uid});
+
+    await _firestore.collection('posts').doc(newId).set({
+      'text': original.text,
+      if (original.media != null && original.media!.isNotEmpty)
+        'images': original.media,
+      'feedId': targetFeed.id,
+      'feed': feedData,
+      'userId': user.uid,
+      'user': userData,
+      'reFeeded': true,
+      'reFeededFrom': {'id': original.id},
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+
+    await _firestore
+        .collection('posts')
+        .doc(original.id)
+        .update({'reFeeds': FieldValue.increment(1)});
+
+    return newId;
   }
 }

--- a/test/post_service_test.dart
+++ b/test/post_service_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:hoot/services/post_service.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/models/user.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  group('PostService', () {
+    test('toggleLike increments and decrements', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = PostService(firestore: firestore);
+      await firestore.collection('posts').doc('p1').set({'likes': 0});
+
+      await service.toggleLike('p1', 'u1', true);
+      var post = await firestore.collection('posts').doc('p1').get();
+      expect(post.get('likes'), 1);
+      expect(
+          (await firestore
+                  .collection('posts')
+                  .doc('p1')
+                  .collection('likes')
+                  .doc('u1')
+                  .get())
+              .exists,
+          isTrue);
+
+      await service.toggleLike('p1', 'u1', false);
+      post = await firestore.collection('posts').doc('p1').get();
+      expect(post.get('likes'), 0);
+      expect(
+          (await firestore
+                  .collection('posts')
+                  .doc('p1')
+                  .collection('likes')
+                  .doc('u1')
+                  .get())
+              .exists,
+          isFalse);
+    });
+
+    test('reFeed creates new post', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = PostService(firestore: firestore);
+      await firestore.collection('posts').doc('orig').set({'text': 'Hello', 'reFeeds': 0});
+      final original = Post(id: 'orig', text: 'Hello');
+      final feed = Feed(id: 'f1', userId: 'u1', title: 'feed', description: 'd', color: Colors.blue);
+      final user = U(uid: 'u1');
+
+      final newId = await service.reFeed(original: original, targetFeed: feed, user: user);
+
+      final newDoc = await firestore.collection('posts').doc(newId).get();
+      expect(newDoc.exists, isTrue);
+      expect(newDoc.get('reFeeded'), true);
+      expect(newDoc.get('reFeededFrom')['id'], 'orig');
+      expect((await firestore.collection('posts').doc('orig').get()).get('reFeeds'), 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- handle likes and reposts via Firestore
- inject `PostService` globally
- use service from `PostComponent`
- test new service features

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68862aa008c08328888b87b6242fbc85