### PR TITLE
Add feed avatar picker

### DIFF
--- a/lib/pages/create_feed/views/create_feed_view.dart
+++ b/lib/pages/create_feed/views/create_feed_view.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import '../controllers/create_feed_controller.dart';
 import '../../feed/widgets/feed_form.dart';
+import '../../feed/widgets/feed_avatar_picker.dart';
 
 class CreateFeedView extends GetView<CreateFeedController> {
   const CreateFeedView({super.key});
@@ -34,18 +35,30 @@ class CreateFeedView extends GetView<CreateFeedController> {
       ),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
-        child: FeedForm(
-          titleController: controller.titleController,
-          descriptionController: controller.descriptionController,
-          typeSearchController: controller.typeSearchController,
-          selectedColor: controller.selectedColor,
-          onColorChanged: (c) => controller.selectedColor.value = c,
-          selectedType: controller.selectedType,
-          onTypeChanged: (t) => controller.selectedType.value = t,
-          isPrivate: controller.isPrivate,
-          onPrivateChanged: (v) => controller.isPrivate.value = v,
-          isNsfw: controller.isNsfw,
-          onNsfwChanged: (v) => controller.isNsfw.value = v,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Obx(() => Center(
+                  child: FeedAvatarPicker(
+                    file: controller.avatarFile.value,
+                    onTap: controller.pickAvatar,
+                  ),
+                )),
+            const SizedBox(height: 16),
+            FeedForm(
+              titleController: controller.titleController,
+              descriptionController: controller.descriptionController,
+              typeSearchController: controller.typeSearchController,
+              selectedColor: controller.selectedColor,
+              onColorChanged: (c) => controller.selectedColor.value = c,
+              selectedType: controller.selectedType,
+              onTypeChanged: (t) => controller.selectedType.value = t,
+              isPrivate: controller.isPrivate,
+              onPrivateChanged: (v) => controller.isPrivate.value = v,
+              isNsfw: controller.isNsfw,
+              onNsfwChanged: (v) => controller.isNsfw.value = v,
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/edit_feed/views/edit_feed_view.dart
+++ b/lib/pages/edit_feed/views/edit_feed_view.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import '../controllers/edit_feed_controller.dart';
 import '../../feed/widgets/feed_form.dart';
+import '../../feed/widgets/feed_avatar_picker.dart';
 
 class EditFeedView extends GetView<EditFeedController> {
   const EditFeedView({super.key});
@@ -37,6 +38,17 @@ class EditFeedView extends GetView<EditFeedController> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
+            Obx(() => Center(
+                  child: FeedAvatarPicker(
+                    file: controller.avatarFile.value,
+                    imageUrl: controller.feed.bigAvatar ??
+                        controller.feed.smallAvatar,
+                    color: controller.feed.color,
+                    foregroundColor: controller.feed.foregroundColor,
+                    onTap: controller.pickAvatar,
+                  ),
+                )),
+            const SizedBox(height: 16),
             FeedForm(
               titleController: controller.titleController,
               descriptionController: controller.descriptionController,

--- a/lib/pages/feed/widgets/feed_avatar_picker.dart
+++ b/lib/pages/feed/widgets/feed_avatar_picker.dart
@@ -1,0 +1,96 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:solar_icons/solar_icons.dart';
+
+import '../../../components/avatar_component.dart';
+
+class FeedAvatarPicker extends StatelessWidget {
+  final File? file;
+  final String? imageUrl;
+  final VoidCallback onTap;
+  final Color? color;
+  final Color? foregroundColor;
+
+  const FeedAvatarPicker({
+    super.key,
+    required this.file,
+    this.imageUrl,
+    required this.onTap,
+    this.color,
+    this.foregroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final hasAvatar =
+        file != null || (imageUrl != null && imageUrl!.isNotEmpty);
+    Widget avatarWidget;
+    if (file != null) {
+      avatarWidget = ClipRRect(
+        borderRadius: BorderRadius.circular(32),
+        child: Image.file(
+          file!,
+          width: 120,
+          height: 120,
+          fit: BoxFit.cover,
+        ),
+      );
+    } else if (imageUrl != null && imageUrl!.isNotEmpty) {
+      avatarWidget = ProfileAvatarComponent(
+        image: imageUrl!,
+        size: 120,
+        radius: 32,
+        color: color,
+        foregroundColor: foregroundColor,
+      );
+    } else {
+      avatarWidget = ClipRRect(
+        borderRadius: BorderRadius.circular(32),
+        child: Image.asset(
+          'assets/images/avatar.png',
+          width: 120,
+          height: 120,
+          fit: BoxFit.cover,
+        ),
+      );
+    }
+
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(32),
+          boxShadow: const [
+            BoxShadow(
+              color: Colors.black26,
+              blurRadius: 8,
+              offset: Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Stack(
+          children: [
+            avatarWidget,
+            if (hasAvatar)
+              Positioned.fill(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.black26,
+                    borderRadius: BorderRadius.circular(32),
+                  ),
+                  child: const Center(
+                    child: Icon(
+                      SolarIconsBold.cameraAdd,
+                      color: Colors.white,
+                      size: 30,
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `FeedAvatarPicker` widget
- enable avatar selection when creating feeds
- enable avatar editing in feeds
- upload avatars when editing feeds

## Testing
- `flutter test` *(fails: Selecting dark mode updates theme)*

------
https://chatgpt.com/codex/tasks/task_e_6888c8c89b688328ba834dee5d1305a0