### PR TITLE
Add subscriber request count and button

### DIFF
--- a/lib/pages/notifications/controllers/notifications_controller.dart
+++ b/lib/pages/notifications/controllers/notifications_controller.dart
@@ -3,25 +3,32 @@ import 'package:get/get.dart';
 import '../../../models/hoot_notification.dart';
 import '../../../services/auth_service.dart';
 import '../../../services/notification_service.dart';
+import '../../../services/feed_request_service.dart';
 
 class NotificationsController extends GetxController {
   final AuthService _authService;
   final BaseNotificationService _notificationService;
+  final FeedRequestService _feedRequestService;
 
   NotificationsController({
     AuthService? authService,
     BaseNotificationService? notificationService,
+    FeedRequestService? feedRequestService,
   })  : _authService = authService ?? Get.find<AuthService>(),
-        _notificationService = notificationService ?? NotificationService();
+        _notificationService = notificationService ?? NotificationService(),
+        _feedRequestService =
+            feedRequestService ?? Get.find<FeedRequestService>();
 
   final RxList<HootNotification> notifications = <HootNotification>[].obs;
   final RxInt unreadCount = 0.obs;
+  final RxInt requestCount = 0.obs;
   final RxBool loading = false.obs;
 
   @override
   void onInit() {
     super.onInit();
     _loadNotifications();
+    _loadRequestCount();
   }
 
   Future<void> _loadNotifications() async {
@@ -35,5 +42,9 @@ class NotificationsController extends GetxController {
     } finally {
       loading.value = false;
     }
+  }
+
+  Future<void> _loadRequestCount() async {
+    requestCount.value = await _feedRequestService.pendingRequestCount();
   }
 }

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/components/avatar_component.dart';
 import 'package:hoot/components/empty_message.dart';
