### PR TITLE
Switch to basic Cupertino setup

### DIFF
--- a/lib/components/appbar_component.dart
+++ b/lib/components/appbar_component.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 class AppBarComponent extends StatelessWidget implements PreferredSizeWidget {
   final String? title;
@@ -18,29 +18,27 @@ class AppBarComponent extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AppBar(
-      elevation: 0,
-      centerTitle: false,
+    return CupertinoNavigationBar(
       backgroundColor: backgroundColor,
-      foregroundColor: foregroundColor,
-      scrolledUnderElevation: elevationDuringScroll,
-      shadowColor: Theme.of(context).colorScheme.surface.withValues(alpha: .25),
-      title: title != null ? PreferredSize(
-        preferredSize: preferredSize,
-        child: Text(
-          title!,
-          overflow: TextOverflow.fade,
-          style: Theme.of(context).textTheme.titleLarge!.copyWith(
-            color: foregroundColor ?? Theme.of(context).colorScheme.primary,
-            fontWeight: FontWeight.w900,
-            fontSize: 32,
-          ),
-        ),
-      ) : null,
-      actions: actions,
+      middle: title != null
+          ? Text(
+              title!,
+              overflow: TextOverflow.fade,
+              style: TextStyle(
+                color:
+                    foregroundColor ?? CupertinoTheme.of(context).primaryColor,
+                fontWeight: FontWeight.w900,
+                fontSize: 32,
+                fontFamily: 'Inter',
+              ),
+            )
+          : null,
+      trailing: actions != null
+          ? Row(mainAxisSize: MainAxisSize.min, children: actions!)
+          : null,
     );
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+  Size get preferredSize => const Size.fromHeight(44.0);
 }

--- a/lib/components/empty_message.dart
+++ b/lib/components/empty_message.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 class NothingToShowComponent extends StatelessWidget {
   final Icon icon;
@@ -28,14 +28,12 @@ class NothingToShowComponent extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 20.0),
-          if (buttonText != null && buttonAction != null) ElevatedButton(
-            onPressed: buttonAction,
-            style: ElevatedButtonTheme.of(context).style?.copyWith(
-              backgroundColor: WidgetStateProperty.all<Color>(Theme.of(context).colorScheme.secondaryContainer),
-              foregroundColor: WidgetStateProperty.all<Color>(Theme.of(context).colorScheme.onSecondaryContainer),
+          if (buttonText != null && buttonAction != null)
+            CupertinoButton.filled(
+              onPressed: buttonAction,
+              padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+              child: Text(buttonText!),
             ),
-            child: Text(buttonText!),
-          ),
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:get/get.dart';
 import 'package:hoot/util/routes/app_pages.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/dependency_injector.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:hoot/theme/theme.dart';
@@ -47,7 +47,7 @@ void main() {
       Portal(
         child: ToastificationWrapper(
           child: Obx(
-            () => GetMaterialApp(
+            () => GetCupertinoApp(
               title: 'Hoot',
               debugShowCheckedModeBanner: false,
               getPages: AppPages.pages,

--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -1,131 +1,21 @@
-import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'package:flutter/cupertino.dart';
 
 class AppTheme {
-  static Color primaryColor = Colors.blue;
+  static const Color primaryColor = CupertinoColors.activeBlue;
 
-  static ThemeData lightTheme = ThemeData(
-    useMaterial3: true,
+  static const CupertinoThemeData lightTheme = CupertinoThemeData(
     brightness: Brightness.light,
-    colorSchemeSeed: primaryColor,
-    appBarTheme: AppBarTheme(
-      centerTitle: false,
+    primaryColor: primaryColor,
+    textTheme: CupertinoTextThemeData(
+      textStyle: TextStyle(fontFamily: 'Inter'),
     ),
-    fontFamily: 'Inter',
-    textTheme: textTheme,
-    snackBarTheme: snackBarTheme,
-    elevatedButtonTheme: elevatedButtonTheme,
-    inputDecorationTheme: inputDecorationTheme,
-    dropdownMenuTheme: DropdownMenuThemeData(
-      inputDecorationTheme: inputDecorationTheme,
-    ),
-    chipTheme: chipTheme,
   );
 
-  static ThemeData darkTheme = ThemeData(
-      useMaterial3: true,
-      brightness: Brightness.dark,
-      colorSchemeSeed: primaryColor,
-      appBarTheme: AppBarTheme(
-        centerTitle: false,
-      ),
-      fontFamily: 'Inter',
-      textTheme: textTheme,
-      snackBarTheme: snackBarTheme,
-      elevatedButtonTheme: elevatedButtonTheme,
-      inputDecorationTheme: inputDecorationTheme.copyWith(
-        labelStyle: const TextStyle(color: Colors.white),
-        fillColor: Colors.grey.shade800,
-      ),
-      dropdownMenuTheme:
-          DropdownMenuThemeData(inputDecorationTheme: inputDecorationTheme),
-      chipTheme: chipTheme.copyWith(
-        backgroundColor: darkColorScheme.onPrimary,
-        labelStyle: TextStyle(
-          fontSize: 12,
-          color: darkColorScheme.primary,
-        ),
-        iconTheme: IconThemeData(size: 16, color: darkColorScheme.primary),
-      ));
-
-  static ColorScheme lightColorScheme = ColorScheme.fromSeed(
-    seedColor: primaryColor,
-    brightness: Brightness.light,
-  );
-
-  static ColorScheme darkColorScheme = ColorScheme.fromSeed(
-    seedColor: primaryColor,
+  static const CupertinoThemeData darkTheme = CupertinoThemeData(
     brightness: Brightness.dark,
-  );
-
-  static TextTheme get textTheme => GoogleFonts.interTextTheme().copyWith(
-    titleLarge: TextStyle(
-      fontSize: 24,
-      fontWeight: FontWeight.w900,
-    ),
-  );
-
-  static SnackBarThemeData snackBarTheme = SnackBarThemeData(
-    behavior: SnackBarBehavior.floating,
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.circular(10),
-    ),
-  );
-
-  static ElevatedButtonThemeData elevatedButtonTheme = ElevatedButtonThemeData(
-    style: ButtonStyle(
-      textStyle: WidgetStateProperty.all(
-        const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-      ),
-      elevation: WidgetStateProperty.all(0),
-      shape: WidgetStateProperty.all(
-        RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(20),
-          side: BorderSide.none,
-        ),
-      ),
-      backgroundColor: WidgetStateProperty.all(
-        primaryColor,
-      ),
-      foregroundColor: WidgetStateProperty.all(
-        Colors.white,
-      ),
-      padding: WidgetStateProperty.all(
-        const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-      ),
-    ),
-  );
-
-  static InputDecorationTheme inputDecorationTheme = InputDecorationTheme(
-    border: const OutlineInputBorder(
-      borderRadius: BorderRadius.all(Radius.circular(15)),
-      borderSide: BorderSide.none,
-    ),
-    focusedBorder: const OutlineInputBorder(
-      borderRadius: BorderRadius.all(Radius.circular(15)),
-      borderSide: BorderSide(color: Colors.blue, width: 2),
-    ),
-    filled: true,
-    fillColor: Colors.grey.shade200,
-    contentPadding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-    alignLabelWithHint: true,
-  );
-
-  static ChipThemeData chipTheme = ChipThemeData(
-    padding: const EdgeInsets.all(8),
-    shape: const RoundedRectangleBorder(
-      side: BorderSide.none,
-      borderRadius: BorderRadius.all(Radius.circular(100)),
-    ),
-    side: BorderSide.none,
-    backgroundColor: lightColorScheme.primary.withValues(alpha: 0.25),
-    labelStyle: TextStyle(
-      fontSize: 12,
-      color: lightColorScheme.primary,
-    ),
-    iconTheme: IconThemeData(
-      color: lightColorScheme.primary,
-      size: 16,
+    primaryColor: primaryColor,
+    textTheme: CupertinoTextThemeData(
+      textStyle: TextStyle(fontFamily: 'Inter'),
     ),
   );
 }

--- a/test/create_feed_controller_test.dart
+++ b/test/create_feed_controller_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:toastification/toastification.dart';

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:toastification/toastification.dart';

--- a/test/create_post_view_test.dart
+++ b/test/create_post_view_test.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -71,8 +71,8 @@ void main() {
       FlutterError.onError = FlutterError.dumpErrorToConsole;
     });
 
-    await tester.pumpWidget(const GetMaterialApp(
-      home: Scaffold(body: CreatePostView()),
+    await tester.pumpWidget(const GetCupertinoApp(
+      home: CupertinoPageScaffold(child: CreatePostView()),
     ));
     await tester.pumpAndSettle();
 

--- a/test/explore_view_test.dart
+++ b/test/explore_view_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
@@ -29,10 +29,10 @@ void main() {
     Get.put(ExploreController(firestore: firestore));
 
     await tester.pumpWidget(
-      GetMaterialApp(
+      GetCupertinoApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
-        home: const Scaffold(body: ExploreView()),
+        home: const CupertinoPageScaffold(child: ExploreView()),
       ),
     );
 
@@ -63,17 +63,17 @@ void main() {
     Get.put(ExploreController(firestore: firestore));
 
     await tester.pumpWidget(
-      GetMaterialApp(
+      GetCupertinoApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
         getPages: [
           GetPage(
             name: '/',
-            page: () => const Scaffold(body: ExploreView()),
+            page: () => const CupertinoPageScaffold(child: ExploreView()),
           ),
           GetPage(
             name: AppRoutes.profile,
-            page: () => const Scaffold(body: Text('profile page')),
+            page: () => const CupertinoPageScaffold(child: Text('profile page')),
           ),
         ],
       ),

--- a/test/feed_view_test.dart
+++ b/test/feed_view_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:hoot/models/post.dart';
@@ -37,8 +37,8 @@ void main() {
     Get.put<FeedController>(controller);
 
     await tester.pumpWidget(
-      const GetMaterialApp(
-        home: Scaffold(body: FeedView()),
+      const GetCupertinoApp(
+        home: CupertinoPageScaffold(child: FeedView()),
       ),
     );
 

--- a/test/home_view_test.dart
+++ b/test/home_view_test.dart
@@ -73,7 +73,7 @@ void main() {
     n.unreadCount.value = 2;
     Get.put<NotificationsController>(n);
 
-    await tester.pumpWidget(const GetMaterialApp(home: HomeView()));
+    await tester.pumpWidget(const GetCupertinoApp(home: HomeView()));
     await tester.pumpAndSettle();
 
     expect(find.text('2'), findsOneWidget);

--- a/test/invitation_view_test.dart
+++ b/test/invitation_view_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 
@@ -56,11 +56,11 @@ void main() {
         InvitationController(invitationService: FakeInvitationService()));
 
     await tester.pumpWidget(
-      GetMaterialApp(
+      GetCupertinoApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
         theme: AppTheme.lightTheme,
-        home: const InvitationView(),
+        home: const CupertinoPageScaffold(child: InvitationView()),
       ),
     );
     await tester.pumpAndSettle();

--- a/test/login_view_test.dart
+++ b/test/login_view_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 
@@ -54,7 +54,7 @@ void main() {
     Get.put(LoginController());
 
     await tester.pumpWidget(
-      GetMaterialApp(
+      GetCupertinoApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
         theme: AppTheme.lightTheme,

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hoot/models/user.dart';
 import 'package:hoot/models/feed.dart';

--- a/test/notifications_view_test.dart
+++ b/test/notifications_view_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
@@ -94,10 +94,10 @@ void main() {
     Get.put<NotificationsController>(controller);
 
     await tester.pumpWidget(
-      GetMaterialApp(
+      GetCupertinoApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
-        home: const NotificationsView(),
+        home: const CupertinoPageScaffold(child: NotificationsView()),
       ),
     );
     await tester.pumpAndSettle();
@@ -127,10 +127,10 @@ void main() {
     Get.put<NotificationsController>(controller);
 
     await tester.pumpWidget(
-      GetMaterialApp(
+      GetCupertinoApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
-        home: const NotificationsView(),
+        home: const CupertinoPageScaffold(child: NotificationsView()),
       ),
     );
     await tester.pumpAndSettle();
@@ -152,10 +152,10 @@ void main() {
     Get.put<NotificationsController>(controller);
 
     await tester.pumpWidget(
-      GetMaterialApp(
+      GetCupertinoApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
-        home: const NotificationsView(),
+        home: const CupertinoPageScaffold(child: NotificationsView()),
       ),
     );
     await tester.pumpAndSettle();

--- a/test/post_component_test.dart
+++ b/test/post_component_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/post_component.dart';
@@ -99,8 +99,9 @@ void main() {
 
     await tester.pumpWidget(
       ToastificationWrapper(
-        child: GetMaterialApp(
-          home: Scaffold(body: PostComponent(post: post, postService: service)),
+        child: GetCupertinoApp(
+          home: CupertinoPageScaffold(
+              child: PostComponent(post: post, postService: service)),
         ),
       ),
     );
@@ -133,8 +134,8 @@ void main() {
     Get.put<BasePostService>(service);
 
     await tester.pumpWidget(
-      GetMaterialApp(
-        home: Scaffold(body: PostComponent(post: post)),
+      GetCupertinoApp(
+        home: CupertinoPageScaffold(child: PostComponent(post: post)),
       ),
     );
     await tester.pumpAndSettle();

--- a/test/post_service_test.dart
+++ b/test/post_service_test.dart
@@ -5,7 +5,7 @@ import 'package:hoot/services/post_service.dart';
 import 'package:hoot/models/post.dart';
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/models/user.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 
 void main() {
   group('PostService', () {

--- a/test/profile_controller_test.dart
+++ b/test/profile_controller_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';

--- a/test/profile_view_test.dart
+++ b/test/profile_view_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -78,8 +78,8 @@ void main() {
     Get.put<AuthService>(service);
     Get.put<ProfileController>(controller);
 
-    await tester.pumpWidget(const GetMaterialApp(
-      home: Scaffold(body: ProfileView()),
+    await tester.pumpWidget(const GetCupertinoApp(
+      home: CupertinoPageScaffold(child: ProfileView()),
     ));
 
     await tester.pumpAndSettle();

--- a/test/services_test.dart
+++ b/test/services_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/toastification.dart';
 

--- a/test/subscriptions_view_test.dart
+++ b/test/subscriptions_view_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
@@ -74,10 +74,10 @@ void main() {
     Get.put<AuthService>(auth);
     Get.put<SubscriptionsController>(controller);
 
-    await tester.pumpWidget(GetMaterialApp(
+    await tester.pumpWidget(GetCupertinoApp(
       translations: AppTranslations(),
       locale: const Locale('en'),
-      home: const SubscriptionsView(),
+      home: const CupertinoPageScaffold(child: SubscriptionsView()),
     ));
     await tester.pumpAndSettle();
 
@@ -113,10 +113,10 @@ void main() {
     Get.put<AuthService>(auth);
     Get.put<SubscriptionsController>(controller);
 
-    await tester.pumpWidget(GetMaterialApp(
+    await tester.pumpWidget(GetCupertinoApp(
       translations: AppTranslations(),
       locale: const Locale('en'),
-      home: const SubscriptionsView(),
+      home: const CupertinoPageScaffold(child: SubscriptionsView()),
     ));
     await tester.pumpAndSettle();
 

--- a/test/theme_toggle_test.dart
+++ b/test/theme_toggle_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -53,7 +53,7 @@ void main() {
     Get.put(SettingsController());
 
     await tester.pumpWidget(
-      Obx(() => GetMaterialApp(
+      Obx(() => GetCupertinoApp(
             translations: AppTranslations(),
             locale: const Locale('en'),
             theme: AppTheme.lightTheme,


### PR DESCRIPTION
## Summary
- start migrating to Cupertino widgets
- create `CupertinoThemeData` in theme
- swap `GetMaterialApp` for `GetCupertinoApp`
- adjust a few components and tests

## Testing
- `flutter test` *(fails: no named parameter `darkTheme`, undefined Material symbols)*

------
https://chatgpt.com/codex/tasks/task_e_688932f26fa08328af266252ba644050