### PR TITLE
Hide self-owned feeds in subscriptions list

### DIFF
--- a/lib/pages/subscriptions/controllers/subscriptions_controller.dart
+++ b/lib/pages/subscriptions/controllers/subscriptions_controller.dart
@@ -31,7 +31,9 @@ class SubscriptionsController extends GetxController {
     loading.value = true;
     try {
       final result = await _subscriptionService.fetchSubscribedFeeds(userId);
-      feeds.assignAll(result);
+      feeds.assignAll(
+        result.where((f) => f.userId != userId).toList(),
+      );
     } finally {
       loading.value = false;
     }


### PR DESCRIPTION
## Summary
- don't list feeds that belong to the current user in `SubscriptionsController`
- update subscription view tests

## Testing
- `flutter test test/subscriptions_view_test.dart --plain-name "SubscriptionsView shows subscribed feeds" -r expanded`
- `flutter test test/subscriptions_view_test.dart --plain-name "tapping unsubscribe removes feed" -r expanded`
- `flutter test test/subscriptions_view_test.dart --plain-name "SubscriptionsView does not show own feeds" -r expanded`
- `flutter test` *(fails: `create_post_view_test.dart` timed out)*

------
https://chatgpt.com/codex/tasks/task_e_6889de0801e883288babee96e39390cd