### PR TITLE
Enable profile open from search

### DIFF
--- a/lib/components/list_item_component.dart
+++ b/lib/components/list_item_component.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hoot/components/shimmer_skeletons.dart';
 import 'package:liquid_glass_renderer/liquid_glass_renderer.dart';
+import 'dart:ui';
 
 class ListItemComponent extends StatelessWidget {
   final Widget? leading;
@@ -125,12 +126,14 @@ class ListItemComponent extends StatelessWidget {
                         )
                       ],
                     ),
-                    child: LiquidGlass(
-                      shape: LiquidRoundedRectangle(
-                        borderRadius: Radius.circular(25),
-                      ),
-                      child: leading!,
-                    ),
+                    child: ImageFilter.isShaderFilterSupported
+                        ? LiquidGlass(
+                            shape: LiquidRoundedRectangle(
+                              borderRadius: Radius.circular(25),
+                            ),
+                            child: leading!,
+                          )
+                        : leading!,
                   ),
                 ),
               )

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -29,6 +29,8 @@ class ExploreView extends GetView<ExploreController> {
               (u) => ListTile(
                 title: Text(u.name ?? ''),
                 subtitle: Text('@${u.username ?? ''}'),
+                onTap: () =>
+                    Get.toNamed(AppRoutes.profile, arguments: u.uid),
               ),
             ),
             ...controller.feedSuggestions.map(

--- a/test/explore_view_test.dart
+++ b/test/explore_view_test.dart
@@ -5,6 +5,7 @@ import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 
 import 'package:hoot/pages/explore/controllers/explore_controller.dart';
 import 'package:hoot/pages/explore/views/explore_view.dart';
+import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 
 void main() {
@@ -47,6 +48,47 @@ void main() {
 
     expect(find.text('Tester'), findsOneWidget);
     expect(find.text('test feed'), findsWidgets);
+
+    Get.reset();
+  });
+
+  testWidgets('tapping user suggestion opens profile', (tester) async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('users').doc('u1').set({
+      'uid': 'u1',
+      'displayName': 'Tester',
+      'username': 'tester',
+    });
+
+    Get.put(ExploreController(firestore: firestore));
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        translations: AppTranslations(),
+        locale: const Locale('en'),
+        getPages: [
+          GetPage(
+            name: '/',
+            page: () => const Scaffold(body: ExploreView()),
+          ),
+          GetPage(
+            name: AppRoutes.profile,
+            page: () => const Scaffold(body: Text('profile page')),
+          ),
+        ],
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'test');
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+
+    await tester.tap(find.text('Tester'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('profile page'), findsOneWidget);
 
     Get.reset();
   });


### PR DESCRIPTION
## Summary
- open user profile when tapping a suggestion on Explore search
- make `ListItemComponent` skip `LiquidGlass` when shader filters aren't supported
- test that user suggestions navigate to the profile

## Testing
- `flutter test test/explore_view_test.dart`
- ❌ `flutter test` *(fails: `create_post_view_test.dart` TimeoutException)*

------
https://chatgpt.com/codex/tasks/task_e_688724086eb483289ad909d869895412