### PR TITLE
Fix notification tap behavior

### DIFF
--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -57,10 +57,28 @@ class NotificationsView extends GetView<NotificationsController> {
                   text = '';
               }
               return ListTile(
-                leading: ProfileAvatarComponent(
-                  image: user.smallProfilePictureUrl ?? '',
-                  size: 40,
-                  radius: 20,
+                onTap: () {
+                  switch (n.type) {
+                    case 0:
+                    case 1:
+                    case 2:
+                      if (n.postId != null) {
+                        Get.toNamed(AppRoutes.post, arguments: {'id': n.postId});
+                      }
+                      break;
+                    case 3:
+                      Get.toNamed(AppRoutes.profile, arguments: user.uid);
+                      break;
+                  }
+                },
+                leading: GestureDetector(
+                  onTap: () =>
+                      Get.toNamed(AppRoutes.profile, arguments: user.uid),
+                  child: ProfileAvatarComponent(
+                    image: user.smallProfilePictureUrl ?? '',
+                    size: 40,
+                    radius: 20,
+                  ),
                 ),
                 title: Text(text),
               );


### PR DESCRIPTION
## Summary
- allow tapping on list tiles in the notifications view
- open the appropriate profile or post when tapping on avatars or notifications

## Testing
- `flutter analyze`
- `flutter test test/notifications_view_test.dart` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6887cc3e1a9c8328bc11bdb1b7652afc