### PR TITLE
Add activity/popularity scores to user model

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -25,6 +25,8 @@ class U {
   bool? tester;
   DateTime? birthday;
   int? subscriptionCount;
+  int? activityScore;
+  int? popularityScore;
   List<Feed>? feeds;
 
   U({
@@ -49,6 +51,8 @@ class U {
     this.tester = false,
     this.birthday,
     this.subscriptionCount,
+    this.activityScore = 0,
+    this.popularityScore = 0,
     this.feeds,
   });
 
@@ -90,6 +94,8 @@ class U {
       tester: json['tester'],
       birthday: json['birthday'],
       subscriptionCount: json['subscriptionCount'],
+      activityScore: json['activityScore'],
+      popularityScore: json['popularityScore'],
       feeds: json['feeds'] != null
           ? List<Feed>.from(json['feeds'].map((x) => Feed.fromJson(x)))
           : [],
@@ -140,6 +146,8 @@ class U {
         'verified': verified,
         'tester': tester,
         'subscriptionCount': subscriptionCount,
+        'activityScore': activityScore,
+        'popularityScore': popularityScore,
         'feeds': feeds?.map((e) => e.toCache()).toList(),
       };
 }

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -6,6 +6,7 @@ import 'package:hoot/models/post.dart';
 import 'package:hoot/util/enums/feed_types.dart';
 
 import 'package:hoot/models/comment.dart';
+
 void main() {
   group('U JSON', () {
     test('fromJson and toJson round trip', () {
@@ -42,6 +43,8 @@ void main() {
         'tester': false,
         'birthday': DateTime(2020, 1, 1),
         'subscriptionCount': 2,
+        'activityScore': 5,
+        'popularityScore': 10,
         'feeds': [feedJson]
       };
 
@@ -52,6 +55,8 @@ void main() {
       expect(user.invitationCode, 'ABCDEF');
       expect(user.invitedBy, 'u0');
       expect(user.invitationUses, 1);
+      expect(user.activityScore, 5);
+      expect(user.popularityScore, 10);
 
       final json = user.toJson();
       expect(json['displayName'], 'John');


### PR DESCRIPTION
## Summary
- add activityScore and popularityScore properties to `U`
- parse and cache the new scores
- extend JSON round trip test

## Testing
- `flutter test test/models_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_6889c81de7148328b5c2fe904b1e1928