### PR TITLE
Improve ReHoot header

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -5,6 +5,7 @@ import 'package:hoot/components/name_component.dart';
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/models/post.dart';
 import 'package:get/get.dart';
+import 'package:flutter/gestures.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import '../util/routes/app_routes.dart';
@@ -53,6 +54,18 @@ class _PostComponentState extends State<PostComponent> {
             ? Get.find<BaseReportService>()
             : ReportService());
     super.initState();
+
+    if (_post.reFeeded &&
+        _post.reFeededFrom?.id != null &&
+        _post.reFeededFrom?.user == null) {
+      _postService.fetchPost(_post.reFeededFrom!.id).then((orig) {
+        if (orig != null) {
+          setState(() {
+            _post.reFeededFrom = orig;
+          });
+        }
+      });
+    }
   }
 
   Future<void> _toggleLike() async {
@@ -172,8 +185,29 @@ class _PostComponentState extends State<PostComponent> {
                   children: [
                     const Icon(SolarIconsOutline.refreshSquare, size: 16),
                     const SizedBox(width: 4),
-                    Text('reHoot'.tr,
-                        style: Theme.of(context).textTheme.bodySmall),
+                    RichText(
+                      text: TextSpan(
+                        style: Theme.of(context).textTheme.bodySmall,
+                        children: [
+                          TextSpan(text: '${'reHootOf'.tr} '),
+                          if (_post.reFeededFrom?.user != null)
+                            TextSpan(
+                              text:
+                                  '@${_post.reFeededFrom!.user!.username ?? ''}',
+                              style: const TextStyle(color: Colors.blue),
+                              recognizer: TapGestureRecognizer()
+                                ..onTap = () {
+                                  if (_post.reFeededFrom?.id != null) {
+                                    Get.toNamed(AppRoutes.post,
+                                        arguments: {'id': _post.reFeededFrom!.id});
+                                  }
+                                },
+                            )
+                          else
+                            const TextSpan(text: '@...'),
+                        ],
+                      ),
+                    ),
                   ],
                 ),
               ),

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -196,6 +196,7 @@ class AppTranslations extends Translations {
           'newReHoot': 'New ReHoot',
           'newMention': 'New Mention',
           'reHoot': 'ReHoot',
+          'reHootOf': 'ReHoot of',
           'deleteOnRefeededPost':
               'To delete, do this on the hoot created when reFeeded',
           'youNeedToCreateAFeedFirst': 'You need to create a feed first',
@@ -545,6 +546,7 @@ class AppTranslations extends Translations {
           'newReHoot': 'Nuevo ReHoot',
           'newMention': 'Nueva Mención',
           'reHoot': 'ReHoot',
+          'reHootOf': 'ReHoot de',
           'deleteOnRefeededPost':
               'Para eliminar, haz esto en el hoot creado cuando se rehootee',
           'youNeedToCreateAFeedFirst': 'Necesitas crear un feed primero',
@@ -895,6 +897,7 @@ class AppTranslations extends Translations {
           'newReHoot': 'Novo ReHoot',
           'newMention': 'Nova Menção',
           'reHoot': 'ReHoot',
+          'reHootOf': 'ReHoot de',
           'deleteOnRefeededPost':
               'Para eliminar, faz isto no hoot criado quando for rehootado',
           'youNeedToCreateAFeedFirst': 'Precisas de criar um feed primeiro',
@@ -1242,6 +1245,7 @@ class AppTranslations extends Translations {
           'newReHoot': 'Novo ReHoot',
           'newMention': 'Nova Menção',
           'reHoot': 'ReHoot',
+          'reHootOf': 'ReHoot de',
           'deleteOnRefeededPost':
               'Para excluir, faça isso no hoot criado quando for rehootado',
           'youNeedToCreateAFeedFirst': 'Você precisa criar um feed primeiro',

--- a/test/post_component_test.dart
+++ b/test/post_component_test.dart
@@ -139,7 +139,7 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    expect(find.text('reHoot'), findsOneWidget);
+    expect(find.textContaining('ReHoot'), findsOneWidget);
     Get.reset();
   });
 }


### PR DESCRIPTION
## Summary
- fetch original post to display original author info
- show `ReHoot of @username` with link to the original post
- update translations for new `reHootOf` string
- adjust widget test for new text

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889c93b507c8328b60ffed44723f3db