### PR TITLE
Generate invite code after verification

### DIFF
--- a/test/invitation_service_test.dart
+++ b/test/invitation_service_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:hoot/services/invitation_service.dart';
+
+void main() {
+  test('useInvitationCode assigns code when none exists', () async {
+    final firestore = FakeFirebaseFirestore();
+    final service = InvitationService(firestore: firestore);
+    await firestore.collection('users').doc('u1').set({
+      'invitationCode': 'CODE',
+      'invitationUses': 0,
+      'invitationLastReset': Timestamp.now(),
+    });
+    await firestore.collection('users').doc('new').set({});
+
+    final result = await service.useInvitationCode('new', 'CODE');
+
+    expect(result, isTrue);
+    final newUser = await firestore.collection('users').doc('new').get();
+    expect(newUser.get('invitedBy'), 'u1');
+    expect(newUser.get('invitationCode'), isNotEmpty);
+  });
+}

--- a/test/invitation_view_test.dart
+++ b/test/invitation_view_test.dart
@@ -65,7 +65,8 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('invitationCodePrompt'.tr), findsOneWidget);
+    expect(find.text('Access is limited. Entry requires a personal invite.'),
+        findsOneWidget);
     addTearDown(Get.reset);
   });
 }


### PR DESCRIPTION
## Summary
- create a new invite code for a user once they successfully redeem an invitation
- update InvitationView test expectation
- add unit test for InvitationService

## Testing
- `flutter test test/invitation_service_test.dart`
- `flutter test` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_68868c72aab88328bc0ce663a065908e