### PR TITLE
Display comment count

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -198,8 +198,7 @@ class _PostComponentState extends State<PostComponent> {
                   icon: const Icon(SolarIconsOutline.chatRoundLine),
                   onPressed: _openPostDetails,
                 ),
-                if ((_post.comments ?? 0) > 0)
-                  Text('${_post.comments ?? 0}'),
+                Text('${_post.comments ?? 0}'),
                 const Spacer(),
               ],
             )

--- a/lib/services/comment_service.dart
+++ b/lib/services/comment_service.dart
@@ -67,11 +67,14 @@ class CommentService implements BaseCommentService {
       .id;
 
   @override
-  Future<void> createComment(String postId, Map<String, dynamic> data, {String? id}) {
-    final ref = _firestore.collection('posts').doc(postId).collection('comments');
-    if (id != null) {
-      return ref.doc(id).set(data);
-    }
-    return ref.add(data);
+  Future<void> createComment(String postId, Map<String, dynamic> data, {String? id}) async {
+    final postRef = _firestore.collection('posts').doc(postId);
+    final commentsRef = postRef.collection('comments');
+
+    await _firestore.runTransaction((txn) async {
+      final doc = id != null ? commentsRef.doc(id) : commentsRef.doc();
+      txn.set(doc, data);
+      txn.update(postRef, {'comments': FieldValue.increment(1)});
+    });
   }
 }


### PR DESCRIPTION
## Summary
- show the comment count label in posts even when zero
- increment the post comment count in Firestore when posting a comment

## Testing
- `flutter analyze`
- `flutter test` *(fails: Multiple exceptions during running tests)*

------
https://chatgpt.com/codex/tasks/task_e_68864e4bc7ac8328a68126606857d847