### PR TITLE
Implement feed detail page and update profile view

### DIFF
--- a/lib/pages/feed_page/bindings/feed_page_binding.dart
+++ b/lib/pages/feed_page/bindings/feed_page_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/feed_page_controller.dart';
+
+class FeedPageBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => FeedPageController());
+  }
+}

--- a/lib/pages/feed_page/controllers/feed_page_controller.dart
+++ b/lib/pages/feed_page/controllers/feed_page_controller.dart
@@ -1,0 +1,143 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:get/get.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+
+import '../../../models/feed.dart';
+import '../../../models/post.dart';
+import '../../../services/auth_service.dart';
+import '../../../services/feed_service.dart';
+import '../../../services/subscription_service.dart';
+import '../../../services/feed_request_service.dart';
+import '../../../services/error_service.dart';
+import '../../../services/toast_service.dart';
+
+class FeedPageController extends GetxController {
+  final AuthService _authService;
+  final BaseFeedService _feedService;
+  final SubscriptionService _subscriptionService;
+  final FeedRequestService _feedRequestService;
+
+  FeedPageController({
+    AuthService? authService,
+    BaseFeedService? feedService,
+    SubscriptionService? subscriptionService,
+    FeedRequestService? feedRequestService,
+  })  : _authService = authService ?? Get.find<AuthService>(),
+        _feedService = feedService ?? Get.find<BaseFeedService>(),
+        _subscriptionService =
+            subscriptionService ?? Get.find<SubscriptionService>(),
+        _feedRequestService =
+            feedRequestService ?? Get.find<FeedRequestService>();
+
+  final Rxn<Feed> feed = Rxn<Feed>();
+  final RxBool loading = false.obs;
+  final Rx<PagingState<DocumentSnapshot?, Post>> state =
+      PagingState<DocumentSnapshot?, Post>().obs;
+  final RxBool subscribed = false.obs;
+  final RxBool requested = false.obs;
+
+  bool get isOwner => feed.value?.userId == _authService.currentUser?.uid;
+
+  @override
+  void onInit() {
+    super.onInit();
+    final args = Get.arguments;
+    if (args is Feed) {
+      feed.value = args;
+    } else if (args is Map && args['feed'] is Feed) {
+      feed.value = args['feed'];
+    } else if (args is String) {
+      _loadFeed(args);
+    } else if (args is Map && args['id'] is String) {
+      _loadFeed(args['id']);
+    }
+    _initState();
+  }
+
+  Future<void> _loadFeed(String id) async {
+    loading.value = true;
+    final doc =
+        await FirebaseFirestore.instance.collection('feeds').doc(id).get();
+    if (doc.exists) {
+      feed.value = Feed.fromJson({'id': doc.id, ...doc.data()!});
+    }
+    loading.value = false;
+  }
+
+  Future<void> _initState() async {
+    final current = _authService.currentUser;
+    final f = feed.value;
+    if (current != null && f != null && current.uid != f.userId) {
+      final subs =
+          await _subscriptionService.fetchSubscriptions(current.uid);
+      subscribed.value = subs.contains(f.id);
+      final exists =
+          await _feedRequestService.exists(f.id, current.uid);
+      requested.value = exists;
+    }
+    fetchNext();
+  }
+
+  void fetchNext() async {
+    if (state.value.isLoading || feed.value == null) return;
+    state.value = state.value.copyWith(isLoading: true, error: null);
+    try {
+      final page = await _feedService.fetchFeedPosts(
+        feed.value!.id,
+        startAfter: state.value.keys?.last,
+      );
+      state.value = state.value.copyWith(
+        pages: [...?state.value.pages, page.posts],
+        keys: [...?state.value.keys, page.lastDoc],
+        hasNextPage: page.hasMore,
+        isLoading: false,
+      );
+    } catch (e, s) {
+      state.value = state.value.copyWith(error: e, isLoading: false);
+      await ErrorService.reportError(e, stack: s);
+    }
+  }
+
+  Future<void> refresh() async {
+    state.value = state.value.reset();
+    await fetchNext();
+  }
+
+  Future<void> toggleSubscription() async {
+    final current = _authService.currentUser;
+    final f = feed.value;
+    if (current == null || f == null) return;
+    if (requested.value) return;
+    final isSub = subscribed.value;
+    if (isSub) {
+      subscribed.value = false;
+      try {
+        await _subscriptionService.unsubscribe(current.uid, f.id);
+      } catch (e, s) {
+        subscribed.value = true;
+        await ErrorService.reportError(e,
+            stack: s, message: 'errorUnsubscribing'.tr);
+      }
+    } else {
+      if (f.private == true) {
+        try {
+          await _feedRequestService.submit(f.id, current.uid);
+          requested.value = true;
+          ToastService.showSuccess('requestSent'.tr);
+        } catch (e, s) {
+          await ErrorService.reportError(e,
+              stack: s, message: 'errorRequestingToJoin'.tr);
+        }
+      } else {
+        subscribed.value = true;
+        try {
+          await _subscriptionService.subscribe(current.uid, f.id);
+        } catch (e, s) {
+          subscribed.value = false;
+          await ErrorService.reportError(e,
+              stack: s, message: 'errorSubscribing'.tr);
+        }
+      }
+    }
+  }
+}

