### PR TITLE
Remove unused requestCount

### DIFF
--- a/lib/models/feed.dart
+++ b/lib/models/feed.dart
@@ -16,7 +16,6 @@ class Feed {
   bool? verified;
   FeedType? type;
   final int? subscriberCount;
-  final int? requestCount;
   List<Post>? posts;
 
   Feed(
@@ -32,7 +31,6 @@ class Feed {
       this.verified,
       this.type,
       this.subscriberCount,
-      this.requestCount,
       this.posts});
 
   factory Feed.fromJson(Map<String, dynamic> json) {
@@ -52,7 +50,6 @@ class Feed {
       nsfw: json['nsfw'],
       verified: json['verified'],
       subscriberCount: json['subscriberCount'],
-      requestCount: json['requestCount'],
       posts: json['posts'] != null
           ? (json['posts'] as List).map((i) => Post.fromJson(i)).toList()
           : null,
@@ -82,7 +79,6 @@ class Feed {
         'private': private,
         'nsfw': nsfw,
         'verified': verified,
-        'subscriberCount': subscriberCount,
-        'requestCount': requestCount
+        'subscriberCount': subscriberCount
       };
 }

--- a/lib/services/feed_request_service.dart
+++ b/lib/services/feed_request_service.dart
@@ -20,10 +20,8 @@ class FeedRequestService {
         .doc(feedId)
         .collection('requests')
         .doc(userId);
-    final feedRef = _firestore.collection('feeds').doc(feedId);
     await _firestore.runTransaction((txn) async {
       txn.set(requestRef, {'createdAt': FieldValue.serverTimestamp()});
-      txn.update(feedRef, {'requestCount': FieldValue.increment(1)});
     });
   }
 
@@ -34,10 +32,8 @@ class FeedRequestService {
         .doc(feedId)
         .collection('requests')
         .doc(userId);
-    final feedRef = _firestore.collection('feeds').doc(feedId);
     await _firestore.runTransaction((txn) async {
       txn.delete(requestRef);
-      txn.update(feedRef, {'requestCount': FieldValue.increment(-1)});
     });
   }
 
@@ -47,10 +43,8 @@ class FeedRequestService {
         .doc(feedId)
         .collection('requests')
         .doc(userId);
-    final feedRef = _firestore.collection('feeds').doc(feedId);
     await _firestore.runTransaction((txn) async {
       txn.delete(requestRef);
-      txn.update(feedRef, {'requestCount': FieldValue.increment(-1)});
     });
   }
 

--- a/test/feed_request_service_test.dart
+++ b/test/feed_request_service_test.dart
@@ -7,13 +7,13 @@ import 'package:hoot/services/subscription_service.dart';
 
 void main() {
   group('FeedRequestService', () {
-    test('submit creates request and increments count', () async {
+    test('submit creates request document', () async {
       final firestore = FakeFirebaseFirestore();
       final service = FeedRequestService(
         firestore: firestore,
         subscriptionService: SubscriptionService(firestore: firestore),
       );
-      await firestore.collection('feeds').doc('f1').set({'requestCount': 0});
+      await firestore.collection('feeds').doc('f1').set({});
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
 
       await service.submit('f1', 'u1');
@@ -24,10 +24,7 @@ void main() {
           .collection('requests')
           .doc('u1')
           .get();
-      final feed = await firestore.collection('feeds').doc('f1').get();
-
       expect(req.exists, isTrue);
-      expect(feed.get('requestCount'), 1);
     });
 
     test('accept subscribes user and removes request', () async {
@@ -38,7 +35,6 @@ void main() {
         subscriptionService: subscriptionService,
       );
       await firestore.collection('feeds').doc('f1').set({
-        'requestCount': 1,
         'subscriberCount': 0,
       });
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
@@ -57,7 +53,6 @@ void main() {
           .collection('requests')
           .doc('u1')
           .get();
-      final feed = await firestore.collection('feeds').doc('f1').get();
       final userSub = await firestore
           .collection('users')
           .doc('u1')
@@ -72,7 +67,6 @@ void main() {
           .get();
 
       expect(req.exists, isFalse);
-      expect(feed.get('requestCount'), 0);
       expect(userSub.exists, isTrue);
       expect(feedSub.exists, isTrue);
     });
@@ -83,7 +77,7 @@ void main() {
         firestore: firestore,
         subscriptionService: SubscriptionService(firestore: firestore),
       );
-      await firestore.collection('feeds').doc('f1').set({'requestCount': 1});
+      await firestore.collection('feeds').doc('f1').set({});
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
       await firestore
           .collection('feeds')
@@ -100,10 +94,8 @@ void main() {
           .collection('requests')
           .doc('u1')
           .get();
-      final feed = await firestore.collection('feeds').doc('f1').get();
 
       expect(req.exists, isFalse);
-      expect(feed.get('requestCount'), 0);
     });
   });
 }

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -76,7 +76,6 @@ void main() {
         'nsfw': false,
         'verified': true,
         'subscriberCount': 5,
-        'requestCount': 1,
         'posts': [
           {'id': 'p1'}
         ]


### PR DESCRIPTION
## Summary
- drop `requestCount` from `Feed`
- remove request count logic from `FeedRequestService`
- update tests to match new behavior

## Testing
- `flutter test test/models_test.dart`
- `flutter test test/feed_request_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_6887a0830f108328be20bf2e0ed924bc