### PR TITLE
Add live unread badge to notifications

### DIFF
--- a/lib/pages/home/views/home_view.dart
+++ b/lib/pages/home/views/home_view.dart
@@ -7,6 +7,7 @@ import 'package:solar_icons/solar_icons.dart';
 import '../../explore/views/explore_view.dart';
 import '../../feed/views/feed_view.dart';
 import '../../notifications/views/notifications_view.dart';
+import '../../notifications/controllers/notifications_controller.dart';
 import '../../profile/views/profile_view.dart';
 import '../controllers/home_controller.dart';
 
@@ -24,6 +25,7 @@ class HomeView extends GetView<HomeController> {
   Widget build(BuildContext context) {
     return Obx(() {
       final index = controller.selectedIndex.value;
+      final unread = Get.find<NotificationsController>().unreadCount.value;
       return Scaffold(
         body: IndexedStack(
           index: index,
@@ -70,14 +72,42 @@ class HomeView extends GetView<HomeController> {
                           ),
                           onPressed: () => controller.changeIndex(1),
                         ),
-                        IconButton(
-                          icon: Icon(
-                            SolarIconsOutline.bell,
-                            color: index == 2
-                                ? Theme.of(context).colorScheme.primary
-                                : Theme.of(context).colorScheme.onSurface,
-                          ),
-                          onPressed: () => controller.changeIndex(2),
+                        Stack(
+                          clipBehavior: Clip.none,
+                          children: [
+                            IconButton(
+                              icon: Icon(
+                                SolarIconsOutline.bell,
+                                color: index == 2
+                                    ? Theme.of(context).colorScheme.primary
+                                    : Theme.of(context).colorScheme.onSurface,
+                              ),
+                              onPressed: () => controller.changeIndex(2),
+                            ),
+                            if (unread > 0)
+                              Positioned(
+                                right: 4,
+                                top: 4,
+                                child: Container(
+                                  padding: const EdgeInsets.all(2),
+                                  decoration: BoxDecoration(
+                                    color: Theme.of(context).colorScheme.error,
+                                    shape: BoxShape.circle,
+                                  ),
+                                  constraints:
+                                      const BoxConstraints(minWidth: 16, minHeight: 16),
+                                  child: Text(
+                                    unread > 99 ? '99+' : '$unread',
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 10,
+                                      height: 1,
+                                    ),
+                                    textAlign: TextAlign.center,
+                                  ),
+                                ),
+                              ),
+                          ],
                         ),
                         IconButton(
                           icon: Icon(

--- a/lib/pages/notifications/controllers/notifications_controller.dart
+++ b/lib/pages/notifications/controllers/notifications_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:get/get.dart';
 
 import '../../../models/hoot_notification.dart';
@@ -24,11 +25,20 @@ class NotificationsController extends GetxController {
   final RxInt requestCount = 0.obs;
   final RxBool loading = false.obs;
 
+  StreamSubscription<int>? _unreadSub;
+
   @override
   void onInit() {
     super.onInit();
     _loadNotifications();
     _loadRequestCount();
+    _listenUnreadCount();
+  }
+
+  @override
+  void onClose() {
+    _unreadSub?.cancel();
+    super.onClose();
   }
 
   Future<void> refreshNotifications() async {
@@ -47,6 +57,14 @@ class NotificationsController extends GetxController {
     } finally {
       loading.value = false;
     }
+  }
+
+  void _listenUnreadCount() {
+    final uid = _authService.currentUser?.uid;
+    if (uid == null) return;
+    _unreadSub = _notificationService
+        .unreadCountStream(uid)
+        .listen((c) => unreadCount.value = c);
   }
 
   Future<void> _loadRequestCount() async {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -6,6 +6,7 @@ abstract class BaseNotificationService {
   Future<List<HootNotification>> fetchNotifications(String userId);
   Future<void> createNotification(String userId, Map<String, dynamic> data);
   Future<void> markAsRead(String userId, String notificationId);
+  Stream<int> unreadCountStream(String userId);
 }
 
 class NotificationService implements BaseNotificationService {
@@ -44,5 +45,16 @@ class NotificationService implements BaseNotificationService {
         .collection('notifications')
         .doc(notificationId)
         .update({'read': true});
+  }
+
+  @override
+  Stream<int> unreadCountStream(String userId) {
+    return _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('notifications')
+        .where('read', isEqualTo: false)
+        .snapshots()
+        .map((s) => s.docs.length);
   }
 }

--- a/test/home_view_test.dart
+++ b/test/home_view_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'package:hoot/pages/home/views/home_view.dart';
+import 'package:hoot/pages/home/controllers/home_controller.dart';
+import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/notification_service.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/models/user.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U _user;
+  FakeAuthService(this._user);
+
+  @override
+  U? get currentUser => _user;
+
+  @override
+  Future<U?> fetchUser() async => _user;
+
+  @override
+  Future<U?> fetchUserById(String uid) async => _user;
+
+  @override
+  Future<U?> fetchUserByUsername(String username) async => _user;
+
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAccount() async {}
+}
+
+class FakeFeedRequestService extends FeedRequestService {
+  FakeFeedRequestService()
+      : super(
+            firestore: FakeFirebaseFirestore(),
+            subscriptionService:
+                SubscriptionService(firestore: FakeFirebaseFirestore()),
+            authService: FakeAuthService(U(uid: 'owner')));
+
+  @override
+  Future<int> pendingRequestCount() async => 0;
+}
+
+class TestNotificationsController extends NotificationsController {
+  TestNotificationsController()
+      : super(
+            authService: FakeAuthService(U(uid: 'u1')),
+            notificationService:
+                NotificationService(firestore: FakeFirebaseFirestore()),
+            feedRequestService: FakeFeedRequestService());
+
+  @override
+  void onInit() {}
+}
+
+void main() {
+  testWidgets('HomeView displays unread count badge', (tester) async {
+    Get.put<AuthService>(FakeAuthService(U(uid: 'u1', username: 't')));
+    Get.put(HomeController());
+    final n = TestNotificationsController();
+    n.unreadCount.value = 2;
+    Get.put<NotificationsController>(n);
+
+    await tester.pumpWidget(const GetMaterialApp(home: HomeView()));
+    await tester.pumpAndSettle();
+
+    expect(find.text('2'), findsOneWidget);
+    Get.reset();
+  });
+}


### PR DESCRIPTION
## Summary
- stream unread notification count and expose via NotificationService
- listen for unread count changes in NotificationsController
- show unread count badge in HomeView bell icon
- add HomeView test for badge display

## Testing
- `flutter analyze`
- `flutter test test/home_view_test.dart` *(fails: liquid_glass_renderer requires shader support)*

------
https://chatgpt.com/codex/tasks/task_e_68887c1856e08328ab059b41d18bf51f