### PR TITLE
Add sentence capitalization to text inputs

### DIFF
--- a/lib/components/mention_text_field.dart
+++ b/lib/components/mention_text_field.dart
@@ -11,6 +11,7 @@ class MentionTextField extends StatelessWidget {
     this.maxLength,
     this.minLines,
     this.maxLines = 1,
+    this.textCapitalization = TextCapitalization.sentences,
     this.onSearchChanged,
     this.onChanged,
   });
@@ -21,6 +22,7 @@ class MentionTextField extends StatelessWidget {
   final int? maxLength;
   final int? minLines;
   final int maxLines;
+  final TextCapitalization textCapitalization;
   final ValueChanged<String>? onSearchChanged;
   final ValueChanged<String>? onChanged;
 
@@ -32,6 +34,7 @@ class MentionTextField extends StatelessWidget {
       minLines: minLines,
       maxLines: maxLines,
       decoration: InputDecoration(hintText: hintText),
+      textCapitalization: textCapitalization,
       onChanged: onChanged,
       onSearchChanged: (trigger, value) {
         if (trigger == '@') onSearchChanged?.call(value);

--- a/lib/pages/edit_profile/views/edit_profile_view.dart
+++ b/lib/pages/edit_profile/views/edit_profile_view.dart
@@ -186,12 +186,14 @@ class EditProfileView extends GetView<EditProfileController> {
             TextField(
               controller: controller.nameController,
               decoration: InputDecoration(labelText: 'displayName'.tr),
+              textCapitalization: TextCapitalization.sentences,
               maxLength: 50,
             ),
             const SizedBox(height: 16),
             TextField(
               controller: controller.bioController,
               decoration: InputDecoration(labelText: 'bio'.tr),
+              textCapitalization: TextCapitalization.sentences,
               maxLines: 3,
               maxLength: 160,
             ),

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -76,6 +76,7 @@ class ExploreView extends GetView<ExploreController> {
                     hintText: 'searchPlaceholder'.tr,
                     prefixIcon: const Icon(Icons.search),
                   ),
+                  textCapitalization: TextCapitalization.sentences,
                   onChanged: controller.search,
                 ),
               ),

--- a/lib/pages/feed/widgets/feed_form.dart
+++ b/lib/pages/feed/widgets/feed_form.dart
@@ -63,11 +63,13 @@ class FeedForm extends StatelessWidget {
         TextField(
           controller: titleController,
           decoration: InputDecoration(labelText: 'title'.tr),
+          textCapitalization: TextCapitalization.sentences,
         ),
         const SizedBox(height: 16),
         TextField(
           controller: descriptionController,
           decoration: InputDecoration(labelText: 'description'.tr),
+          textCapitalization: TextCapitalization.sentences,
           maxLines: 3,
         ),
         const SizedBox(height: 16),
@@ -127,6 +129,7 @@ class FeedForm extends StatelessWidget {
                     hintText: 'searchEllipsis'.tr,
                     border: const OutlineInputBorder(),
                   ),
+                  textCapitalization: TextCapitalization.sentences,
                 ),
               ),
               searchMatchFn: (item, searchValue) {

--- a/lib/pages/invitation/views/invitation_view.dart
+++ b/lib/pages/invitation/views/invitation_view.dart
@@ -81,6 +81,7 @@ class InvitationView extends GetView<InvitationController> {
                         controller: controller.codeController,
                         decoration:
                             InputDecoration(labelText: 'invitationCode'.tr),
+                        textCapitalization: TextCapitalization.sentences,
                       ),
                     ),
                     const SizedBox(height: 16),

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -43,7 +43,12 @@ class _ProfileViewState extends State<ProfileView> {
     final reasons = await showTextInputDialog(
       context: context,
       title: 'reportUsername'.trParams({'username': user.username ?? ''}),
-      textFields: [DialogTextField(hintText: 'reportInfo'.tr)],
+      textFields: [
+        DialogTextField(
+          hintText: 'reportInfo'.tr,
+          textCapitalization: TextCapitalization.sentences,
+        )
+      ],
     );
     final reason = reasons?.first;
     if (reason == null || reason.isEmpty) return;

--- a/lib/pages/welcome/views/welcome_view.dart
+++ b/lib/pages/welcome/views/welcome_view.dart
@@ -184,6 +184,7 @@ class _WelcomeViewState extends State<WelcomeView> {
                             labelText: 'displayName'.tr,
                             hintText: 'displayNameExample'.tr,
                           ),
+                          textCapitalization: TextCapitalization.sentences,
                         ),
                       );
                     case 1:


### PR DESCRIPTION
## Summary
- add `textCapitalization` to `MentionTextField`
- capitalize sentences in FeedForm text fields
- capitalize sentences in Explore search bar
- capitalize sentences in invitation code field
- capitalize sentences in edit profile name and bio
- capitalize sentences in Welcome display name
- set capitalization on Profile report dialog

## Testing
- `flutter analyze`
- `flutter test` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6888eaffa290832888fe270b8c0d020c