### PR TITLE
Show placeholder for private feed

### DIFF
--- a/lib/pages/feed_page/views/feed_page_view.dart
+++ b/lib/pages/feed_page/views/feed_page_view.dart
@@ -52,6 +52,36 @@ class FeedPageView extends GetView<FeedPageController> {
       if (controller.loading.value || controller.feed.value == null) {
         return const Center(child: CircularProgressIndicator());
       }
+      final feed = controller.feed.value!;
+
+      // If the feed is private and the current user is not subscribed, show a
+      // placeholder instead of the posts.
+      if (feed.private == true &&
+          !controller.isOwner &&
+          !controller.subscribed.value) {
+        return RefreshIndicator(
+          onRefresh: controller.refreshFeed,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            children: [
+              _buildHeader(context),
+              const SizedBox(height: 16),
+              NothingToShowComponent(
+                icon: const Icon(Icons.lock_outline),
+                text: 'thisFeedIsPrivate'.tr,
+                buttonText: controller.requested.value
+                    ? 'requested'.tr
+                    : 'requestToJoin'.tr,
+                buttonAction: controller.requested.value
+                    ? null
+                    : controller.toggleSubscription,
+              ),
+              const SizedBox(height: 32),
+            ],
+          ),
+        );
+      }
+
       final state = controller.state.value;
       final body = RefreshIndicator(
         onRefresh: controller.refreshFeed,


### PR DESCRIPTION
## Summary
- show an empty message when viewing a private feed without a subscription

## Testing
- `flutter pub get`
- `flutter test` *(fails: TestDeviceException Shell subprocess terminated by SIGINT)*

------
https://chatgpt.com/codex/tasks/task_e_6888d1989b0c8328a2c03eb44eb8a9d1