### PR TITLE
Fix subscriber list loading

### DIFF
--- a/test/subscription_service_test.dart
+++ b/test/subscription_service_test.dart
@@ -80,5 +80,27 @@ void main() {
       expect(banned.exists, isTrue);
       expect(feed.get('subscriberCount'), 0);
     });
+
+    test('fetchSubscribers returns all users even when more than 10', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = SubscriptionService(
+        firestore: firestore,
+      );
+      await firestore.collection('feeds').doc('f1').set({});
+      for (var i = 0; i < 11; i++) {
+        await firestore.collection('users').doc('u\$i').set({'uid': 'u\$i'});
+        await firestore
+            .collection('feeds')
+            .doc('f1')
+            .collection('subscribers')
+            .doc('u\$i')
+            .set({'createdAt': Timestamp.now()});
+      }
+
+      final result = await service.fetchSubscribers('f1');
+
+      expect(result.length, 11);
+      expect(result.first.uid, 'u0');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- handle batches of more than 10 subscriber IDs
- ensure `uid` is passed to user model
- cover fetching subscribers with a new test

## Testing
- `flutter test` *(fails: ProfileView shows profile information)*

------
https://chatgpt.com/codex/tasks/task_e_6889d9ba24348328b3e3e4259f80a181