### PR TITLE
Add quick action shortcuts

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -5,6 +5,7 @@ import 'services/theme_service.dart';
 import 'services/post_service.dart';
 import 'services/subscription_service.dart';
 import 'services/feed_request_service.dart';
+import 'services/quick_actions_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -18,7 +19,9 @@ class DependencyInjector {
     Get.put<BasePostService>(PostService(), permanent: true);
     Get.put(SubscriptionService(), permanent: true);
     Get.put(FeedRequestService(), permanent: true);
+    Get.put(QuickActionsService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeMode();
+    await Get.find<QuickActionsService>().init();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'package:toastification/toastification.dart';
 import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'services/theme_service.dart';
+import 'services/quick_actions_service.dart';
 import 'firebase_options.dart';
 
 void main() {
@@ -27,6 +28,7 @@ void main() {
       options: DefaultFirebaseOptions.currentPlatform,
     );
     await DependencyInjector.init();
+    final quickActions = Get.find<QuickActionsService>();
     await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
     FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
 
@@ -61,6 +63,7 @@ void main() {
         ),
       ),
     );
+    quickActions.handlePendingAction();
     FlutterNativeSplash.remove();
   }, (error, stack) {
     FirebaseCrashlytics.instance.recordError(error, stack);

--- a/lib/services/quick_actions_service.dart
+++ b/lib/services/quick_actions_service.dart
@@ -1,0 +1,54 @@
+import 'package:get/get.dart';
+import 'package:quick_actions/quick_actions.dart';
+import '../util/routes/app_routes.dart';
+import '../pages/home/controllers/home_controller.dart';
+
+class QuickActionsService extends GetxService {
+  final QuickActions _quickActions = const QuickActions();
+  String? _pendingAction;
+
+  Future<void> init() async {
+    _quickActions.initialize((type) {
+      _pendingAction = type;
+    });
+    await _quickActions.setShortcutItems(<ShortcutItem>[
+      const ShortcutItem(
+        type: 'action_create_hoot',
+        localizedTitle: 'Create Hoot',
+        icon: 'ic_launcher',
+      ),
+      const ShortcutItem(
+        type: 'action_create_feed',
+        localizedTitle: 'Create Feed',
+        icon: 'ic_launcher',
+      ),
+      const ShortcutItem(
+        type: 'action_view_notifications',
+        localizedTitle: 'Notifications',
+        icon: 'ic_launcher',
+      ),
+    ]);
+  }
+
+  void handlePendingAction() {
+    final action = _pendingAction;
+    if (action == null) return;
+    _pendingAction = null;
+    switch (action) {
+      case 'action_create_hoot':
+        Get.toNamed(AppRoutes.createPost);
+        break;
+      case 'action_create_feed':
+        Get.toNamed(AppRoutes.createFeed);
+        break;
+      case 'action_view_notifications':
+        if (Get.currentRoute != AppRoutes.home) {
+          Get.offAllNamed(AppRoutes.home);
+        }
+        if (Get.isRegistered<HomeController>()) {
+          Get.find<HomeController>().changeIndex(2);
+        }
+        break;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   full_screen_image_null_safe: ^2.0.0
   animations: ^2.0.7
   package_info_plus: ^8.3.0
+  quick_actions: ^1.1.0
   image_cropper: ^9.1.0
   timeago: ^3.5.0
   flex_color_picker: ^3.2.2


### PR DESCRIPTION
## Summary
- add quick actions service
- wire service into startup
- expose create post, create feed and notifications actions

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888f938e36083289b1dafb8826178ac