--- a/lib/pages/feed_page/views/feed_page_view.dart
+++ b/lib/pages/feed_page/views/feed_page_view.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:hoot/components/post_component.dart';
+import 'package:hoot/components/empty_message.dart';
+import 'package:hoot/components/avatar_component.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
+import '../../../models/post.dart';
+import '../../../util/routes/app_routes.dart';
+import '../controllers/feed_page_controller.dart';
+
+class FeedPageView extends GetView<FeedPageController> {
+  const FeedPageView({super.key});
+
+  Widget _buildHeader(BuildContext context) {
+    final feed = controller.feed.value!;
+    final color = feed.color ?? Theme.of(context).colorScheme.primary;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.2),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          if (feed.imageUrl != null && feed.imageUrl!.isNotEmpty)
+            ProfileAvatarComponent(
+              image: feed.imageUrl!,
+              size: 120,
+              radius: 32,
+            ),
+          const SizedBox(height: 8),
+          Text(
+            feed.title,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+          if (feed.description != null && feed.description!.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: Text(feed.description!),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody(BuildContext context) {
+    return Obx(() {
+      if (controller.loading.value || controller.feed.value == null) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      final state = controller.state.value;
+      return RefreshIndicator(
+        onRefresh: controller.refresh,
+        child: CustomScrollView(
+          slivers: [
+            SliverToBoxAdapter(child: _buildHeader(context)),
+            const SliverToBoxAdapter(child: SizedBox(height: 16)),
+            PagedSliverList<DocumentSnapshot?, Post>(
+              state: state,
+              fetchNextPage: controller.fetchNext,
+              builderDelegate: PagedChildBuilderDelegate<Post>(
+                itemBuilder: (context, item, index) => PostComponent(post: item),
+                firstPageProgressIndicatorBuilder: (_) => const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+                newPageProgressIndicatorBuilder: (_) => const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+                firstPageErrorIndicatorBuilder: (_) => NothingToShowComponent(
+                  icon: const Icon(Icons.error_outline),
+                  text: 'somethingWentWrong'.tr,
+                ),
+                noItemsFoundIndicatorBuilder: (_) => NothingToShowComponent(
+                  icon: const Icon(Icons.feed_outlined),
+                  text: 'noPosts'.tr,
+                ),
+              ),
+            ),
+            SliverToBoxAdapter(
+              child: SafeArea(child: const SizedBox(height: 32)),
+            ),
+          ],
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Obx(() {
+      final feed = controller.feed.value;
+      return Scaffold(
+        appBar: AppBar(
+          title: Text(feed?.title ?? ''),
+          actions: [
+            if (controller.isOwner)
+              IconButton(
+                onPressed: () => Get.toNamed(
+                  AppRoutes.editFeed,
+                  arguments: feed,
+                ),
+                icon: const Icon(Icons.edit),
+              )
+            else if (feed != null)
+              IconButton(
+                onPressed:
+                    controller.requested.value ? null : controller.toggleSubscription,
+                icon: Icon(controller.subscribed.value
+                    ? Icons.remove
+                    : controller.requested.value
+                        ? Icons.hourglass_top
+                        : Icons.add),
+              )
+          ],
+        ),
+        body: _buildBody(context),
+      );
+    });
+  }
+}

--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -85,20 +85,8 @@ class ProfileController extends GetxController {
       }
 
       if (feeds.isNotEmpty) {
-        var index = 0;
-        if (initialFeedId != null) {
-          final i = feeds.indexWhere((f) => f.id == initialFeedId);
-          if (i != -1) index = i;
-        }
-        selectedFeedIndex.value = index;
-        await loadFeedPosts(feeds[index].id, refresh: true);
+        selectedFeedIndex.value = 0;
       }
-      ever<int>(selectedFeedIndex, (i) {
-        final feed = feeds[i];
-        if (feed.posts == null || feed.posts!.isEmpty) {
-          loadFeedPosts(feed.id, refresh: true);
-        }
-      });
     } finally {
       isLoading.value = false;
     }

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -33,6 +33,8 @@ import 'package:hoot/pages/subscriptions/bindings/subscriptions_binding.dart';
 import 'package:hoot/pages/subscriptions/views/subscriptions_view.dart';
 import 'package:hoot/pages/subscribers/bindings/subscribers_binding.dart';
 import 'package:hoot/pages/subscribers/views/subscribers_view.dart';
+import 'package:hoot/pages/feed_page/bindings/feed_page_binding.dart';
+import 'package:hoot/pages/feed_page/views/feed_page_view.dart';
 import 'package:hoot/pages/post/bindings/post_binding.dart';
 import 'package:hoot/pages/post/views/post_view.dart';
 import 'package:hoot/pages/report/bindings/report_binding.dart';
@@ -145,6 +147,12 @@ class AppPages {
         name: AppRoutes.subscribers,
         page: () => const SubscribersView(),
         binding: SubscribersBinding(),
+        middlewares: [AuthMiddleware()],
+      ),
+      GetPage(
+        name: AppRoutes.feed,
+        page: () => const FeedPageView(),
+        binding: FeedPageBinding(),
         middlewares: [AuthMiddleware()],
       ),
       GetPage(

--- a/lib/util/routes/app_routes.dart
+++ b/lib/util/routes/app_routes.dart
@@ -17,6 +17,7 @@ class AppRoutes {
   static const feedRequests = '/feed_requests';
   static const subscriptions = '/subscriptions';
   static const subscribers = '/subscribers';
+  static const feed = '/feed';
   static const post = '/post';
   static const report = '/report';
   static const aboutUs = '/about_us';


### PR DESCRIPTION
## Summary
- create dedicated feed page displaying posts and allowing subscription
- route `/feed` to new page
- show user's feeds in a grid and open feed page on tap
- simplify profile actions and add create-feed FAB

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888bb2df2448328b8290513f85a3454