### PR TITLE
Add subscribers count link in feed header

### DIFF
--- a/lib/pages/feed_page/views/feed_page_view.dart
+++ b/lib/pages/feed_page/views/feed_page_view.dart
@@ -74,6 +74,14 @@ class FeedPageView extends GetView<FeedPageController> {
               padding: const EdgeInsets.only(top: 8),
               child: Text(feed.description!),
             ),
+          TextButton.icon(
+            onPressed: () => Get.toNamed(
+              AppRoutes.subscribers,
+              arguments: feed.id,
+            ),
+            icon: const Icon(Icons.group_outlined),
+            label: Text('${feed.subscriberCount ?? 0} ${'followers'.tr}'),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- show subscriber count on feed header and link to subscribers list

## Testing
- `flutter pub get`
- `flutter test` *(fails: TestDeviceException)*

------
https://chatgpt.com/codex/tasks/task_e_6888d89a68a883289907a9c10d3238fe