### PR TITLE
Fix quick actions navigation

### DIFF
--- a/lib/services/quick_actions_service.dart
+++ b/lib/services/quick_actions_service.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'package:flutter/widgets.dart';
 import 'package:quick_actions/quick_actions.dart';
 import '../util/routes/app_routes.dart';
 import '../pages/home/controllers/home_controller.dart';
@@ -10,6 +11,7 @@ class QuickActionsService extends GetxService {
   Future<void> init() async {
     _quickActions.initialize((type) {
       _pendingAction = type;
+      WidgetsBinding.instance.addPostFrameCallback((_) => handlePendingAction());
     });
     await _quickActions.setShortcutItems(<ShortcutItem>[
       const ShortcutItem(


### PR DESCRIPTION
## Summary
- ensure `QuickActionsService` handles actions even when the app is resumed

## Testing
- `dart format --set-exit-if-changed lib/services/quick_actions_service.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889377e04548328859f2822bb29037d