### PR TITLE
Implement feed tap navigation

### DIFF
--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -40,6 +40,10 @@ class ExploreView extends GetView<ExploreController> {
                 ),
                 title: Text(f.title),
                 subtitle: Text('feed'.tr),
+                onTap: () => Get.toNamed(
+                  AppRoutes.profile,
+                  arguments: {'uid': f.userId, 'feedId': f.id},
+                ),
               ),
             ),
           ],
@@ -95,17 +99,23 @@ class ExploreView extends GetView<ExploreController> {
                       final f = controller.topFeeds[index];
                       return SizedBox(
                         width: 250,
-                        child: ListItemComponent(
-                          leading: ProfileAvatarComponent(
-                            image: f.imageUrl ?? '',
-                            size: 100,
-                            radius: 25,
+                        child: GestureDetector(
+                          onTap: () => Get.toNamed(
+                            AppRoutes.profile,
+                            arguments: {'uid': f.userId, 'feedId': f.id},
                           ),
-                          title: f.title,
-                          subtitle:
-                              '${f.subscriberCount ?? 0} ${'followers'.tr}',
-                          backgroundColor: f.color,
-                          foregroundColor: f.foregroundColor,
+                          child: ListItemComponent(
+                            leading: ProfileAvatarComponent(
+                              image: f.imageUrl ?? '',
+                              size: 100,
+                              radius: 25,
+                            ),
+                            title: f.title,
+                            subtitle:
+                                '${f.subscriberCount ?? 0} ${'followers'.tr}',
+                            backgroundColor: f.color,
+                            foregroundColor: f.foregroundColor,
+                          ),
                         ),
                       );
                     },
@@ -124,7 +134,7 @@ class ExploreView extends GetView<ExploreController> {
               SizedBox(
                 height: 100,
                 child: Obx(() => ListView.separated(
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
                       scrollDirection: Axis.horizontal,
                       itemCount: controller.genres.length,
                       separatorBuilder: (_, __) => const SizedBox(width: 12),

--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -24,6 +24,7 @@ class ProfileController extends GetxController {
   final RxSet<String> subscribedFeedIds = <String>{}.obs;
   final Map<String, PagingState<DocumentSnapshot?, Post>> feedStates = {};
   String? uid;
+  String? initialFeedId;
   bool get isCurrentUser => uid == null || uid == _authService.currentUser?.uid;
 
   @override
@@ -32,8 +33,13 @@ class ProfileController extends GetxController {
     final args = Get.arguments;
     if (args is String) {
       uid = args;
-    } else if (args is Map && args['uid'] is String) {
-      uid = args['uid'] as String;
+    } else if (args is Map) {
+      if (args['uid'] is String) {
+        uid = args['uid'] as String;
+      }
+      if (args['feedId'] is String) {
+        initialFeedId = args['feedId'] as String;
+      }
     }
     loadProfile();
   }
@@ -53,7 +59,13 @@ class ProfileController extends GetxController {
         }
       }
       if (feeds.isNotEmpty) {
-        await loadFeedPosts(feeds.first.id, refresh: true);
+        var index = 0;
+        if (initialFeedId != null) {
+          final i = feeds.indexWhere((f) => f.id == initialFeedId);
+          if (i != -1) index = i;
+        }
+        selectedFeedIndex.value = index;
+        await loadFeedPosts(feeds[index].id, refresh: true);
       }
       ever<int>(selectedFeedIndex, (i) {
         final feed = feeds[i];

--- a/lib/pages/search_by_genre/views/search_by_genre_view.dart
+++ b/lib/pages/search_by_genre/views/search_by_genre_view.dart
@@ -22,14 +22,20 @@ class SearchByGenreView extends GetView<SearchByGenreController> {
             itemCount: controller.feeds.length,
             itemBuilder: (context, index) {
               final feed = controller.feeds[index];
-              return ListItemComponent(
-                leading: ProfileAvatarComponent(
-                  image: feed.imageUrl ?? '',
-                  size: 100,
-                  radius: 25,
+              return GestureDetector(
+                onTap: () => Get.toNamed(
+                  AppRoutes.profile,
+                  arguments: {'uid': feed.userId, 'feedId': feed.id},
                 ),
-                title: feed.title,
-                subtitle: '${feed.subscriberCount ?? 0} ${'followers'.tr}',
+                child: ListItemComponent(
+                  leading: ProfileAvatarComponent(
+                    image: feed.imageUrl ?? '',
+                    size: 100,
+                    radius: 25,
+                  ),
+                  title: feed.title,
+                  subtitle: '${feed.subscriberCount ?? 0} ${'followers'.tr}',
+                ),
               );
             },
           )),


### PR DESCRIPTION
## Summary
- navigate to the author's profile with the tapped feed selected when exploring feeds
- allow `ProfileController` to accept a `feedId` argument and preselect that feed

## Testing
- `flutter pub get`
- `flutter test` *(fails: TimeoutException after 10 minutes)*

------
https://chatgpt.com/codex/tasks/task_e_6887241fc2b083289a5eb577bdf39e73