### PR TITLE
Fix unread notifications

### DIFF
--- a/lib/models/hoot_notification.dart
+++ b/lib/models/hoot_notification.dart
@@ -3,6 +3,7 @@ import 'package:hoot/models/feed.dart';
 import 'package:hoot/models/user.dart';
 
 class HootNotification {
+  final String id;
   final U user;
   final Feed? feed;
   final String? postId;
@@ -11,6 +12,7 @@ class HootNotification {
   final DateTime createdAt;
 
   HootNotification({
+    required this.id,
     required this.user,
     this.feed,
     this.postId,
@@ -21,6 +23,7 @@ class HootNotification {
 
   factory HootNotification.fromJson(Map<String, dynamic> map) {
     return HootNotification(
+      id: map['id'],
       user: U.fromJson(map['user']),
       feed: map['feed'] != null ? Feed.fromJson(map['feed']) : null,
       postId: map['postId'],

--- a/lib/pages/home/controllers/home_controller.dart
+++ b/lib/pages/home/controllers/home_controller.dart
@@ -1,6 +1,7 @@
 import 'package:get/get.dart';
 import '../../../services/auth_service.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../notifications/controllers/notifications_controller.dart';
 
 class HomeController extends GetxController {
   final selectedIndex = 0.obs;
@@ -25,5 +26,8 @@ class HomeController extends GetxController {
 
   void changeIndex(int index) {
     selectedIndex.value = index;
+    if (index == 2 && Get.isRegistered<NotificationsController>()) {
+      Get.find<NotificationsController>().markAllAsRead();
+    }
   }
 }

--- a/lib/pages/notifications/controllers/notifications_controller.dart
+++ b/lib/pages/notifications/controllers/notifications_controller.dart
@@ -46,6 +46,27 @@ class NotificationsController extends GetxController {
     await _loadRequestCount();
   }
 
+  Future<void> markAllAsRead() async {
+    final uid = _authService.currentUser?.uid;
+    if (uid == null) return;
+    await _notificationService.markAllAsRead(uid);
+    notifications.value = [
+      for (final n in notifications)
+        n.read
+            ? n
+            : HootNotification(
+                id: n.id,
+                user: n.user,
+                feed: n.feed,
+                postId: n.postId,
+                type: n.type,
+                read: true,
+                createdAt: n.createdAt,
+              )
+    ];
+    unreadCount.value = 0;
+  }
+
   Future<void> _loadNotifications() async {
     final uid = _authService.currentUser?.uid;
     if (uid == null) return;

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -7,6 +7,7 @@ abstract class BaseNotificationService {
   Future<void> createNotification(String userId, Map<String, dynamic> data);
   Future<void> markAsRead(String userId, String notificationId);
   Stream<int> unreadCountStream(String userId);
+  Future<void> markAllAsRead(String userId);
 }
 
 class NotificationService implements BaseNotificationService {
@@ -45,6 +46,22 @@ class NotificationService implements BaseNotificationService {
         .collection('notifications')
         .doc(notificationId)
         .update({'read': true});
+  }
+
+  @override
+  Future<void> markAllAsRead(String userId) async {
+    final snapshot = await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('notifications')
+        .where('read', isEqualTo: false)
+        .get();
+
+    final batch = _firestore.batch();
+    for (final doc in snapshot.docs) {
+      batch.update(doc.reference, {'read': true});
+    }
+    await batch.commit();
   }
 
   @override

--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -60,5 +60,42 @@ void main() {
       expect(result.first.type, 1);
       expect(result.last.type, 0);
     });
+
+    test('markAllAsRead updates unread notifications', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = NotificationService(firestore: firestore);
+
+      await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('notifications')
+          .add({
+        'user': {'uid': 'u2'},
+        'type': 0,
+        'read': false,
+        'createdAt': Timestamp.now(),
+      });
+      await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('notifications')
+          .add({
+        'user': {'uid': 'u3'},
+        'type': 0,
+        'read': false,
+        'createdAt': Timestamp.now(),
+      });
+
+      await service.markAllAsRead('u1');
+
+      final remaining = await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('notifications')
+          .where('read', isEqualTo: false)
+          .get();
+
+      expect(remaining.docs, isEmpty);
+    });
   });
 }

--- a/test/notifications_view_test.dart
+++ b/test/notifications_view_test.dart
@@ -84,6 +84,7 @@ void main() {
     controller.loading.value = false;
     controller.notifications.assignAll([
       HootNotification(
+        id: 'n1',
         user: U(uid: 'u2', username: 'Tester'),
         type: 0,
         read: false,
@@ -115,6 +116,7 @@ void main() {
     controller.loading.value = false;
     controller.notifications.assignAll([
       HootNotification(
+        id: 'n2',
         user: U(uid: 'u2', username: 'Tester'),
         type: 4,
         postId: 'p1',


### PR DESCRIPTION
## Summary
- track notification document id
- mark notifications as read when opening the notification tab
- batch update read status in service
- cover new behaviour with tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ba95e3248328b3f77a1145ddbe97