### PR TITLE
Add localized timeago

### DIFF
--- a/lib/components/comment_component.dart
+++ b/lib/components/comment_component.dart
@@ -3,6 +3,7 @@ import 'package:hoot/components/avatar_component.dart';
 import 'package:hoot/components/name_component.dart';
 import 'package:hoot/models/comment.dart';
 import '../util/mention_utils.dart';
+import '../util/extensions/datetime_extension.dart';
 
 class CommentComponent extends StatelessWidget {
   final Comment comment;
@@ -25,6 +26,12 @@ class CommentComponent extends StatelessWidget {
           children: parseMentions(comment.text),
         ),
       ),
+      trailing: comment.createdAt != null
+          ? Text(
+              comment.createdAt!.timeAgo(),
+              style: Theme.of(context).textTheme.bodySmall,
+            )
+          : null,
     );
   }
 }

--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -13,6 +13,7 @@ import '../services/auth_service.dart';
 import '../services/dialog_service.dart';
 import '../services/toast_service.dart';
 import '../util/mention_utils.dart';
+import '../util/extensions/datetime_extension.dart';
 
 class PostComponent extends StatefulWidget {
   final Post post;
@@ -115,6 +116,12 @@ class _PostComponentState extends State<PostComponent> {
                     user: _post.user!,
                     size: 16,
                     feedName: _post.feed?.title ?? '',
+                  ),
+                const Spacer(),
+                if (_post.createdAt != null)
+                  Text(
+                    _post.createdAt!.timeAgo(),
+                    style: Theme.of(context).textTheme.bodySmall,
                   ),
               ],
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:hoot/theme/theme.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:toastification/toastification.dart';
 import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
+import 'package:timeago/timeago.dart' as timeago;
 import 'services/theme_service.dart';
 import 'firebase_options.dart';
 
@@ -34,6 +35,10 @@ void main() {
       locale: Get.locale?.toLanguageTag() ?? 'en',
       country: Get.deviceLocale?.countryCode ?? 'US',
     );
+
+    timeago.setLocaleMessages('es', timeago.EsMessages());
+    timeago.setLocaleMessages('pt', timeago.PtBrMessages());
+    timeago.setLocaleMessages('pt_BR', timeago.PtBrMessages());
 
     final themeService = Get.find<ThemeService>();
     runApp(

--- a/lib/util/extensions/datetime_extension.dart
+++ b/lib/util/extensions/datetime_extension.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
+extension DateTimeExtension on DateTime {
+  String timeAgo() {
+    final locale = Get.locale?.toLanguageTag() ?? 'en';
+    return timeago.format(this, locale: locale);
+  }
+}


### PR DESCRIPTION
## Summary
- create a DateTime extension for timeago formatting
- show relative dates in post and comment headers
- register supported locales for timeago

## Testing
- `flutter pub get`
- `flutter test` *(fails: Multiple exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_688696177a0483288ba8a09c28eac4ff