### PR TITLE
Update quick action icons

### DIFF
--- a/lib/services/quick_actions_service.dart
+++ b/lib/services/quick_actions_service.dart
@@ -15,17 +15,17 @@ class QuickActionsService extends GetxService {
       const ShortcutItem(
         type: 'action_create_hoot',
         localizedTitle: 'Create Hoot',
-        icon: 'ic_launcher',
+        icon: 'ic_create_hoot',
       ),
       const ShortcutItem(
         type: 'action_create_feed',
         localizedTitle: 'Create Feed',
-        icon: 'ic_launcher',
+        icon: 'ic_create_feed',
       ),
       const ShortcutItem(
         type: 'action_view_notifications',
         localizedTitle: 'Notifications',
-        icon: 'ic_launcher',
+        icon: 'ic_notifications',
       ),
     ]);
   }


### PR DESCRIPTION
## Summary
- use specific icons for quick actions instead of the app launcher icon

## Testing
- `flutter pub get`
- `flutter test` *(fails: Some tests failed)*
- `flutter build apk --debug` *(fails: No Android SDK found)*
- `flutter build ios --no-codesign` *(fails: could not find option `--no-codesign`)*

------
https://chatgpt.com/codex/tasks/task_e_6888ff4a43048328b02282f4d9a04cff