### PR TITLE
Implement feed join request workflow

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -4,6 +4,7 @@ import 'services/feed_service.dart';
 import 'services/theme_service.dart';
 import 'services/post_service.dart';
 import 'services/subscription_service.dart';
+import 'services/feed_request_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -16,6 +17,7 @@ class DependencyInjector {
     Get.put<BaseFeedService>(FeedService(), permanent: true);
     Get.put<BasePostService>(PostService(), permanent: true);
     Get.put(SubscriptionService(), permanent: true);
+    Get.put(FeedRequestService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeMode();
   }

--- a/lib/pages/feed_requests/controllers/feed_requests_controller.dart
+++ b/lib/pages/feed_requests/controllers/feed_requests_controller.dart
@@ -1,3 +1,47 @@
 import 'package:get/get.dart';
 
-class FeedRequestsController extends GetxController {}
+import '../../../models/user.dart';
+import '../../../services/feed_request_service.dart';
+import '../../../util/routes/app_routes.dart';
+
+class FeedRequestsController extends GetxController {
+  final FeedRequestService _service;
+
+  FeedRequestsController({FeedRequestService? service})
+      : _service = service ?? Get.find<FeedRequestService>();
+
+  late String feedId;
+  final RxList<U> requests = <U>[].obs;
+  final RxBool loading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    feedId = Get.arguments as String;
+    loadRequests();
+  }
+
+  Future<void> loadRequests() async {
+    loading.value = true;
+    try {
+      final result = await _service.fetchRequests(feedId);
+      requests.assignAll(result);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  Future<void> accept(String userId) async {
+    await _service.accept(feedId, userId);
+    requests.removeWhere((u) => u.uid == userId);
+  }
+
+  Future<void> reject(String userId) async {
+    await _service.reject(feedId, userId);
+    requests.removeWhere((u) => u.uid == userId);
+  }
+
+  void openProfile(String userId) {
+    Get.toNamed(AppRoutes.profile, arguments: userId);
+  }
+}

--- a/lib/pages/feed_requests/views/feed_requests_view.dart
+++ b/lib/pages/feed_requests/views/feed_requests_view.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/feed_requests_controller.dart';
+import '../../../components/avatar_component.dart';
+import '../../../components/name_component.dart';
+import '../../../components/empty_message.dart';
 
 class FeedRequestsView extends GetView<FeedRequestsController> {
   const FeedRequestsView({super.key});
@@ -11,9 +14,47 @@ class FeedRequestsView extends GetView<FeedRequestsController> {
       appBar: AppBar(
         title: Text('feedRequests'.tr),
       ),
-      body: Center(
-        child: Text('feedRequests'.tr),
-      ),
+      body: Obx(() {
+        if (controller.loading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.requests.isEmpty) {
+          return NothingToShowComponent(
+            icon: const Icon(Icons.person_outline),
+            text: 'numberOfRequests'.trParams({'numberOfRequests': '0'}),
+          );
+        }
+        return ListView.builder(
+          itemCount: controller.requests.length,
+          itemBuilder: (context, index) {
+            final user = controller.requests[index];
+            return ListTile(
+              onTap: () => controller.openProfile(user.uid),
+              leading: ProfileAvatarComponent(
+                image: user.smallProfilePictureUrl ?? '',
+                size: 40,
+                radius: 20,
+              ),
+              title: NameComponent(user: user, size: 16),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.check),
+                    tooltip: 'approve'.tr,
+                    onPressed: () => controller.accept(user.uid),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    tooltip: 'reject'.tr,
+                    onPressed: () => controller.reject(user.uid),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      }),
     );
   }
 }

--- a/lib/services/feed_request_service.dart
+++ b/lib/services/feed_request_service.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:get/get.dart';
+
+import 'auth_service.dart';
+import 'subscription_service.dart';
+import '../models/user.dart';
+
+class FeedRequestService {
+  final FirebaseFirestore _firestore;
+  final SubscriptionService _subscriptionService;
+
+  FeedRequestService(
+      {FirebaseFirestore? firestore, SubscriptionService? subscriptionService})
+      : _firestore = firestore ?? FirebaseFirestore.instance,
+        _subscriptionService =
+            subscriptionService ?? Get.find<SubscriptionService>();
+
+  Future<void> submit(String feedId, String userId) async {
+    final requestRef = _firestore
+        .collection('feeds')
+        .doc(feedId)
+        .collection('requests')
+        .doc(userId);
+    final feedRef = _firestore.collection('feeds').doc(feedId);
+    await _firestore.runTransaction((txn) async {
+      txn.set(requestRef, {'createdAt': FieldValue.serverTimestamp()});
+      txn.update(feedRef, {'requestCount': FieldValue.increment(1)});
+    });
+  }
+
+  Future<void> accept(String feedId, String userId) async {
+    await _subscriptionService.subscribe(userId, feedId);
+    final requestRef = _firestore
+        .collection('feeds')
+        .doc(feedId)
+        .collection('requests')
+        .doc(userId);
+    final feedRef = _firestore.collection('feeds').doc(feedId);
+    await _firestore.runTransaction((txn) async {
+      txn.delete(requestRef);
+      txn.update(feedRef, {'requestCount': FieldValue.increment(-1)});
+    });
+  }
+
+  Future<void> reject(String feedId, String userId) async {
+    final requestRef = _firestore
+        .collection('feeds')
+        .doc(feedId)
+        .collection('requests')
+        .doc(userId);
+    final feedRef = _firestore.collection('feeds').doc(feedId);
+    await _firestore.runTransaction((txn) async {
+      txn.delete(requestRef);
+      txn.update(feedRef, {'requestCount': FieldValue.increment(-1)});
+    });
+  }
+
+  Future<List<U>> fetchRequests(String feedId) async {
+    final snapshot = await _firestore
+        .collection('feeds')
+        .doc(feedId)
+        .collection('requests')
+        .get();
+    final ids = snapshot.docs.map((d) => d.id).toList();
+    if (ids.isEmpty) return [];
+    final usersSnapshot = await _firestore
+        .collection('users')
+        .where(FieldPath.documentId, whereIn: ids)
+        .get();
+    return usersSnapshot.docs
+        .map((d) => U.fromJson({'uid': d.id, ...d.data()}))
+        .toList();
+  }
+}

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -140,6 +140,9 @@ class AppTranslations extends Translations {
               '{numberOfRequests, plural, =0 {No requests} one {# request} other {# requests}}',
           'errorRequestingToJoin':
               'There was an error requesting to join this feed',
+          'feedRequests': 'Feed Requests',
+          'approve': 'Approve',
+          'reject': 'Reject',
           'editFeed': 'Edit Feed',
           'unsubscriber': ' @{username} unsubscribed from {feedName}',
           'privateFeedRequest': '@{username} requested to join {feedName}',
@@ -471,6 +474,9 @@ class AppTranslations extends Translations {
               '{numberOfRequests, plural, =0 {No hay solicitudes} one {# solicitud} other {# solicitudes}}',
           'errorRequestingToJoin':
               'Hubo un error al solicitar unirse a este feed',
+          'feedRequests': 'Solicitudes',
+          'approve': 'Aprobar',
+          'reject': 'Rechazar',
           'editFeed': 'Editar Feed',
           'unsubscriber': ' @{username} canceló la suscripción a {feedName}',
           'privateFeedRequest': '@{username} solicitó unirse a {feedName}',
@@ -806,6 +812,9 @@ class AppTranslations extends Translations {
               '{numberOfRequests, plural, =0 {Sem pedidos} one {# pedido} other {# pedidos}}',
           'errorRequestingToJoin':
               'Ocorreu um erro ao pedir para aderir a este feed',
+          'feedRequests': 'Pedidos',
+          'approve': 'Aprovar',
+          'reject': 'Rejeitar',
           'editFeed': 'Editar Feed',
           'unsubscriber': ' @{username} cancelou a subscrição de {feedName}',
           'privateFeedRequest': '@{username} pediu para aderir a {feedName}',
@@ -1136,6 +1145,9 @@ class AppTranslations extends Translations {
           'numberOfRequests':
               '{numberOfRequests, plural, =0 {Sem solicitações} one {# solicitação} other {# solicitações}}',
           'errorRequestingToJoin': 'Erro ao solicitar participação neste feed',
+          'feedRequests': 'Solicitações',
+          'approve': 'Aprovar',
+          'reject': 'Rejeitar',
           'editFeed': 'Editar Feed',
           'unsubscriber': ' @{username} cancelou a inscrição em {feedName}',
           'privateFeedRequest':

--- a/test/feed_request_service_test.dart
+++ b/test/feed_request_service_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/subscription_service.dart';
+
+void main() {
+  group('FeedRequestService', () {
+    test('submit creates request and increments count', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = FeedRequestService(
+        firestore: firestore,
+        subscriptionService: SubscriptionService(firestore: firestore),
+      );
+      await firestore.collection('feeds').doc('f1').set({'requestCount': 0});
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+
+      await service.submit('f1', 'u1');
+
+      final req = await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('requests')
+          .doc('u1')
+          .get();
+      final feed = await firestore.collection('feeds').doc('f1').get();
+
+      expect(req.exists, isTrue);
+      expect(feed.get('requestCount'), 1);
+    });
+
+    test('accept subscribes user and removes request', () async {
+      final firestore = FakeFirebaseFirestore();
+      final subscriptionService = SubscriptionService(firestore: firestore);
+      final service = FeedRequestService(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+      );
+      await firestore.collection('feeds').doc('f1').set({
+        'requestCount': 1,
+        'subscriberCount': 0,
+      });
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+      await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('requests')
+          .doc('u1')
+          .set({'createdAt': Timestamp.now()});
+
+      await service.accept('f1', 'u1');
+
+      final req = await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('requests')
+          .doc('u1')
+          .get();
+      final feed = await firestore.collection('feeds').doc('f1').get();
+      final userSub = await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('subscriptions')
+          .doc('f1')
+          .get();
+      final feedSub = await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('subscribers')
+          .doc('u1')
+          .get();
+
+      expect(req.exists, isFalse);
+      expect(feed.get('requestCount'), 0);
+      expect(userSub.exists, isTrue);
+      expect(feedSub.exists, isTrue);
+    });
+
+    test('reject removes request only', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = FeedRequestService(
+        firestore: firestore,
+        subscriptionService: SubscriptionService(firestore: firestore),
+      );
+      await firestore.collection('feeds').doc('f1').set({'requestCount': 1});
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+      await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('requests')
+          .doc('u1')
+          .set({'createdAt': Timestamp.now()});
+
+      await service.reject('f1', 'u1');
+
+      final req = await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('requests')
+          .doc('u1')
+          .get();
+      final feed = await firestore.collection('feeds').doc('f1').get();
+
+      expect(req.exists, isFalse);
+      expect(feed.get('requestCount'), 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `FeedRequestService` to handle join requests
- update dependency injection with new service
- expand `FeedRequestsController` logic
- show pending requests in `FeedRequestsView`
- translate UI strings for approvals
- test `FeedRequestService`

## Testing
- `flutter test test/feed_request_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_6887937beca48328b4f9501799fae9d7