### PR TITLE
Fix empty feed translation

### DIFF
--- a/lib/pages/feed_page/views/feed_page_view.dart
+++ b/lib/pages/feed_page/views/feed_page_view.dart
@@ -76,7 +76,7 @@ class FeedPageView extends GetView<FeedPageController> {
                 ),
                 noItemsFoundIndicatorBuilder: (_) => NothingToShowComponent(
                   icon: const Icon(Icons.feed_outlined),
-                  text: 'noPosts'.tr,
+                  text: 'noHoots'.tr,
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- show "No hoots" message for empty feed lists

## Testing
- `flutter test` *(fails: Firebase not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6888c6e806408328a992630de6f06cc0