### PR TITLE
Add notification service and view tests

### DIFF
--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:hoot/services/notification_service.dart';
+
+void main() {
+  group('NotificationService', () {
+    test('createNotification writes document', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = NotificationService(firestore: firestore);
+
+      await service.createNotification('u1', {
+        'user': {'uid': 'u2'},
+        'type': 0,
+        'read': false,
+        'createdAt': Timestamp.now(),
+      });
+
+      final snapshot = await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('notifications')
+          .get();
+      expect(snapshot.docs.length, 1);
+      expect(snapshot.docs.first.get('type'), 0);
+    });
+
+    test('fetchNotifications returns sorted notifications', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = NotificationService(firestore: firestore);
+      final older = Timestamp.now();
+      final newer =
+          Timestamp.fromDate(older.toDate().add(const Duration(seconds: 1)));
+
+      await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('notifications')
+          .add({
+        'user': {'uid': 'u2'},
+        'type': 0,
+        'read': false,
+        'createdAt': older,
+      });
+      await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('notifications')
+          .add({
+        'user': {'uid': 'u3'},
+        'type': 1,
+        'read': true,
+        'createdAt': newer,
+      });
+
+      final result = await service.fetchNotifications('u1');
+
+      expect(result.length, 2);
+      expect(result.first.type, 1);
+      expect(result.last.type, 0);
+    });
+  });
+}

--- a/test/notifications_view_test.dart
+++ b/test/notifications_view_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+
+import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
+import 'package:hoot/pages/notifications/views/notifications_view.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/notification_service.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/util/translations/app_translations.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/models/hoot_notification.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U _user;
+  FakeAuthService(this._user);
+
+  @override
+  U? get currentUser => _user;
+
+  @override
+  Future<U?> fetchUser() async => _user;
+
+  @override
+  Future<U?> fetchUserById(String uid) async => _user;
+
+  @override
+  Future<U?> fetchUserByUsername(String username) async => _user;
+
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAccount() async {}
+}
+
+class FakeFeedRequestService extends FeedRequestService {
+  final int count;
+  FakeFeedRequestService(this.count)
+      : super(
+            firestore: FakeFirebaseFirestore(),
+            subscriptionService: SubscriptionService(
+              firestore: FakeFirebaseFirestore(),
+              notificationService:
+                  NotificationService(firestore: FakeFirebaseFirestore()),
+            ),
+            authService: FakeAuthService(U(uid: 'owner')));
+
+  @override
+  Future<int> pendingRequestCount() async => count;
+}
+
+class TestNotificationsController extends NotificationsController {
+  TestNotificationsController({
+    required AuthService authService,
+    required BaseNotificationService notificationService,
+    required FeedRequestService feedRequestService,
+  }) : super(
+            authService: authService,
+            notificationService: notificationService,
+            feedRequestService: feedRequestService);
+
+  @override
+  void onInit() {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('NotificationsView lists notifications', (tester) async {
+    final controller = TestNotificationsController(
+      authService: FakeAuthService(U(uid: 'u1')),
+      notificationService:
+          NotificationService(firestore: FakeFirebaseFirestore()),
+      feedRequestService: FakeFeedRequestService(0),
+    );
+    controller.loading.value = false;
+    controller.notifications.assignAll([
+      HootNotification(
+        user: U(uid: 'u2', username: 'Tester'),
+        type: 0,
+        read: false,
+        createdAt: DateTime.now(),
+      ),
+    ]);
+    Get.put<NotificationsController>(controller);
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        translations: AppTranslations(),
+        locale: const Locale('en'),
+        home: const NotificationsView(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('@{username} liked your hoot'), findsOneWidget);
+    Get.reset();
+  });
+
+  testWidgets('Shows Subscriber Requests button when there are requests',
+      (tester) async {
+    final controller = TestNotificationsController(
+      authService: FakeAuthService(U(uid: 'u1')),
+      notificationService:
+          NotificationService(firestore: FakeFirebaseFirestore()),
+      feedRequestService: FakeFeedRequestService(2),
+    );
+    controller.loading.value = false;
+    controller.requestCount.value = 2;
+    Get.put<NotificationsController>(controller);
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        translations: AppTranslations(),
+        locale: const Locale('en'),
+        home: const NotificationsView(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Subscriber Requests'), findsOneWidget);
+    Get.reset();
+  });
+}


### PR DESCRIPTION
## Summary
- test `NotificationService` create/fetch operations with `FakeFirebaseFirestore`
- verify `NotificationsView` lists notifications and displays the request button

## Testing
- `flutter test test/notification_service_test.dart test/notifications_view_test.dart`
- `flutter test` *(fails: FeedView shows posts from controller)*

------
https://chatgpt.com/codex/tasks/task_e_6887c1a4abac8328923410691b1b27bb