### PR TITLE
Add subscriber removal/ban translations and confirmations

### DIFF
--- a/lib/pages/subscribers/views/subscribers_view.dart
+++ b/lib/pages/subscribers/views/subscribers_view.dart
@@ -5,6 +5,7 @@ import '../../../components/avatar_component.dart';
 import '../../../components/name_component.dart';
 import '../../../components/empty_message.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../../services/dialog_service.dart';
 
 class SubscribersView extends GetView<SubscribersController> {
   const SubscribersView({super.key});
@@ -38,16 +39,35 @@ class SubscribersView extends GetView<SubscribersController> {
               ),
               title: NameComponent(user: user, size: 16),
               trailing: PopupMenuButton<String>(
-                onSelected: (value) {
+                onSelected: (value) async {
                   if (value == 'remove') {
-                    controller.removeSubscriber(user.uid);
+                    final confirmed = await DialogService.confirm(
+                      context: context,
+                      title: 'removeSubscriber'.tr,
+                      message: 'removeSubscriberConfirmation'.tr,
+                      okLabel: 'removeSubscriber'.tr,
+                      cancelLabel: 'cancel'.tr,
+                    );
+                    if (confirmed) {
+                      controller.removeSubscriber(user.uid);
+                    }
                   } else if (value == 'ban') {
-                    controller.banSubscriber(user.uid);
+                    final confirmed = await DialogService.confirm(
+                      context: context,
+                      title: 'banSubscriber'.tr,
+                      message: 'banSubscriberConfirmation'.tr,
+                      okLabel: 'banSubscriber'.tr,
+                      cancelLabel: 'cancel'.tr,
+                    );
+                    if (confirmed) {
+                      controller.banSubscriber(user.uid);
+                    }
                   }
                 },
                 itemBuilder: (_) => [
-                  PopupMenuItem(value: 'remove', child: Text('remove'.tr)),
-                  PopupMenuItem(value: 'ban', child: Text('ban'.tr)),
+                  PopupMenuItem(
+                      value: 'remove', child: Text('removeSubscriber'.tr)),
+                  PopupMenuItem(value: 'ban', child: Text('banSubscriber'.tr)),
                 ],
               ),
             );

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -143,6 +143,12 @@ class AppTranslations extends Translations {
           'editFeed': 'Edit Feed',
           'unsubscriber': ' @{username} unsubscribed from {feedName}',
           'privateFeedRequest': '@{username} requested to join {feedName}',
+          'removeSubscriber': 'Remove subscriber',
+          'banSubscriber': 'Ban subscriber',
+          'removeSubscriberConfirmation':
+              'Are you sure you want to remove this subscriber?',
+          'banSubscriberConfirmation':
+              'Are you sure you want to ban this subscriber?',
           'comingSoon': 'Coming soon!',
           'numberOfSubscriptions':
               '{count, plural, =0 {No subscriptions} one {1 subscription} other {{count} subscriptions}}',
@@ -468,6 +474,12 @@ class AppTranslations extends Translations {
           'editFeed': 'Editar Feed',
           'unsubscriber': ' @{username} canceló la suscripción a {feedName}',
           'privateFeedRequest': '@{username} solicitó unirse a {feedName}',
+          'removeSubscriber': 'Eliminar suscriptor',
+          'banSubscriber': 'Prohibir suscriptor',
+          'removeSubscriberConfirmation':
+              '¿Estás seguro de que deseas eliminar a este suscriptor?',
+          'banSubscriberConfirmation':
+              '¿Estás seguro de que deseas prohibir a este suscriptor?',
           'comingSoon': '¡Próximamente!',
           'numberOfSubscriptions':
               '{count, plural, =0 {No hay suscripciones} one {1 suscripción} other {{count} suscripciones}}',
@@ -797,6 +809,12 @@ class AppTranslations extends Translations {
           'editFeed': 'Editar Feed',
           'unsubscriber': ' @{username} cancelou a subscrição de {feedName}',
           'privateFeedRequest': '@{username} pediu para aderir a {feedName}',
+          'removeSubscriber': 'Remover subscritor',
+          'banSubscriber': 'Banir subscritor',
+          'removeSubscriberConfirmation':
+              'Tens a certeza de que queres remover este subscritor?',
+          'banSubscriberConfirmation':
+              'Tens a certeza de que queres banir este subscritor?',
           'comingSoon': 'Em Breve!',
           'numberOfSubscriptions':
               '{count, plural, =0 {Sem subscrições} one {1 subscrição} other {{count} subscrições}}',
@@ -1122,6 +1140,12 @@ class AppTranslations extends Translations {
           'unsubscriber': ' @{username} cancelou a inscrição em {feedName}',
           'privateFeedRequest':
               '@{username} solicitou participação em {feedName}',
+          'removeSubscriber': 'Remover inscrito',
+          'banSubscriber': 'Banir inscrito',
+          'removeSubscriberConfirmation':
+              'Tem certeza de que deseja remover este inscrito?',
+          'banSubscriberConfirmation':
+              'Tem certeza de que deseja banir este inscrito?',
           'comingSoon': 'Em Breve!',
           'numberOfSubscriptions':
               '{count, plural, =0 {Sem inscrições} one {1 inscrição} other {{count} inscrições}}',


### PR DESCRIPTION
## Summary
- add translations for removing/banning subscribers in all languages
- confirm before removing or banning subscribers
- update subscribers view buttons to use new keys

## Testing
- `flutter test` *(fails: Multiple exceptions in feed_view_test)*

------
https://chatgpt.com/codex/tasks/task_e_688789dd696c8328a72bca5abb6a999c