### PR TITLE
Add subscription FAB and service

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -3,6 +3,7 @@ import 'services/auth_service.dart';
 import 'services/feed_service.dart';
 import 'services/theme_service.dart';
 import 'services/post_service.dart';
+import 'services/subscription_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -14,6 +15,7 @@ class DependencyInjector {
     await auth.fetchUser();
     Get.put<BaseFeedService>(FeedService(), permanent: true);
     Get.put<BasePostService>(PostService(), permanent: true);
+    Get.put(SubscriptionService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeMode();
   }

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -173,15 +173,6 @@ class _ProfileViewState extends State<ProfileView> {
               selectedColor: color,
               backgroundColor: color.withValues(alpha: 0.2),
             ),
-            if (!controller.isCurrentUser) ...[
-              const SizedBox(width: 4),
-              TextButton(
-                child: Text(controller.isSubscribed(feed.id)
-                    ? 'unsubscribe'.tr
-                    : 'subscribe'.tr),
-                onPressed: () => controller.toggleSubscription(feed.id),
-              ),
-            ],
           ],
         );
       }));
@@ -317,18 +308,31 @@ class _ProfileViewState extends State<ProfileView> {
         ],
       ),
       extendBodyBehindAppBar: true,
-      floatingActionButton: controller.isCurrentUser &&
-              controller.feeds.isNotEmpty
-          ? FloatingActionButton.extended(
-              heroTag: 'edit_feed_fab',
-              onPressed: () => Get.toNamed(
-                AppRoutes.editFeed,
-                arguments: controller.feeds[controller.selectedFeedIndex.value],
-              ),
-              icon: const Icon(Icons.edit),
-              label: Text('editFeed'.tr),
-            )
-          : null,
+      floatingActionButton: controller.feeds.isEmpty
+          ? null
+          : Obx(() {
+              if (controller.isCurrentUser) {
+                return FloatingActionButton.extended(
+                  heroTag: 'edit_feed_fab',
+                  onPressed: () => Get.toNamed(
+                    AppRoutes.editFeed,
+                    arguments:
+                        controller.feeds[controller.selectedFeedIndex.value],
+                  ),
+                  icon: const Icon(Icons.edit),
+                  label: Text('editFeed'.tr),
+                );
+              }
+              final feedId =
+                  controller.feeds[controller.selectedFeedIndex.value].id;
+              final subscribed = controller.isSubscribed(feedId);
+              return FloatingActionButton.extended(
+                heroTag: 'sub_fab',
+                onPressed: () => controller.toggleSubscription(feedId),
+                icon: Icon(subscribed ? Icons.check : Icons.add),
+                label: Text(subscribed ? 'unsubscribe'.tr : 'subscribe'.tr),
+              );
+            }),
       body: buildBody(context),
     );
   }

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -1,0 +1,45 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class SubscriptionService {
+  final FirebaseFirestore _firestore;
+
+  SubscriptionService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  Future<Set<String>> fetchSubscriptions(String userId) async {
+    final snapshot = await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('subscriptions')
+        .get();
+    return snapshot.docs.map((d) => d.id).toSet();
+  }
+
+  Future<void> subscribe(String userId, String feedId) async {
+    final userSubRef = _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('subscriptions')
+        .doc(feedId);
+    final feedRef = _firestore.collection('feeds').doc(feedId);
+
+    await _firestore.runTransaction((txn) async {
+      txn.set(userSubRef, {'createdAt': FieldValue.serverTimestamp()});
+      txn.update(feedRef, {'subscriberCount': FieldValue.increment(1)});
+    });
+  }
+
+  Future<void> unsubscribe(String userId, String feedId) async {
+    final userSubRef = _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('subscriptions')
+        .doc(feedId);
+    final feedRef = _firestore.collection('feeds').doc(feedId);
+
+    await _firestore.runTransaction((txn) async {
+      txn.delete(userSubRef);
+      txn.update(feedRef, {'subscriberCount': FieldValue.increment(-1)});
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- create `SubscriptionService` for managing subscriptions in Firestore
- register `SubscriptionService` in `DependencyInjector`
- fetch current user's subscriptions in `ProfileController`
- implement real subscribe/unsubscribe logic with error handling
- show a floating action button to subscribe/unsubscribe to the selected feed

## Testing
- `flutter test` *(fails: TestDeviceException)*

------
https://chatgpt.com/codex/tasks/task_e_68876cf240f08328945788e6a6ebe169