### PR TITLE
Handle feed request ordering and data

### DIFF
--- a/lib/models/feed_join_request.dart
+++ b/lib/models/feed_join_request.dart
@@ -1,0 +1,18 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'user.dart';
+
+class FeedJoinRequest {
+  final U user;
+  final DateTime createdAt;
+
+  FeedJoinRequest({required this.user, required this.createdAt});
+
+  factory FeedJoinRequest.fromJson(Map<String, dynamic> json) {
+    return FeedJoinRequest(
+      user: U.fromJson(json['user']),
+      createdAt: json['createdAt'] is Timestamp
+          ? (json['createdAt'] as Timestamp).toDate()
+          : DateTime.fromMillisecondsSinceEpoch(json['createdAt']['_seconds'] * 1000),
+    );
+  }
+}

--- a/lib/pages/feed_requests/controllers/feed_requests_controller.dart
+++ b/lib/pages/feed_requests/controllers/feed_requests_controller.dart
@@ -1,6 +1,6 @@
 import 'package:get/get.dart';
 
-import '../../../models/user.dart';
+import '../../../models/feed_join_request.dart';
 import '../../../services/feed_request_service.dart';
 import '../../../util/routes/app_routes.dart';
 
@@ -11,7 +11,7 @@ class FeedRequestsController extends GetxController {
       : _service = service ?? Get.find<FeedRequestService>();
 
   late String feedId;
-  final RxList<U> requests = <U>[].obs;
+  final RxList<FeedJoinRequest> requests = <FeedJoinRequest>[].obs;
   final RxBool loading = false.obs;
 
   @override
@@ -33,12 +33,12 @@ class FeedRequestsController extends GetxController {
 
   Future<void> accept(String userId) async {
     await _service.accept(feedId, userId);
-    requests.removeWhere((u) => u.uid == userId);
+    requests.removeWhere((r) => r.user.uid == userId);
   }
 
   Future<void> reject(String userId) async {
     await _service.reject(feedId, userId);
-    requests.removeWhere((u) => u.uid == userId);
+    requests.removeWhere((r) => r.user.uid == userId);
   }
 
   void openProfile(String userId) {

--- a/lib/pages/feed_requests/views/feed_requests_view.dart
+++ b/lib/pages/feed_requests/views/feed_requests_view.dart
@@ -27,7 +27,8 @@ class FeedRequestsView extends GetView<FeedRequestsController> {
         return ListView.builder(
           itemCount: controller.requests.length,
           itemBuilder: (context, index) {
-            final user = controller.requests[index];
+            final request = controller.requests[index];
+            final user = request.user;
             return ListTile(
               onTap: () => controller.openProfile(user.uid),
               leading: ProfileAvatarComponent(


### PR DESCRIPTION
## Summary
- include new model `FeedJoinRequest`
- chunk query results and preserve order in `FeedRequestService.fetchRequests`
- expose request timestamp information
- update controller and view to use `FeedJoinRequest`
- test fetching requests for >10 users and ordering

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e01a924083288dd2c78ae63e0baf