### PR TITLE
Adjust explore page padding

### DIFF
--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -55,23 +55,34 @@ class ExploreView extends GetView<ExploreController> {
         onRefresh: controller.refreshExplore,
         child: SingleChildScrollView(
           physics: const AlwaysScrollableScrollPhysics(),
-          padding: const EdgeInsets.all(16),
+          padding: const EdgeInsets.symmetric(vertical: 16),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              TextField(
-                controller: controller.searchController,
-                decoration: InputDecoration(
-                  hintText: 'searchPlaceholder'.tr,
-                  prefixIcon: const Icon(Icons.search),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: TextField(
+                  controller: controller.searchController,
+                  decoration: InputDecoration(
+                    hintText: 'searchPlaceholder'.tr,
+                    prefixIcon: const Icon(Icons.search),
+                  ),
+                  onChanged: controller.search,
                 ),
-                onChanged: controller.search,
               ),
               const SizedBox(height: 16),
-              buildSuggestions(),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: buildSuggestions(),
+              ),
               const SizedBox(height: 16),
-              Text('top10MostSubscribed'.tr,
-                  style: Theme.of(context).textTheme.titleMedium),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'top10MostSubscribed'.tr,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
               const SizedBox(height: 8),
               SizedBox(
                 height: 200,
@@ -101,8 +112,13 @@ class ExploreView extends GetView<ExploreController> {
                 ),
               ),
               const SizedBox(height: 16),
-              Text('popularTypes'.tr,
-                  style: Theme.of(context).textTheme.titleMedium),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'popularTypes'.tr,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ),
               const SizedBox(height: 8),
               SizedBox(
                 height: 100,


### PR DESCRIPTION
## Summary
- adjust ExploreView layout so horizontal padding only surrounds search, suggestions and titles
- keep top/bottom padding on Explore page

## Testing
- `flutter test test/explore_view_test.dart`
- `flutter test` *(fails: TimeoutException after 10 minutes)*

------
https://chatgpt.com/codex/tasks/task_e_688657cb9d0883288cac35742bc798f2