### PR TITLE
Implement server-side notifications

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -10,6 +10,8 @@
 import {setGlobalOptions} from "firebase-functions";
 
 import {initializeApp} from "firebase-admin/app";
+import {getFirestore, FieldValue} from "firebase-admin/firestore";
+import {onDocumentCreated} from "firebase-functions/v2/firestore";
 
 // Start writing functions
 // https://firebase.google.com/docs/functions/typescript
@@ -26,4 +28,151 @@ import {initializeApp} from "firebase-admin/app";
 // this will be the maximum concurrent request count.
 setGlobalOptions({ maxInstances: 10 });
 initializeApp();
+const db = getFirestore();
+
+export const onLikeCreated = onDocumentCreated("posts/{postId}/likes/{userId}", async (event) => {
+  const { postId, userId } = event.params;
+  const postSnap = await db.collection("posts").doc(postId).get();
+  if (!postSnap.exists) return;
+  const ownerId = postSnap.get("userId");
+  if (ownerId === userId) return;
+  const userSnap = await db.collection("users").doc(userId).get();
+  const userData = userSnap.data();
+  if (!userData) return;
+  userData["uid"] = userId;
+  const feedData = postSnap.data()?.feed;
+  await db
+    .collection("users")
+    .doc(ownerId)
+    .collection("notifications")
+    .add({
+      user: userData,
+      ...(feedData ? { feed: feedData } : {}),
+      postId,
+      type: 0,
+      read: false,
+      createdAt: FieldValue.serverTimestamp(),
+    });
+});
+
+export const onCommentCreated = onDocumentCreated(
+  "posts/{postId}/comments/{commentId}",
+  async (event) => {
+    const { postId } = event.params;
+    const comment = event.data?.data();
+    if (!comment) return;
+    const userId = comment.userId;
+    const user = comment.user;
+    const text = comment.text as string | undefined;
+    const postSnap = await db.collection("posts").doc(postId).get();
+    if (!postSnap.exists) return;
+    const ownerId = postSnap.get("userId");
+    const feedData = postSnap.data()?.feed;
+    if (ownerId && ownerId !== userId) {
+      await db
+        .collection("users")
+        .doc(ownerId)
+        .collection("notifications")
+        .add({
+          user,
+          ...(feedData ? { feed: feedData } : {}),
+          postId,
+          type: 1,
+          read: false,
+          createdAt: FieldValue.serverTimestamp(),
+        });
+    }
+    if (text && text.includes("@")) {
+      const regex = /@([A-Za-z0-9_]+)/g;
+      let match;
+      while ((match = regex.exec(text)) !== null) {
+        const username = match[1];
+        const userQuery = await db
+          .collection("users")
+          .where("username", "==", username)
+          .limit(1)
+          .get();
+        if (userQuery.empty) continue;
+        const targetId = userQuery.docs[0].id;
+        if (targetId === userId) continue;
+        await db
+          .collection("users")
+          .doc(targetId)
+          .collection("notifications")
+          .add({
+            user,
+            ...(feedData ? { feed: feedData } : {}),
+            postId,
+            type: 2,
+            read: false,
+            createdAt: FieldValue.serverTimestamp(),
+          });
+      }
+    }
+  }
+);
+
+export const onPostCreated = onDocumentCreated("posts/{postId}", async (event) => {
+  const { postId } = event.params;
+  const post = event.data?.data();
+  if (!post) return;
+  const text = post.text as string | undefined;
+  if (!text || !text.includes("@")) return;
+  const userId = post.userId;
+  const user = post.user;
+  const feed = post.feed;
+  const regex = /@([A-Za-z0-9_]+)/g;
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const username = match[1];
+    const userQuery = await db
+      .collection("users")
+      .where("username", "==", username)
+      .limit(1)
+      .get();
+    if (userQuery.empty) continue;
+    const targetId = userQuery.docs[0].id;
+    if (targetId === userId) continue;
+    await db
+      .collection("users")
+      .doc(targetId)
+      .collection("notifications")
+      .add({
+        user,
+        ...(feed ? { feed } : {}),
+        postId,
+        type: 2,
+        read: false,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+  }
+});
+
+export const onSubscriptionCreated = onDocumentCreated(
+  "feeds/{feedId}/subscribers/{userId}",
+  async (event) => {
+    const { feedId, userId } = event.params;
+    const feedSnap = await db.collection("feeds").doc(feedId).get();
+    if (!feedSnap.exists) return;
+    const ownerId = feedSnap.get("userId");
+    if (ownerId === userId) return;
+    const userSnap = await db.collection("users").doc(userId).get();
+    const userData = userSnap.data();
+    if (!userData) return;
+    userData["uid"] = userId;
+    const feedData = feedSnap.data();
+    if (feedData) feedData["id"] = feedId;
+    await db
+      .collection("users")
+      .doc(ownerId)
+      .collection("notifications")
+      .add({
+        user: userData,
+        ...(feedData ? { feed: feedData } : {}),
+        type: 3,
+        read: false,
+        createdAt: FieldValue.serverTimestamp(),
+      });
+  }
+);
 

--- a/lib/services/comment_service.dart
+++ b/lib/services/comment_service.dart
@@ -1,8 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:get/get.dart';
-
 import '../models/comment.dart';
-import 'notification_service.dart';
 
 class CommentPage {
   CommentPage({required this.comments, this.lastDoc, this.hasMore = false});
@@ -27,16 +24,9 @@ abstract class BaseCommentService {
 
 class CommentService implements BaseCommentService {
   final FirebaseFirestore _firestore;
-  final BaseNotificationService _notificationService;
 
-  CommentService(
-      {FirebaseFirestore? firestore,
-      BaseNotificationService? notificationService})
-      : _firestore = firestore ?? FirebaseFirestore.instance,
-        _notificationService = notificationService ??
-            (Get.isRegistered<BaseNotificationService>()
-                ? Get.find<BaseNotificationService>()
-                : NotificationService());
+  CommentService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   @override
   Future<CommentPage> fetchComments(
@@ -87,41 +77,6 @@ class CommentService implements BaseCommentService {
       txn.set(doc, data);
       txn.update(postRef, {'comments': FieldValue.increment(1)});
     });
-    final postDoc = await postRef.get();
-    final ownerId = postDoc.get('userId');
-    if (ownerId != data['userId']) {
-      await _notificationService.createNotification(ownerId, {
-        'user': data['user'],
-        if (data['feed'] != null) 'feed': data['feed'],
-        'postId': postId,
-        'type': 1,
-        'read': false,
-        'createdAt': FieldValue.serverTimestamp(),
-      });
-    }
-
-    final text = data['text'] as String?;
-    if (text != null && text.contains('@')) {
-      final regex = RegExp(r'@([A-Za-z0-9_]+)');
-      for (final match in regex.allMatches(text)) {
-        final username = match.group(1)!;
-        final userQuery = await _firestore
-            .collection('users')
-            .where('username', isEqualTo: username)
-            .limit(1)
-            .get();
-        if (userQuery.docs.isEmpty) continue;
-        final targetId = userQuery.docs.first.id;
-        if (targetId == data['userId']) continue;
-        await _notificationService.createNotification(targetId, {
-          'user': data['user'],
-          if (data['feed'] != null) 'feed': data['feed'],
-          'postId': postId,
-          'type': 2,
-          'read': false,
-          'createdAt': FieldValue.serverTimestamp(),
-        });
-      }
-    }
+    // Notification creation is handled server-side by Firestore triggers.
   }
 }

--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -1,10 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:get/get.dart';
 
 import '../models/post.dart';
 import '../models/user.dart';
 import '../models/feed.dart';
-import 'notification_service.dart';
+
 
 /// Base interface for creating posts in Firestore.
 abstract class BasePostService {
@@ -29,16 +28,9 @@ abstract class BasePostService {
 /// Default implementation writing to the `posts` collection.
 class PostService implements BasePostService {
   final FirebaseFirestore _firestore;
-  final BaseNotificationService _notificationService;
 
-  PostService(
-      {FirebaseFirestore? firestore,
-      BaseNotificationService? notificationService})
-      : _firestore = firestore ?? FirebaseFirestore.instance,
-        _notificationService = notificationService ??
-            (Get.isRegistered<BaseNotificationService>()
-                ? Get.find<BaseNotificationService>()
-                : NotificationService());
+  PostService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   @override
   String newPostId() => _firestore.collection('posts').doc().id;
@@ -51,29 +43,7 @@ class PostService implements BasePostService {
       final doc = await _firestore.collection('posts').add(data);
       id = doc.id;
     }
-    final text = data['text'] as String?;
-    if (text != null && text.contains('@')) {
-      final regex = RegExp(r'@([A-Za-z0-9_]+)');
-      for (final match in regex.allMatches(text)) {
-        final username = match.group(1)!;
-        final userQuery = await _firestore
-            .collection('users')
-            .where('username', isEqualTo: username)
-            .limit(1)
-            .get();
-        if (userQuery.docs.isEmpty) continue;
-        final targetId = userQuery.docs.first.id;
-        if (targetId == data['userId']) continue;
-        await _notificationService.createNotification(targetId, {
-          'user': data['user'],
-          if (data['feed'] != null) 'feed': data['feed'],
-          'postId': id,
-          'type': 2,
-          'read': false,
-          'createdAt': FieldValue.serverTimestamp(),
-        });
-      }
-    }
+    // Mentions are now handled server-side by a Firestore trigger.
   }
 
   @override
@@ -89,26 +59,7 @@ class PostService implements BasePostService {
         txn.update(postRef, {'likes': FieldValue.increment(-1)});
       }
     });
-    if (like) {
-      final postDoc = await postRef.get();
-      final ownerId = postDoc.get('userId');
-      if (ownerId != userId) {
-        final userDoc = await _firestore.collection('users').doc(userId).get();
-        final userData = userDoc.data();
-        if (userData != null) {
-          userData['uid'] = userId;
-          final feedData = postDoc.data()?['feed'];
-          await _notificationService.createNotification(ownerId, {
-            'user': userData,
-            if (feedData != null) 'feed': feedData,
-            'postId': postId,
-            'type': 0,
-            'read': false,
-            'createdAt': FieldValue.serverTimestamp(),
-          });
-        }
-      }
-    }
+    // Like notifications are handled server-side by a Firestore trigger.
   }
 
   @override

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -1,22 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:get/get.dart';
-
 import '../models/feed.dart';
 import '../models/user.dart';
-import 'notification_service.dart';
 
 class SubscriptionService {
   final FirebaseFirestore _firestore;
-  final BaseNotificationService _notificationService;
 
-  SubscriptionService(
-      {FirebaseFirestore? firestore,
-      BaseNotificationService? notificationService})
-      : _firestore = firestore ?? FirebaseFirestore.instance,
-        _notificationService = notificationService ??
-            (Get.isRegistered<BaseNotificationService>()
-                ? Get.find<BaseNotificationService>()
-                : NotificationService());
+  SubscriptionService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
 
   Future<Set<String>> fetchSubscriptions(String userId) async {
     final snapshot = await _firestore
@@ -65,22 +55,7 @@ class SubscriptionService {
     });
     final feedDoc = await feedRef.get();
     final ownerId = feedDoc.get('userId');
-    if (ownerId != userId) {
-      final userDoc = await _firestore.collection('users').doc(userId).get();
-      final userData = userDoc.data();
-      if (userData != null) {
-        userData['uid'] = userId;
-        final feedData = feedDoc.data();
-        if (feedData != null) feedData['id'] = feedId;
-        await _notificationService.createNotification(ownerId, {
-          'user': userData,
-          if (feedData != null) 'feed': feedData,
-          'type': 3,
-          'read': false,
-          'createdAt': FieldValue.serverTimestamp(),
-        });
-      }
-    }
+    // Subscription notifications are handled server-side by Firestore triggers.
   }
 
   Future<void> unsubscribe(String userId, String feedId) async {

--- a/test/create_feed_controller_test.dart
+++ b/test/create_feed_controller_test.dart
@@ -140,7 +140,6 @@ void main() {
     final auth = FakeAuthService(user);
     final subService = SubscriptionService(
       firestore: firestore,
-      notificationService: NotificationService(firestore: firestore),
     );
     final profile = ProfileController(
       authService: auth,

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -71,7 +71,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final postService = PostService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       final auth = FakeAuthService(U(
           uid: 'u1',
@@ -105,7 +104,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final postService = PostService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       final auth = FakeAuthService(U(
           uid: 'u1',
@@ -145,7 +143,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final postService = PostService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       final auth = FakeAuthService(U(
           uid: 'u1',
@@ -194,7 +191,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final postService = PostService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       final auth = FakeAuthService(U(
           uid: 'u1',
@@ -241,7 +237,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final postService = PostService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       final feed = Feed(
           id: 'f1',

--- a/test/feed_request_service_test.dart
+++ b/test/feed_request_service_test.dart
@@ -50,7 +50,6 @@ void main() {
         firestore: firestore,
         subscriptionService: SubscriptionService(
           firestore: firestore,
-          notificationService: NotificationService(firestore: firestore),
         ),
         authService: FakeAuthService(U(uid: 'owner')),
       );
@@ -72,7 +71,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final subscriptionService = SubscriptionService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       final service = FeedRequestService(
         firestore: firestore,
@@ -122,7 +120,6 @@ void main() {
         firestore: firestore,
         subscriptionService: SubscriptionService(
           firestore: firestore,
-          notificationService: NotificationService(firestore: firestore),
         ),
         authService: FakeAuthService(U(uid: 'owner')),
       );
@@ -170,7 +167,6 @@ void main() {
         firestore: firestore,
         subscriptionService: SubscriptionService(
           firestore: firestore,
-          notificationService: NotificationService(firestore: firestore),
         ),
         authService: FakeAuthService(U(uid: 'owner')),
       );

--- a/test/post_service_test.dart
+++ b/test/post_service_test.dart
@@ -14,7 +14,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final service = PostService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       await firestore.collection('posts').doc('p1').set({'likes': 0});
 
@@ -49,7 +48,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final service = PostService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       await firestore
           .collection('posts')

--- a/test/subscription_service_test.dart
+++ b/test/subscription_service_test.dart
@@ -11,7 +11,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final service = SubscriptionService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       await firestore.collection('feeds').doc('f1').set({'subscriberCount': 1});
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
@@ -53,7 +52,6 @@ void main() {
       final firestore = FakeFirebaseFirestore();
       final service = SubscriptionService(
         firestore: firestore,
-        notificationService: NotificationService(firestore: firestore),
       );
       await firestore.collection('feeds').doc('f1').set({'subscriberCount': 1});
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});

--- a/test/subscriptions_view_test.dart
+++ b/test/subscriptions_view_test.dart
@@ -67,7 +67,6 @@ void main() {
     final auth = FakeAuthService(U(uid: 'u1'));
     final service = SubscriptionService(
       firestore: firestore,
-      notificationService: NotificationService(firestore: firestore),
     );
     final controller = SubscriptionsController(
       authService: auth,
@@ -107,7 +106,6 @@ void main() {
     final auth = FakeAuthService(U(uid: 'u1'));
     final service = SubscriptionService(
       firestore: firestore,
-      notificationService: NotificationService(firestore: firestore),
     );
     final controller = SubscriptionsController(
       authService: auth,


### PR DESCRIPTION
## Summary
- add Firestore triggers to create notifications server-side
- drop client-side notification writes
- update tests for new service APIs

## Testing
- `npm install` in `functions`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887c1c8207483288bf0d61d843ffd75