### PR TITLE
Update subscribe button for private feeds

### DIFF
--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -360,11 +360,23 @@ class _ProfileViewState extends State<ProfileView> {
                 final feedId =
                     controller.feeds[controller.selectedFeedIndex.value].id;
                 final subscribed = controller.isSubscribed(feedId);
+                final requested = controller.isRequested(feedId);
                 return FloatingActionButton.extended(
                   heroTag: 'sub_fab',
-                  onPressed: () => controller.toggleSubscription(feedId),
-                  icon: Icon(subscribed ? Icons.remove : Icons.add),
-                  label: Text(subscribed ? 'unsubscribe'.tr : 'subscribe'.tr),
+                  onPressed:
+                      requested ? null : () => controller.toggleSubscription(feedId),
+                  icon: Icon(subscribed
+                      ? Icons.remove
+                      : requested
+                          ? Icons.hourglass_top
+                          : Icons.add),
+                  label: Text(subscribed
+                      ? 'unsubscribe'.tr
+                      : requested
+                          ? 'requested'.tr
+                          : (controller.feeds[controller.selectedFeedIndex.value].private == true
+                              ? 'request'.tr
+                              : 'subscribe'.tr)),
                 );
               }),
         body: buildBody(context),

--- a/lib/services/feed_request_service.dart
+++ b/lib/services/feed_request_service.dart
@@ -53,6 +53,17 @@ class FeedRequestService {
     });
   }
 
+  /// Returns true if [userId] has a pending request to join the feed [feedId].
+  Future<bool> exists(String feedId, String userId) async {
+    final doc = await _firestore
+        .collection('feeds')
+        .doc(feedId)
+        .collection('requests')
+        .doc(userId)
+        .get();
+    return doc.exists;
+  }
+
   Future<List<U>> fetchRequests(String feedId) async {
     final snapshot = await _firestore
         .collection('feeds')

--- a/test/feed_request_service_test.dart
+++ b/test/feed_request_service_test.dart
@@ -78,6 +78,7 @@ void main() {
       );
       await firestore.collection('feeds').doc('f1').set({
         'subscriberCount': 0,
+        'userId': 'owner',
       });
       await firestore.collection('users').doc('u1').set({'uid': 'u1'});
       await firestore
@@ -141,6 +142,28 @@ void main() {
           .get();
 
       expect(req.exists, isFalse);
+    });
+
+    test('exists returns true when request present', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = FeedRequestService(
+        firestore: firestore,
+        subscriptionService: SubscriptionService(
+          firestore: firestore,
+        ),
+        authService: FakeAuthService(U(uid: 'owner')),
+      );
+      await firestore.collection('feeds').doc('f1').set({});
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+      await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('requests')
+          .doc('u1')
+          .set({'createdAt': Timestamp.now()});
+
+      final result = await service.exists('f1', 'u1');
+      expect(result, isTrue);
     });
 
     test('pendingRequestCount returns total for user feeds', () async {

--- a/test/profile_controller_test.dart
+++ b/test/profile_controller_test.dart
@@ -126,6 +126,7 @@ void main() {
 
       expect(subService.subscribeCalls.length, 1);
       expect(requestService.submitCalls, isEmpty);
+      expect(controller.requestedFeedIds.contains('f1'), isFalse);
       Get.reset();
     });
 
@@ -158,6 +159,7 @@ void main() {
 
       expect(subService.subscribeCalls, isEmpty);
       expect(requestService.submitCalls.length, 1);
+      expect(controller.requestedFeedIds.contains('f1'), isTrue);
       Get.reset();
     });
   });


### PR DESCRIPTION
## Summary
- track feed join requests in ProfileController
- show 'Requested' state after requesting to join private feeds
- expose FeedRequestService.exists helper
- test pending request state

## Testing
- `flutter test --no-pub -j 1 test/feed_request_service_test.dart test/profile_controller_test.dart`
- `flutter test --no-pub -j 1` *(fails: TestDeviceException …)*

------
https://chatgpt.com/codex/tasks/task_e_688873f22f208328afe9709f1a2abdeb