### PR TITLE
Disable manual swiping on welcome screen

### DIFF
--- a/lib/pages/welcome/views/welcome_view.dart
+++ b/lib/pages/welcome/views/welcome_view.dart
@@ -164,6 +164,7 @@ class _WelcomeViewState extends State<WelcomeView> {
               child: Swiper(
                 controller: _controller,
                 index: widget.initialIndex,
+                physics: const NeverScrollableScrollPhysics(),
                 loop: false,
                 itemCount: 3,
                 itemBuilder: (context, i) {


### PR DESCRIPTION
## Summary
- disable manual swiping for the welcome Swiper

## Testing
- `flutter pub get`
- `flutter test` *(fails: LiquidGlassLayer requires Impeller, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6887244d54188328b974d17eecc7fae4