### PR TITLE
Handle private feed subscription requests

### DIFF
--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -140,6 +140,7 @@ class AppTranslations extends Translations {
               '{numberOfRequests, plural, =0 {No requests} one {# request} other {# requests}}',
           'errorRequestingToJoin':
               'There was an error requesting to join this feed',
+          'requestSent': 'Request sent',
           'feedRequests': 'Feed Requests',
           'subscriberRequests': 'Subscriber Requests',
           'approve': 'Approve',
@@ -475,6 +476,7 @@ class AppTranslations extends Translations {
               '{numberOfRequests, plural, =0 {No hay solicitudes} one {# solicitud} other {# solicitudes}}',
           'errorRequestingToJoin':
               'Hubo un error al solicitar unirse a este feed',
+          'requestSent': 'Solicitud enviada',
           'feedRequests': 'Solicitudes',
           'subscriberRequests': 'Solicitudes de suscriptores',
           'approve': 'Aprobar',
@@ -814,6 +816,7 @@ class AppTranslations extends Translations {
               '{numberOfRequests, plural, =0 {Sem pedidos} one {# pedido} other {# pedidos}}',
           'errorRequestingToJoin':
               'Ocorreu um erro ao pedir para aderir a este feed',
+          'requestSent': 'Pedido enviado',
           'feedRequests': 'Pedidos',
           'subscriberRequests': 'Pedidos de subscritores',
           'approve': 'Aprovar',
@@ -1148,14 +1151,14 @@ class AppTranslations extends Translations {
           'numberOfRequests':
               '{numberOfRequests, plural, =0 {Sem solicitações} one {# solicitação} other {# solicitações}}',
           'errorRequestingToJoin': 'Erro ao solicitar participação neste feed',
+          'requestSent': 'Solicitação enviada',
           'feedRequests': 'Solicitações',
           'subscriberRequests': 'Solicitações de inscritos',
           'approve': 'Aprovar',
           'reject': 'Rejeitar',
           'editFeed': 'Editar Feed',
           'unsubscriber': ' @username cancelou a inscrição em @feedName',
-          'privateFeedRequest':
-              '@username solicitou participação em @feedName',
+          'privateFeedRequest': '@username solicitou participação em @feedName',
           'removeSubscriber': 'Remover inscrito',
           'banSubscriber': 'Banir inscrito',
           'removeSubscriberConfirmation':

--- a/test/profile_controller_test.dart
+++ b/test/profile_controller_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:toastification/toastification.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'package:hoot/models/user.dart';
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/pages/profile/controllers/profile_controller.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/feed_service.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U _user;
+  FakeAuthService(this._user);
+
+  @override
+  U? get currentUser => _user;
+
+  @override
+  Future<U?> fetchUser() async => _user;
+
+  @override
+  Future<U?> fetchUserById(String uid) async => _user;
+
+  @override
+  Future<U?> fetchUserByUsername(String username) async => _user;
+
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAccount() async {}
+}
+
+class FakeSubscriptionService extends SubscriptionService {
+  final List<List<String>> subscribeCalls = [];
+  FakeSubscriptionService() : super(firestore: FakeFirebaseFirestore());
+
+  @override
+  Future<void> subscribe(String userId, String feedId) async {
+    subscribeCalls.add([userId, feedId]);
+  }
+}
+
+class FakeFeedRequestService extends FeedRequestService {
+  final List<List<String>> submitCalls = [];
+  FakeFeedRequestService()
+      : super(
+          firestore: FakeFirebaseFirestore(),
+          subscriptionService: SubscriptionService(
+            firestore: FakeFirebaseFirestore(),
+          ),
+          authService: FakeAuthService(U(uid: 'owner')),
+        );
+
+  @override
+  Future<void> submit(String feedId, String userId) async {
+    submitCalls.add([feedId, userId]);
+  }
+}
+
+class FakeFeedService implements BaseFeedService {
+  @override
+  Future<PostPage> fetchSubscribedPosts({
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  }) async {
+    return PostPage(posts: []);
+  }
+
+  @override
+  Future<PostPage> fetchFeedPosts(String feedId,
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
+    return PostPage(posts: []);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ProfileController.toggleSubscription', () {
+    testWidgets('public feed subscribes', (tester) async {
+      await tester.pumpWidget(const ToastificationWrapper(
+        child: MaterialApp(home: Scaffold(body: SizedBox())),
+      ));
+      final user = U(uid: 'u1', feeds: [
+        Feed(
+            id: 'f1',
+            userId: 'u2',
+            title: 'f',
+            description: 'd',
+            private: false)
+      ]);
+      final auth = FakeAuthService(user);
+      final subService = FakeSubscriptionService();
+      final requestService = FakeFeedRequestService();
+      final controller = ProfileController(
+        authService: auth,
+        feedService: FakeFeedService(),
+        subscriptionService: subService,
+        feedRequestService: requestService,
+      );
+      controller.feeds.assignAll(user.feeds ?? []);
+      Get.put<AuthService>(auth);
+      Get.put<SubscriptionService>(subService);
+      Get.put<FeedRequestService>(requestService);
+      Get.put<ProfileController>(controller);
+
+      await controller.toggleSubscription('f1');
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+
+      expect(subService.subscribeCalls.length, 1);
+      expect(requestService.submitCalls, isEmpty);
+      Get.reset();
+    });
+
+    testWidgets('private feed submits request', (tester) async {
+      await tester.pumpWidget(const ToastificationWrapper(
+        child: MaterialApp(home: Scaffold(body: SizedBox())),
+      ));
+      final user = U(uid: 'u1', feeds: [
+        Feed(
+            id: 'f1', userId: 'u2', title: 'f', description: 'd', private: true)
+      ]);
+      final auth = FakeAuthService(user);
+      final subService = FakeSubscriptionService();
+      final requestService = FakeFeedRequestService();
+      final controller = ProfileController(
+        authService: auth,
+        feedService: FakeFeedService(),
+        subscriptionService: subService,
+        feedRequestService: requestService,
+      );
+      controller.feeds.assignAll(user.feeds ?? []);
+      Get.put<AuthService>(auth);
+      Get.put<SubscriptionService>(subService);
+      Get.put<FeedRequestService>(requestService);
+      Get.put<ProfileController>(controller);
+
+      await controller.toggleSubscription('f1');
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+
+      expect(subService.subscribeCalls, isEmpty);
+      expect(requestService.submitCalls.length, 1);
+      Get.reset();
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- defer to `FeedRequestService.submit` for private feeds in `ProfileController`
- show a toast when sending a subscription request
- add translations for the new "requestSent" message
- test ProfileController subscription behavior

## Testing
- `flutter test test/profile_controller_test.dart`
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68886e7ac6008328a98c394a4882358a