### PR TITLE
Show subscriber count on profile feed tiles

### DIFF
--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -206,6 +206,14 @@ class _ProfileViewState extends State<ProfileView> {
                           textAlign: TextAlign.center,
                         ),
                       ],
+                      const SizedBox(height: 8),
+                      Text(
+                        '${feed.subscriberCount ?? 0} ${'followers'.tr}',
+                        style: Get.textTheme.bodySmall?.copyWith(
+                          color: textColor,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
                     ],
                   ),
                 ),


### PR DESCRIPTION
## Summary
- display number of followers for feeds on a user's profile

## Testing
- `flutter test` *(fails: TestDeviceException, Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6888d8ae4adc83289411e51c24152c97