### PR TITLE
Open post details after publishing

### DIFF
--- a/lib/pages/create_post/views/create_post_view.dart
+++ b/lib/pages/create_post/views/create_post_view.dart
@@ -45,7 +45,12 @@ class CreatePostView extends GetView<CreatePostController> {
                       child: CircularProgressIndicator(strokeWidth: 2)),
                 )
               : TextButton(
-                  onPressed: controller.publish,
+                  onPressed: () async {
+                    final post = await controller.publish();
+                    if (post != null) {
+                      Get.toNamed(AppRoutes.post, arguments: post);
+                    }
+                  },
                   child: Text('publish'.tr),
                 ))
         ],

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -10,6 +10,7 @@ import 'package:get/get.dart';
 import 'package:hoot/services/post_service.dart';
 import 'package:hoot/services/storage_service.dart';
 import 'package:hoot/models/feed.dart';
+import 'package:hoot/models/post.dart';
 import 'package:hoot/models/user.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -82,7 +83,7 @@ void main() {
           userId: 'u1',
           storageService: storage);
       controller.textController.text = 'Hello';
-      expect(await controller.publish(), isFalse);
+      expect(await controller.publish(), isNull);
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
     });
@@ -119,7 +120,7 @@ void main() {
           title: 't',
           description: 'd',
           color: Colors.blue);
-      expect(await controller.publish(), isFalse);
+      expect(await controller.publish(), isNull);
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
     });
@@ -159,7 +160,7 @@ void main() {
       final result = await controller.publish();
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
-      expect(result, isTrue);
+      expect(result, isA<Post>());
       final posts = await firestore.collection('posts').get();
       expect(posts.docs.length, 1);
       final data = posts.docs.first.data();
@@ -210,7 +211,7 @@ void main() {
       final result = await controller.publish();
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
-      expect(result, isTrue);
+      expect(result, isA<Post>());
       expect(storage.calls.length, 1);
       final posts = await firestore.collection('posts').get();
       expect(


### PR DESCRIPTION
## Summary
- return the newly created post when publishing
- open the new post details from CreatePostView
- update CreatePostController tests

## Testing
- `flutter test` *(fails: FeedView shows posts from controller)*
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_6886581085ec8328943a995765a1612e