### PR TITLE
Add popular posts section to Explore page

### DIFF
--- a/lib/pages/explore/controllers/explore_controller.dart
+++ b/lib/pages/explore/controllers/explore_controller.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../../models/feed.dart';
+import '../../../models/post.dart';
 import '../../../models/user.dart';
 import '../../../util/enums/feed_types.dart';
 
@@ -28,6 +29,9 @@ class ExploreController extends GetxController {
   /// Recently created feeds.
   final RxList<Feed> newFeeds = <Feed>[].obs;
 
+  /// Most popular recent posts from public feeds.
+  final RxList<Post> topPosts = <Post>[].obs;
+
   /// Popular feed genres.
   final RxList<FeedType> genres = <FeedType>[].obs;
 
@@ -51,6 +55,7 @@ class ExploreController extends GetxController {
       loadTopFeeds(),
       loadNewFeeds(),
       loadGenres(),
+      loadTopPosts(),
     ]);
   }
 
@@ -75,6 +80,21 @@ class ExploreController extends GetxController {
         .get();
     newFeeds.assignAll(snapshot.docs
         .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
+        .toList());
+  }
+
+  /// Queries the most popular recent posts from public feeds.
+  Future<void> loadTopPosts() async {
+    final snapshot = await _firestore
+        .collection('posts')
+        .where('feed.private', isEqualTo: false)
+        .orderBy('likes', descending: true)
+        .orderBy('createdAt', descending: true)
+        .limit(10)
+        .get();
+
+    topPosts.assignAll(snapshot.docs
+        .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
         .toList());
   }
 

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -5,6 +5,7 @@ import 'package:hoot/components/list_item_component.dart';
 import 'package:hoot/components/type_box_component.dart';
 import 'package:hoot/util/extensions/feed_extension.dart';
 import 'package:hoot/components/avatar_component.dart';
+import 'package:hoot/components/post_component.dart';
 import '../../../util/routes/app_routes.dart';
 import '../controllers/explore_controller.dart';
 
@@ -126,6 +127,30 @@ class ExploreView extends GetView<ExploreController> {
                       );
                     },
                   ),
+                ),
+              ),
+              const SizedBox(height: 32),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  'top10RecentPopularHoots'.tr,
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Obx(
+                () => ListView.builder(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: controller.topPosts.length,
+                  itemBuilder: (context, index) {
+                    final p = controller.topPosts[index];
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 16.0),
+                      child: PostComponent(post: p),
+                    );
+                  },
                 ),
               ),
               const SizedBox(height: 32),

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -170,6 +170,7 @@ class AppTranslations extends Translations {
           'noHoots': 'No hoots to show',
           'subscribeToSeeHoots': 'Subscribe to some feeds to see hoots here',
           'top10MostSubscribed': 'Top 10 most subscribed feeds',
+          'top10RecentPopularHoots': 'Top 10 most popular recent hoots',
           'upAndComing': 'Up and coming feeds',
           'upAndComingDescription': 'Recent feeds that are gaining popularity',
           'noteToUser': 'Note to @displayName',
@@ -511,6 +512,8 @@ class AppTranslations extends Translations {
           'subscribeToSeeHoots':
               'Suscríbete a algunos feeds para ver hoots aquí',
           'top10MostSubscribed': 'Top 10 de feeds más suscritos',
+          'top10RecentPopularHoots':
+              'Top 10 de hoots recientes más populares',
           'upAndComing': 'Feeds en Ascenso',
           'upAndComingDescription':
               'Feeds recientes que están ganando popularidad',
@@ -854,6 +857,8 @@ class AppTranslations extends Translations {
           'noHoots': 'Não há hoots para mostrar',
           'subscribeToSeeHoots': 'Subscreve a alguns feeds para ver hoots aqui',
           'top10MostSubscribed': 'Top 10 de feeds mais subscritos',
+          'top10RecentPopularHoots':
+              'Top 10 de hoots recentes mais populares',
           'upAndComing': 'Feeds em Ascensão',
           'upAndComingDescription':
               'Feeds recentes que estão a ganhar popularidade',
@@ -1194,6 +1199,8 @@ class AppTranslations extends Translations {
           'subscribeToSeeHoots':
               'Inscreva-se em alguns feeds para ver hoots aqui',
           'top10MostSubscribed': 'Top 10 dos feeds mais inscritos',
+          'top10RecentPopularHoots':
+              'Top 10 hoots recentes mais populares',
           'upAndComing': 'Novos em Ascensão',
           'upAndComingDescription':
               'Feeds recentes que estão ganhando popularidade',


### PR DESCRIPTION
## Summary
- load and display top posts from public feeds on the Explore page
- add translations for new "Top 10 most popular recent hoots" section

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e32b019c8328b1489e41c251f4c4