+import '../../../util/routes/app_routes.dart';
 import '../controllers/notifications_controller.dart';
 
 class NotificationsView extends GetView<NotificationsController> {
@@ -18,48 +19,63 @@ class NotificationsView extends GetView<NotificationsController> {
         if (controller.loading.value) {
           return const Center(child: CircularProgressIndicator());
         }
+        Widget list;
         if (controller.notifications.isEmpty) {
-          return NothingToShowComponent(
+          list = NothingToShowComponent(
             icon: const Icon(Icons.notifications_none),
             text: 'noNotifications'.tr,
           );
+        } else {
+          list = ListView.builder(
+            itemCount: controller.notifications.length,
+            itemBuilder: (context, index) {
+              final n = controller.notifications[index];
+              final user = n.user;
+              final feed = n.feed;
+              String text;
+              switch (n.type) {
+                case 0:
+                  text = 'userLikedYourHoot'
+                      .trParams({'username': user.username ?? ''});
+                  break;
+                case 1:
+                  text = 'newComment'.tr;
+                  break;
+                case 2:
+                  text = 'newMention'.tr;
+                  break;
+                case 3:
+                  text = 'newSubscriber'.trParams({
+                    'username': user.username ?? '',
+                    'feedName': feed?.title ?? '',
+                  });
+                  break;
+                default:
+                  text = '';
+              }
+              return ListTile(
+                leading: ProfileAvatarComponent(
+                  image: user.smallProfilePictureUrl ?? '',
+                  size: 40,
+                  radius: 20,
+                ),
+                title: Text(text),
+              );
+            },
+          );
         }
-        return ListView.builder(
-          itemCount: controller.notifications.length,
-          itemBuilder: (context, index) {
-            final n = controller.notifications[index];
-            final user = n.user;
-            final feed = n.feed;
-            String text;
-            switch (n.type) {
-              case 0:
-                text = 'userLikedYourHoot'
-                    .trParams({'username': user.username ?? ''});
-                break;
-              case 1:
-                text = 'newComment'.tr;
-                break;
-              case 2:
-                text = 'newMention'.tr;
-                break;
-              case 3:
-                text = 'newSubscriber'.trParams({
-                  'username': user.username ?? '',
-                  'feedName': feed?.title ?? '',
-                });
-                break;
-              default:
-                text = '';
-            }
-            return ListTile(
-              leading: ProfileAvatarComponent(
-                image: user.smallProfilePictureUrl ?? '',
-                size: 40,
-                radius: 20,
+        return Column(
+          children: [
+            if (controller.requestCount.value > 0)
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: ElevatedButton(
+                  onPressed: () => Get.toNamed(AppRoutes.feedRequests),
+                  child: Text('subscriberRequests'.tr),
+                ),
               ),
-              title: Text(text),
-            );
-          },
+            Expanded(child: list),
+          ],
         );
       }),
     );

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -141,6 +141,7 @@ class AppTranslations extends Translations {
           'errorRequestingToJoin':
               'There was an error requesting to join this feed',
           'feedRequests': 'Feed Requests',
+          'subscriberRequests': 'Subscriber Requests',
           'approve': 'Approve',
           'reject': 'Reject',
           'editFeed': 'Edit Feed',
@@ -475,6 +476,7 @@ class AppTranslations extends Translations {
           'errorRequestingToJoin':
               'Hubo un error al solicitar unirse a este feed',
           'feedRequests': 'Solicitudes',
+          'subscriberRequests': 'Solicitudes de suscriptores',
           'approve': 'Aprobar',
           'reject': 'Rechazar',
           'editFeed': 'Editar Feed',
@@ -813,6 +815,7 @@ class AppTranslations extends Translations {
           'errorRequestingToJoin':
               'Ocorreu um erro ao pedir para aderir a este feed',
           'feedRequests': 'Pedidos',
+          'subscriberRequests': 'Pedidos de subscritores',
           'approve': 'Aprovar',
           'reject': 'Rejeitar',
           'editFeed': 'Editar Feed',
@@ -1146,6 +1149,7 @@ class AppTranslations extends Translations {
               '{numberOfRequests, plural, =0 {Sem solicitações} one {# solicitação} other {# solicitações}}',
           'errorRequestingToJoin': 'Erro ao solicitar participação neste feed',
           'feedRequests': 'Solicitações',
+          'subscriberRequests': 'Solicitações de inscritos',
           'approve': 'Aprovar',
           'reject': 'Rejeitar',
           'editFeed': 'Editar Feed',

--- a/test/create_feed_controller_test.dart
+++ b/test/create_feed_controller_test.dart
@@ -12,6 +12,7 @@ import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/models/user.dart';
 import 'package:hoot/services/feed_service.dart';
 import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/notification_service.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class FakeAuthService extends GetxService implements AuthService {
@@ -56,7 +57,8 @@ class FakeFeedService implements BaseFeedService {
   }
 
   @override
-  Future<PostPage> fetchFeedPosts(String feedId, {DocumentSnapshot? startAfter, int limit = 10}) async {
+  Future<PostPage> fetchFeedPosts(String feedId,
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
     return PostPage(posts: []);
   }
 }
@@ -71,7 +73,8 @@ void main() {
 
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
-    final controller = CreateFeedController(firestore: firestore, userId: 'u1', authService: auth);
+    final controller = CreateFeedController(
+        firestore: firestore, userId: 'u1', authService: auth);
     controller.titleController.text = 'My Feed';
     controller.descriptionController.text = 'Desc';
     controller.selectedType.value = FeedType.music;
@@ -94,7 +97,8 @@ void main() {
 
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
-    final controller = CreateFeedController(firestore: firestore, userId: 'u1', authService: auth);
+    final controller = CreateFeedController(
+        firestore: firestore, userId: 'u1', authService: auth);
     controller.selectedType.value = FeedType.music;
 
     final result = await controller.createFeed();
@@ -113,7 +117,8 @@ void main() {
 
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
-    final controller = CreateFeedController(firestore: firestore, userId: 'u1', authService: auth);
+    final controller = CreateFeedController(
+        firestore: firestore, userId: 'u1', authService: auth);
     controller.titleController.text = 'Feed';
 
     final result = await controller.createFeed();
@@ -133,7 +138,10 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     final user = U(uid: 'u1', feeds: []);
     final auth = FakeAuthService(user);
-    final subService = SubscriptionService(firestore: firestore);
+    final subService = SubscriptionService(
+      firestore: firestore,
+      notificationService: NotificationService(firestore: firestore),
+    );
     final profile = ProfileController(
       authService: auth,
       feedService: FakeFeedService(),
@@ -143,8 +151,11 @@ void main() {
     Get.put<SubscriptionService>(subService);
     Get.put<ProfileController>(profile);
 
-    final controller =
-        CreateFeedController(firestore: firestore, userId: 'u1', authService: auth, profileController: profile);
+    final controller = CreateFeedController(
+        firestore: firestore,
+        userId: 'u1',
+        authService: auth,
+        profileController: profile);
     controller.titleController.text = 'My Feed';
     controller.selectedType.value = FeedType.music;
 
@@ -166,7 +177,8 @@ void main() {
 
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
-    final controller = CreateFeedController(firestore: firestore, userId: 'u1', authService: auth);
+    final controller = CreateFeedController(
+        firestore: firestore, userId: 'u1', authService: auth);
     controller.titleController.text = 'My Feed';
     controller.selectedType.value = FeedType.music;
 
@@ -177,7 +189,11 @@ void main() {
     expect(result, isTrue);
     final feeds = await firestore.collection('feeds').get();
     final feedId = feeds.docs.first.id;
-    final subs = await firestore.collection('users').doc('u1').collection('subscriptions').get();
+    final subs = await firestore
+        .collection('users')
+        .doc('u1')
+        .collection('subscriptions')
+        .get();
     expect(subs.docs.length, 1);
     expect(subs.docs.first.id, feedId);
   });

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -9,6 +9,7 @@ import 'package:hoot/pages/create_post/controllers/create_post_controller.dart';
 import 'package:get/get.dart';
 import 'package:hoot/services/post_service.dart';
 import 'package:hoot/services/storage_service.dart';
+import 'package:hoot/services/notification_service.dart';
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/models/post.dart';
 import 'package:hoot/models/user.dart';
@@ -53,7 +54,9 @@ class FakeStorageService extends GetxService implements BaseStorageService {
   @override
   Future<List<String>> uploadPostImages(String postId, List<File> files) async {
     calls.add(files);
-    return files.map((f) => 'https://example.com/${f.path.split('/').last}').toList();
+    return files
+        .map((f) => 'https://example.com/${f.path.split('/').last}')
+        .toList();
   }
 }
 
@@ -66,16 +69,29 @@ void main() {
         child: MaterialApp(home: Scaffold(body: SizedBox())),
       ));
       final firestore = FakeFirebaseFirestore();
-      final postService = PostService(firestore: firestore);
+      final postService = PostService(
+        firestore: firestore,
+        notificationService: NotificationService(firestore: firestore),
+      );
       final auth = FakeAuthService(U(
           uid: 'u1',
           name: 'Tester',
           username: 'tester',
           smallProfilePictureUrl: 'a.png',
-          feeds: [Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue)]));
+          feeds: [
+            Feed(
+                id: 'f1',
+                userId: 'u1',
+                title: 't',
+                description: 'd',
+                color: Colors.blue)
+          ]));
       final storage = FakeStorageService();
-      final controller =
-          CreatePostController(postService: postService, authService: auth, userId: 'u1', storageService: storage);
+      final controller = CreatePostController(
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
       controller.textController.text = 'Hello';
       expect(await controller.publish(), isNull);
       await tester.pump(const Duration(seconds: 4));
@@ -87,18 +103,36 @@ void main() {
         child: MaterialApp(home: Scaffold(body: SizedBox())),
       ));
       final firestore = FakeFirebaseFirestore();
-      final postService = PostService(firestore: firestore);
+      final postService = PostService(
+        firestore: firestore,
+        notificationService: NotificationService(firestore: firestore),
+      );
       final auth = FakeAuthService(U(
           uid: 'u1',
           name: 'Tester',
           username: 'tester',
           smallProfilePictureUrl: 'a.png',
-          feeds: [Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue)]));
+          feeds: [
+            Feed(
+                id: 'f1',
+                userId: 'u1',
+                title: 't',
+                description: 'd',
+                color: Colors.blue)
+          ]));
       final storage = FakeStorageService();
-      final controller =
-          CreatePostController(postService: postService, authService: auth, userId: 'u1', storageService: storage);
+      final controller = CreatePostController(
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
       controller.textController.text = 'a' * 281;
-      controller.selectedFeed.value = Feed(id: 'f1', userId: 't', title: 't', description: 'd', color: Colors.blue);
+      controller.selectedFeed.value = Feed(
+          id: 'f1',
+          userId: 't',
+          title: 't',
+          description: 'd',
+          color: Colors.blue);
       expect(await controller.publish(), isNull);
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
@@ -109,17 +143,35 @@ void main() {
         child: MaterialApp(home: Scaffold(body: SizedBox())),
       ));
       final firestore = FakeFirebaseFirestore();
-      final postService = PostService(firestore: firestore);
+      final postService = PostService(
+        firestore: firestore,
+        notificationService: NotificationService(firestore: firestore),
+      );
       final auth = FakeAuthService(U(
           uid: 'u1',
           name: 'Tester',
           username: 'tester',
           smallProfilePictureUrl: 'a.png',
-          feeds: [Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue)]));
+          feeds: [
+            Feed(
+                id: 'f1',
+                userId: 'u1',
+                title: 't',
+                description: 'd',
+                color: Colors.blue)
+          ]));
       final storage = FakeStorageService();
-      final controller =
-          CreatePostController(postService: postService, authService: auth, userId: 'u1', storageService: storage);
-      controller.selectedFeed.value = Feed(id: 'f1', userId: 't', title: 't', description: 'd', color: Colors.blue);
+      final controller = CreatePostController(
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
+      controller.selectedFeed.value = Feed(
+          id: 'f1',
+          userId: 't',
+          title: 't',
+          description: 'd',
+          color: Colors.blue);
       controller.textController.text = 'Hi';
       final result = await controller.publish();
       await tester.pump(const Duration(seconds: 4));
@@ -140,19 +192,38 @@ void main() {
         child: MaterialApp(home: Scaffold(body: SizedBox())),
       ));
       final firestore = FakeFirebaseFirestore();
-      final postService = PostService(firestore: firestore);
+      final postService = PostService(
+        firestore: firestore,
+        notificationService: NotificationService(firestore: firestore),
+      );
       final auth = FakeAuthService(U(
           uid: 'u1',
           name: 'Tester',
           username: 'tester',
           smallProfilePictureUrl: 'a.png',
-          feeds: [Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue)]));
+          feeds: [
+            Feed(
+                id: 'f1',
+                userId: 'u1',
+                title: 't',
+                description: 'd',
+                color: Colors.blue)
+          ]));
       final storage = FakeStorageService();
