### PR TITLE
Add subscriber management features

### DIFF
--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -306,6 +306,28 @@ class _ProfileViewState extends State<ProfileView> {
                         ),
                 ),
               ),
+              if (controller.isCurrentUser && controller.feeds.isNotEmpty)
+                Padding(
+                  padding: const EdgeInsets.only(right: 16),
+                  child: LiquidGlass(
+                    settings: LiquidGlassSettings(
+                      blur: 4,
+                      glassColor:
+                          Theme.of(context).colorScheme.surface.withAlpha(50),
+                    ),
+                    shape: LiquidOval(),
+                    glassContainsChild: false,
+                    child: IconButton(
+                      icon: const Icon(Icons.group),
+                      color: Colors.white,
+                      onPressed: () => Get.toNamed(
+                        AppRoutes.subscribers,
+                        arguments: controller
+                            .feeds[controller.selectedFeedIndex.value].id,
+                      ),
+                    ),
+                  ),
+                ),
             ],
           ),
           extendBodyBehindAppBar: true,

--- a/lib/pages/subscribers/controllers/subscribers_controller.dart
+++ b/lib/pages/subscribers/controllers/subscribers_controller.dart
@@ -1,3 +1,43 @@
 import 'package:get/get.dart';
 
-class SubscribersController extends GetxController {}
+import '../../../models/user.dart';
+import '../../../services/subscription_service.dart';
+
+class SubscribersController extends GetxController {
+  final SubscriptionService _subscriptionService;
+
+  SubscribersController({SubscriptionService? subscriptionService})
+      : _subscriptionService =
+            subscriptionService ?? Get.find<SubscriptionService>();
+
+  late String feedId;
+  final RxList<U> subscribers = <U>[].obs;
+  final RxBool loading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    feedId = Get.arguments as String;
+    loadSubscribers();
+  }
+
+  Future<void> loadSubscribers() async {
+    loading.value = true;
+    try {
+      final result = await _subscriptionService.fetchSubscribers(feedId);
+      subscribers.assignAll(result);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  Future<void> removeSubscriber(String userId) async {
+    await _subscriptionService.removeSubscriber(feedId, userId);
+    subscribers.removeWhere((u) => u.uid == userId);
+  }
+
+  Future<void> banSubscriber(String userId) async {
+    await _subscriptionService.banSubscriber(feedId, userId);
+    subscribers.removeWhere((u) => u.uid == userId);
+  }
+}

--- a/lib/pages/subscribers/views/subscribers_view.dart
+++ b/lib/pages/subscribers/views/subscribers_view.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/subscribers_controller.dart';
+import '../../../components/avatar_component.dart';
+import '../../../components/name_component.dart';
+import '../../../components/empty_message.dart';
+import '../../../util/routes/app_routes.dart';
 
 class SubscribersView extends GetView<SubscribersController> {
   const SubscribersView({super.key});
@@ -11,9 +15,45 @@ class SubscribersView extends GetView<SubscribersController> {
       appBar: AppBar(
         title: Text('subscribers'.tr),
       ),
-      body: Center(
-        child: Text('subscribers'.tr),
-      ),
+      body: Obx(() {
+        if (controller.loading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.subscribers.isEmpty) {
+          return NothingToShowComponent(
+            icon: const Icon(Icons.person_outline),
+            text: 'numberOfSubscribers'.trParams({'count': '0'}),
+          );
+        }
+        return ListView.builder(
+          itemCount: controller.subscribers.length,
+          itemBuilder: (context, index) {
+            final user = controller.subscribers[index];
+            return ListTile(
+              onTap: () => Get.toNamed(AppRoutes.profile, arguments: user.uid),
+              leading: ProfileAvatarComponent(
+                image: user.smallProfilePictureUrl ?? '',
+                size: 40,
+                radius: 20,
+              ),
+              title: NameComponent(user: user, size: 16),
+              trailing: PopupMenuButton<String>(
+                onSelected: (value) {
+                  if (value == 'remove') {
+                    controller.removeSubscriber(user.uid);
+                  } else if (value == 'ban') {
+                    controller.banSubscriber(user.uid);
+                  }
+                },
+                itemBuilder: (_) => [
+                  PopupMenuItem(value: 'remove', child: Text('remove'.tr)),
+                  PopupMenuItem(value: 'ban', child: Text('ban'.tr)),
+                ],
+              ),
+            );
+          },
+        );
+      }),
     );
   }
 }

--- a/test/create_feed_controller_test.dart
+++ b/test/create_feed_controller_test.dart
@@ -11,6 +11,7 @@ import 'package:hoot/pages/profile/controllers/profile_controller.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/models/user.dart';
 import 'package:hoot/services/feed_service.dart';
+import 'package:hoot/services/subscription_service.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class FakeAuthService extends GetxService implements AuthService {
@@ -132,11 +133,14 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     final user = U(uid: 'u1', feeds: []);
     final auth = FakeAuthService(user);
+    final subService = SubscriptionService(firestore: firestore);
     final profile = ProfileController(
       authService: auth,
       feedService: FakeFeedService(),
+      subscriptionService: subService,
     );
     Get.put<AuthService>(auth);
+    Get.put<SubscriptionService>(subService);
     Get.put<ProfileController>(profile);
 
     final controller =

--- a/test/subscription_service_test.dart
+++ b/test/subscription_service_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:hoot/services/subscription_service.dart';
+
+void main() {
+  group('SubscriptionService', () {
+    test('removeSubscriber deletes docs and decrements count', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = SubscriptionService(firestore: firestore);
+      await firestore.collection('feeds').doc('f1').set({'subscriberCount': 1});
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+      await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('subscriptions')
+          .doc('f1')
+          .set({'createdAt': Timestamp.now()});
+      await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('subscribers')
+          .doc('u1')
+          .set({'createdAt': Timestamp.now()});
+
+      await service.removeSubscriber('f1', 'u1');
+
+      final userSub = await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('subscriptions')
+          .doc('f1')
+          .get();
+      final feedSub = await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('subscribers')
+          .doc('u1')
+          .get();
+      final feed = await firestore.collection('feeds').doc('f1').get();
+
+      expect(userSub.exists, isFalse);
+      expect(feedSub.exists, isFalse);
+      expect(feed.get('subscriberCount'), 0);
+    });
+
+    test('banSubscriber moves user to banned list', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = SubscriptionService(firestore: firestore);
+      await firestore.collection('feeds').doc('f1').set({'subscriberCount': 1});
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+      await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('subscriptions')
+          .doc('f1')
+          .set({'createdAt': Timestamp.now()});
+      await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('subscribers')
+          .doc('u1')
+          .set({'createdAt': Timestamp.now()});
+
+      await service.banSubscriber('f1', 'u1');
+
+      final banned = await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('banned')
+          .doc('u1')
+          .get();
+      final feed = await firestore.collection('feeds').doc('f1').get();
+
+      expect(banned.exists, isTrue);
+      expect(feed.get('subscriberCount'), 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- expand subscription service with subscriber subcollection support
- add subscriber fetch/remove/ban methods
- implement SubscribersController and SubscribersView
- expose Subscribers page from profile view
- add unit tests for new subscription logic
- fix tests to provide SubscriptionService

## Testing
- `flutter test test/subscription_service_test.dart`
- `flutter test test/create_feed_controller_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688783e545188328a72e4637edebab93