### PR TITLE
Implement subscriptions page

### DIFF
--- a/lib/pages/settings/views/settings_view.dart
+++ b/lib/pages/settings/views/settings_view.dart
@@ -49,6 +49,10 @@ class SettingsView extends GetView<SettingsController> {
             onTap: controller.findFriends,
           ),
           ListTile(
+            title: Text('subscriptions'.tr),
+            onTap: () => Get.toNamed(AppRoutes.subscriptions),
+          ),
+          ListTile(
             title: Text('termsOfService'.tr),
             onTap: () => Get.toNamed(AppRoutes.terms),
           ),

--- a/lib/pages/subscriptions/controllers/subscriptions_controller.dart
+++ b/lib/pages/subscriptions/controllers/subscriptions_controller.dart
@@ -1,3 +1,47 @@
 import 'package:get/get.dart';
 
-class SubscriptionsController extends GetxController {}
+import '../../../models/feed.dart';
+import '../../../services/auth_service.dart';
+import '../../../services/subscription_service.dart';
+
+/// Controller that loads the feeds the current user is subscribed to.
+class SubscriptionsController extends GetxController {
+  final AuthService _authService;
+  final SubscriptionService _subscriptionService;
+
+  SubscriptionsController({
+    AuthService? authService,
+    SubscriptionService? subscriptionService,
+  })  : _authService = authService ?? Get.find<AuthService>(),
+        _subscriptionService =
+            subscriptionService ?? Get.find<SubscriptionService>();
+
+  final RxList<Feed> feeds = <Feed>[].obs;
+  final RxBool loading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadFeeds();
+  }
+
+  Future<void> _loadFeeds() async {
+    final userId = _authService.currentUser?.uid;
+    if (userId == null) return;
+    loading.value = true;
+    try {
+      final result = await _subscriptionService.fetchSubscribedFeeds(userId);
+      feeds.assignAll(result);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  /// Unsubscribes from [feedId] and updates the local list.
+  Future<void> unsubscribeFeed(String feedId) async {
+    final userId = _authService.currentUser?.uid;
+    if (userId == null) return;
+    await _subscriptionService.unsubscribe(userId, feedId);
+    feeds.removeWhere((f) => f.id == feedId);
+  }
+}

--- a/lib/pages/subscriptions/views/subscriptions_view.dart
+++ b/lib/pages/subscriptions/views/subscriptions_view.dart
@@ -1,5 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+
+import '../../../components/avatar_component.dart';
+import '../../../components/list_item_component.dart';
+import '../../../components/empty_message.dart';
+import '../../../util/routes/app_routes.dart';
 import '../controllers/subscriptions_controller.dart';
 
 class SubscriptionsView extends GetView<SubscriptionsController> {
@@ -11,9 +16,44 @@ class SubscriptionsView extends GetView<SubscriptionsController> {
       appBar: AppBar(
         title: Text('subscriptions'.tr),
       ),
-      body: Center(
-        child: Text('subscriptions'.tr),
-      ),
+      body: Obx(() {
+        if (controller.loading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.feeds.isEmpty) {
+          return NothingToShowComponent(
+            icon: const Icon(Icons.feed_outlined),
+            text: 'numberOfSubscriptions'.trParams({'count': '0'}),
+          );
+        }
+        return ListView.builder(
+          itemCount: controller.feeds.length,
+          itemBuilder: (context, index) {
+            final feed = controller.feeds[index];
+            return GestureDetector(
+              onTap: () => Get.toNamed(
+                AppRoutes.profile,
+                arguments: {'uid': feed.userId, 'feedId': feed.id},
+              ),
+              child: ListItemComponent(
+                leading: ProfileAvatarComponent(
+                  image: feed.imageUrl ?? '',
+                  size: 100,
+                  radius: 25,
+                ),
+                title: feed.title,
+                subtitle:
+                    '${feed.subscriberCount ?? 0} ${'followers'.tr}',
+                trailing: IconButton(
+                  icon: const Icon(Icons.cancel),
+                  tooltip: 'unsubscribe'.tr,
+                  onPressed: () => controller.unsubscribeFeed(feed.id),
+                ),
+              ),
+            );
+          },
+        );
+      }),
     );
   }
 }

--- a/test/subscriptions_view_test.dart
+++ b/test/subscriptions_view_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'package:hoot/pages/subscriptions/controllers/subscriptions_controller.dart';
+import 'package:hoot/pages/subscriptions/views/subscriptions_view.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/util/translations/app_translations.dart';
+import 'package:hoot/models/user.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U _user;
+  FakeAuthService(this._user);
+
+  @override
+  U? get currentUser => _user;
+
+  @override
+  Future<U?> fetchUser() async => _user;
+
+  @override
+  Future<U?> fetchUserById(String uid) async => _user;
+
+  @override
+  Future<U?> fetchUserByUsername(String username) async => _user;
+
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAccount() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('SubscriptionsView shows subscribed feeds', (tester) async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('feeds').doc('f1').set({
+      'title': 'Feed 1',
+      'description': 'd',
+      'color': '0',
+      'userId': 'u1',
+      'subscriberCount': 1,
+    });
+    await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+    await firestore
+        .collection('users')
+        .doc('u1')
+        .collection('subscriptions')
+        .doc('f1')
+        .set({'createdAt': Timestamp.now()});
+    final auth = FakeAuthService(U(uid: 'u1'));
+    final service = SubscriptionService(firestore: firestore);
+    final controller = SubscriptionsController(
+      authService: auth,
+      subscriptionService: service,
+    );
+    Get.put<AuthService>(auth);
+    Get.put<SubscriptionsController>(controller);
+
+    await tester.pumpWidget(GetMaterialApp(
+      translations: AppTranslations(),
+      locale: const Locale('en'),
+      home: const SubscriptionsView(),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Feed 1'), findsOneWidget);
+
+    Get.reset();
+  });
+
+  testWidgets('tapping unsubscribe removes feed', (tester) async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('feeds').doc('f1').set({
+      'title': 'Feed 1',
+      'description': 'd',
+      'color': '0',
+      'userId': 'u1',
+      'subscriberCount': 1,
+    });
+    await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+    await firestore
+        .collection('users')
+        .doc('u1')
+        .collection('subscriptions')
+        .doc('f1')
+        .set({'createdAt': Timestamp.now()});
+    final auth = FakeAuthService(U(uid: 'u1'));
+    final service = SubscriptionService(firestore: firestore);
+    final controller = SubscriptionsController(
+      authService: auth,
+      subscriptionService: service,
+    );
+    Get.put<AuthService>(auth);
+    Get.put<SubscriptionsController>(controller);
+
+    await tester.pumpWidget(GetMaterialApp(
+      translations: AppTranslations(),
+      locale: const Locale('en'),
+      home: const SubscriptionsView(),
+    ));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.cancel));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Feed 1'), findsNothing);
+
+    Get.reset();
+  });
+}
+


### PR DESCRIPTION
## Summary
- extend `SubscriptionService` with feed fetching and removing from subscribers
- implement `SubscriptionsController` to manage subscription data
- build `SubscriptionsView` with unsubscribe actions
- link subscriptions page from settings
- test subscriptions view behaviour

## Testing
- `flutter pub get`
- `flutter test` *(fails: FeedView shows posts from controller, others pass)*

------
https://chatgpt.com/codex/tasks/task_e_68877f444ae48328a4fb5124fe462388