### PR TITLE
Add activity and popularity score fields

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -88,6 +88,8 @@ class AuthService {
       'invitationUses': 0,
       'invitationLastReset': FieldValue.serverTimestamp(),
       'createdAt': FieldValue.serverTimestamp(),
+      'activityScore': 0,
+      'popularityScore': 0,
     });
   }
 


### PR DESCRIPTION
## Summary
- initialize activityScore and popularityScore when creating a user document

## Testing
- `flutter pub get`
- `flutter test` *(fails: unhandled error during finalization of test)*

------
https://chatgpt.com/codex/tasks/task_e_6889cd1acb348328b0f6f0d33d9fadd7