### PR TITLE
Add subscriptions link to profile

### DIFF
--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -135,6 +135,16 @@ class _ProfileViewState extends State<ProfileView> {
                     user.bio!,
                   ),
                 ),
+              if (controller.isCurrentUser)
+                Padding(
+                  padding: const EdgeInsets.only(top: 16),
+                  child: TextButton.icon(
+                    onPressed: () =>
+                        Get.toNamed(AppRoutes.subscriptions),
+                    icon: const Icon(Icons.feed_outlined),
+                    label: Text('subscriptions'.tr),
+                  ),
+                ),
             ],
           ),
         ),

--- a/test/profile_view_test.dart
+++ b/test/profile_view_test.dart
@@ -88,5 +88,6 @@ void main() {
     expect(find.text('@tester'), findsOneWidget);
     expect(find.text('Hello'), findsOneWidget);
     expect(find.text('Feed 1'), findsOneWidget);
+    expect(find.text('Subscriptions'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add a button on the profile page linking to subscriptions
- update profile view test

## Testing
- `flutter pub get`
- `flutter test` *(fails: TestDeviceException & PathNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6889d9a8d4c08328aa87a9a639e4e85b