-      final controller =
-          CreatePostController(postService: postService, authService: auth, userId: 'u1', storageService: storage);
+      final controller = CreatePostController(
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
 
-      controller.selectedFeed.value = Feed(id: 'f1', userId: 't', title: 't', description: 'd', color: Colors.blue);
-      final file = File('${Directory.systemTemp.path}/img.jpg')..writeAsBytesSync([0]);
+      controller.selectedFeed.value = Feed(
+          id: 'f1',
+          userId: 't',
+          title: 't',
+          description: 'd',
+          color: Colors.blue);
+      final file = File('${Directory.systemTemp.path}/img.jpg')
+        ..writeAsBytesSync([0]);
       addTearDown(() => file.deleteSync());
       controller.imageFiles.add(file);
       controller.textController.text = 'Hi';
@@ -162,18 +233,34 @@ void main() {
       expect(result, isA<Post>());
       expect(storage.calls.length, 1);
       final posts = await firestore.collection('posts').get();
-      expect(posts.docs.first.data()['images'][0], 'https://example.com/img.jpg');
+      expect(
+          posts.docs.first.data()['images'][0], 'https://example.com/img.jpg');
     });
 
     testWidgets('available feeds loaded on init', (tester) async {
       final firestore = FakeFirebaseFirestore();
-      final postService = PostService(firestore: firestore);
-      final feed = Feed(id: 'f1', userId: 'u1', title: 't', description: 'd', color: Colors.blue);
-      final auth = FakeAuthService(
-          U(uid: 'u1', name: 'Tester', username: 'tester', smallProfilePictureUrl: 'a.png', feeds: [feed]));
+      final postService = PostService(
+        firestore: firestore,
+        notificationService: NotificationService(firestore: firestore),
+      );
+      final feed = Feed(
+          id: 'f1',
+          userId: 'u1',
+          title: 't',
+          description: 'd',
+          color: Colors.blue);
+      final auth = FakeAuthService(U(
+          uid: 'u1',
+          name: 'Tester',
+          username: 'tester',
+          smallProfilePictureUrl: 'a.png',
+          feeds: [feed]));
       final storage = FakeStorageService();
-      final controller =
-          CreatePostController(postService: postService, authService: auth, userId: 'u1', storageService: storage);
+      final controller = CreatePostController(
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
       Get.put(controller);
       await tester.pump();
       expect(controller.availableFeeds.length, 1);

--- a/test/feed_request_service_test.dart
+++ b/test/feed_request_service_test.dart
@@ -2,8 +2,45 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import 'package:get/get.dart';
 import 'package:hoot/services/feed_request_service.dart';
 import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/notification_service.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hoot/models/user.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U _user;
+  FakeAuthService(this._user);
+
+  @override
+  U? get currentUser => _user;
+
+  @override
+  Future<U?> fetchUser() async => _user;
+
+  @override
+  Future<U?> fetchUserById(String uid) async => _user;
+
+  @override
+  Future<U?> fetchUserByUsername(String username) async => _user;
+
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAccount() async {}
+}
 
 void main() {
   group('FeedRequestService', () {
@@ -11,7 +48,11 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final service = FeedRequestService(
         firestore: firestore,
-        subscriptionService: SubscriptionService(firestore: firestore),
+        subscriptionService: SubscriptionService(
+          firestore: firestore,
+          notificationService: NotificationService(firestore: firestore),
+        ),
+        authService: FakeAuthService(U(uid: 'owner')),
       );
       await firestore.collection('feeds').doc('f1').set({});
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
@@ -29,10 +70,14 @@ void main() {
 
     test('accept subscribes user and removes request', () async {
       final firestore = FakeFirebaseFirestore();
-      final subscriptionService = SubscriptionService(firestore: firestore);
+      final subscriptionService = SubscriptionService(
+        firestore: firestore,
+        notificationService: NotificationService(firestore: firestore),
+      );
       final service = FeedRequestService(
         firestore: firestore,
         subscriptionService: subscriptionService,
+        authService: FakeAuthService(U(uid: 'owner')),
       );
       await firestore.collection('feeds').doc('f1').set({
         'subscriberCount': 0,
@@ -75,7 +120,11 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final service = FeedRequestService(
         firestore: firestore,
-        subscriptionService: SubscriptionService(firestore: firestore),
+        subscriptionService: SubscriptionService(
+          firestore: firestore,
+          notificationService: NotificationService(firestore: firestore),
+        ),
+        authService: FakeAuthService(U(uid: 'owner')),
       );
       await firestore.collection('feeds').doc('f1').set({});
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
@@ -96,6 +145,38 @@ void main() {
           .get();
 
       expect(req.exists, isFalse);
+    });
+
+    test('pendingRequestCount returns total for user feeds', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('feeds').doc('f1').set({'userId': 'owner'});
+      await firestore.collection('feeds').doc('f2').set({'userId': 'owner'});
+      await firestore.collection('users').doc('r1').set({'uid': 'r1'});
+      await firestore.collection('users').doc('r2').set({'uid': 'r2'});
+      await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('requests')
+          .doc('r1')
+          .set({'createdAt': Timestamp.now()});
+      await firestore
+          .collection('feeds')
+          .doc('f2')
+          .collection('requests')
+          .doc('r2')
+          .set({'createdAt': Timestamp.now()});
+
+      final service = FeedRequestService(
+        firestore: firestore,
+        subscriptionService: SubscriptionService(
+          firestore: firestore,
+          notificationService: NotificationService(firestore: firestore),
+        ),
+        authService: FakeAuthService(U(uid: 'owner')),
+      );
+
+      final count = await service.pendingRequestCount();
+      expect(count, 2);
     });
   });
 }

--- a/test/subscription_service_test.dart
+++ b/test/subscription_service_test.dart
@@ -3,12 +3,16 @@ import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/notification_service.dart';
 
 void main() {
   group('SubscriptionService', () {
     test('removeSubscriber deletes docs and decrements count', () async {
       final firestore = FakeFirebaseFirestore();
-      final service = SubscriptionService(firestore: firestore);
+      final service = SubscriptionService(
+        firestore: firestore,
+        notificationService: NotificationService(firestore: firestore),
+      );
       await firestore.collection('feeds').doc('f1').set({'subscriberCount': 1});
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
       await firestore
@@ -47,7 +51,10 @@ void main() {
 
     test('banSubscriber moves user to banned list', () async {
       final firestore = FakeFirebaseFirestore();
-      final service = SubscriptionService(firestore: firestore);
+      final service = SubscriptionService(
+        firestore: firestore,
+        notificationService: NotificationService(firestore: firestore),
+      );
       await firestore.collection('feeds').doc('f1').set({'subscriberCount': 1});
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
       await firestore

--- a/test/subscriptions_view_test.dart
+++ b/test/subscriptions_view_test.dart
@@ -8,6 +8,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:hoot/pages/subscriptions/controllers/subscriptions_controller.dart';
 import 'package:hoot/pages/subscriptions/views/subscriptions_view.dart';
 import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/notification_service.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:hoot/models/user.dart';
@@ -64,7 +65,10 @@ void main() {
         .doc('f1')
         .set({'createdAt': Timestamp.now()});
     final auth = FakeAuthService(U(uid: 'u1'));
-    final service = SubscriptionService(firestore: firestore);
+    final service = SubscriptionService(
+      firestore: firestore,
+      notificationService: NotificationService(firestore: firestore),
+    );
     final controller = SubscriptionsController(
       authService: auth,
       subscriptionService: service,
@@ -101,7 +105,10 @@ void main() {
         .doc('f1')
         .set({'createdAt': Timestamp.now()});
     final auth = FakeAuthService(U(uid: 'u1'));
-    final service = SubscriptionService(firestore: firestore);
+    final service = SubscriptionService(
+      firestore: firestore,
+      notificationService: NotificationService(firestore: firestore),
+    );
     final controller = SubscriptionsController(
       authService: auth,
       subscriptionService: service,
@@ -124,4 +131,3 @@ void main() {
     Get.reset();
   });
 }
-


### PR DESCRIPTION
## Summary
- show count of pending requests for user feeds
- display button in notifications to view subscriber requests
- translate new subscriber requests label
- update tests for NotificationService and new method

## Testing
- `flutter test --run-skipped -r expanded` *(fails: Bad state: Cannot get field that does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6887bd8325bc832893b6308c018c8ff2