### PR TITLE
Add swipe left gesture to open post creation

### DIFF
--- a/lib/pages/home/views/home_view.dart
+++ b/lib/pages/home/views/home_view.dart
@@ -26,12 +26,18 @@ class HomeView extends GetView<HomeController> {
     return Obx(() {
       final index = controller.selectedIndex.value;
       final unread = Get.find<NotificationsController>().unreadCount.value;
-      return Scaffold(
-        body: IndexedStack(
-          index: index,
-          children: _pages,
-        ),
-        extendBody: true,
+      return GestureDetector(
+        onHorizontalDragEnd: (details) {
+          if (details.primaryVelocity != null && details.primaryVelocity! < 0) {
+            Get.toNamed(AppRoutes.createPost);
+          }
+        },
+        child: Scaffold(
+          body: IndexedStack(
+            index: index,
+            children: _pages,
+          ),
+          extendBody: true,
         bottomNavigationBar: Padding(
           padding: EdgeInsets.only(
             bottom: MediaQuery.of(context).padding.bottom + 8,

--- a/test/home_view_test.dart
+++ b/test/home_view_test.dart
@@ -11,6 +11,8 @@ import 'package:hoot/services/notification_service.dart';
 import 'package:hoot/services/feed_request_service.dart';
 import 'package:hoot/services/subscription_service.dart';
 import 'package:hoot/models/user.dart';
+import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/util/translations/app_translations.dart';
 
 class FakeAuthService extends GetxService implements AuthService {
   final U _user;
@@ -77,6 +79,33 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('2'), findsOneWidget);
+    Get.reset();
+  });
+
+  testWidgets('swiping left opens create post page', (tester) async {
+    Get.put<AuthService>(FakeAuthService(U(uid: 'u1', username: 't')));
+    Get.put(HomeController());
+    Get.put<NotificationsController>(TestNotificationsController());
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        translations: AppTranslations(),
+        locale: const Locale('en'),
+        getPages: [
+          GetPage(name: '/', page: () => const HomeView()),
+          GetPage(
+            name: AppRoutes.createPost,
+            page: () => const Scaffold(body: Text('create post page')),
+          ),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(HomeView), const Offset(-300, 0));
+    await tester.pumpAndSettle();
+
+    expect(find.text('create post page'), findsOneWidget);
     Get.reset();
   });
 }


### PR DESCRIPTION
## Summary
- navigate to the create-post page when swiping left on HomeView
- test that gesture opens the post creation page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889c83b0dcc83289a3e322d52e4f1f8