### PR TITLE
Add text confirmation for account deletion

### DIFF
--- a/lib/pages/settings/controllers/settings_controller.dart
+++ b/lib/pages/settings/controllers/settings_controller.dart
@@ -67,10 +67,20 @@ class SettingsController extends GetxController {
   }
 
   Future<void> deleteAccount(BuildContext context) async {
-    final confirmed = await DialogService.confirm(
+    var confirmed = await DialogService.confirm(
       context: context,
       title: 'deleteAccount'.tr,
-      message: 'deleteAccountDescription'.tr,
+      message: 'deleteAccountConfirmation'.tr,
+      okLabel: 'delete'.tr,
+      cancelLabel: 'cancel'.tr,
+    );
+    if (!confirmed) return;
+
+    confirmed = await DialogService.confirmWithText(
+      context: context,
+      title: 'deleteAccount'.tr,
+      message: 'deleteAccountVerify'.tr,
+      expectedWord: 'delete',
       okLabel: 'delete'.tr,
       cancelLabel: 'cancel'.tr,
     );

--- a/lib/services/dialog_service.dart
+++ b/lib/services/dialog_service.dart
@@ -22,6 +22,30 @@ class DialogService {
     return result == OkCancelResult.ok;
   }
 
+  /// Shows a confirmation dialog requiring the user to type [expectedWord]
+  /// before confirming. Returns true when the word is entered correctly.
+  static Future<bool> confirmWithText({
+    required BuildContext context,
+    required String title,
+    required String message,
+    required String expectedWord,
+    required String okLabel,
+    required String cancelLabel,
+  }) async {
+    final result = await showTextInputDialog(
+      context: context,
+      title: title,
+      message: message,
+      textFields: [
+        DialogTextField(autocorrect: false),
+      ],
+      okLabel: okLabel,
+      cancelLabel: cancelLabel,
+    );
+    final input = result?.first.trim().toLowerCase();
+    return input == expectedWord.toLowerCase();
+  }
+
   /// Shows a modal action sheet with the provided [actions].
   /// Returns the value associated with the selected action.
   static Future<T?> showActionSheet<T>({

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -295,6 +295,7 @@ class AppTranslations extends Translations {
               'This will delete your account and all your data. This action is irreversible.',
           'deleteAccountConfirmation':
               'Are you sure you want to delete your account?',
+          'deleteAccountVerify': "Type 'delete' to confirm.",
           'deleteAccountFailed': 'Failed to delete account',
           'deleteAccountSuccess': 'Account deleted successfully',
           'blockUser': 'Block @username',
@@ -653,6 +654,7 @@ class AppTranslations extends Translations {
               'Esto eliminará tu cuenta y todos tus datos. Esta acción es irreversible.',
           'deleteAccountConfirmation':
               '¿Estás seguro de que deseas eliminar tu cuenta?',
+          'deleteAccountVerify': "Escribe 'delete' para confirmar.",
           'deleteAccountFailed': 'No se pudo eliminar la cuenta',
           'deleteAccountSuccess': 'Cuenta eliminada exitosamente',
           'blockUser': 'Bloquear a @username',
@@ -1012,6 +1014,7 @@ class AppTranslations extends Translations {
               'Isto irá eliminar a tua conta e todos os teus dados. Esta ação é irreversível.',
           'deleteAccountConfirmation':
               'Tens a certeza de que queres eliminar a tua conta?',
+          'deleteAccountVerify': "Escreve 'delete' para confirmar.",
           'deleteAccountFailed': 'Não foi possível eliminar a conta',
           'deleteAccountSuccess': 'Conta eliminada com sucesso',
           'blockUser': 'Bloquear @username',
@@ -1368,6 +1371,7 @@ class AppTranslations extends Translations {
               'Isso excluirá sua conta e todos os seus dados. Essa ação é irreversível.',
           'deleteAccountConfirmation':
               'Tem certeza de que deseja excluir sua conta?',
+          'deleteAccountVerify': "Digite 'delete' para confirmar.",
           'deleteAccountFailed': 'Não foi possível excluir a conta',
           'deleteAccountSuccess': 'Conta excluída com sucesso',
           'blockUser': 'Bloquear @username',

--- a/test/services_test.dart
+++ b/test/services_test.dart
@@ -52,4 +52,60 @@ void main() {
 
     expect(await future, isTrue);
   });
+
+  testWidgets('DialogService confirmWithText succeeds when text matches',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SizedBox()),
+      ),
+    );
+
+    final context = tester.element(find.byType(Scaffold));
+
+    final future = DialogService.confirmWithText(
+      context: context,
+      title: 'Title',
+      message: 'Message',
+      expectedWord: 'delete',
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'DELETE');
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(await future, isTrue);
+  });
+
+  testWidgets('DialogService confirmWithText returns false on mismatch',
+      (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SizedBox()),
+      ),
+    );
+
+    final context = tester.element(find.byType(Scaffold));
+
+    final future = DialogService.confirmWithText(
+      context: context,
+      title: 'Title',
+      message: 'Message',
+      expectedWord: 'delete',
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'wrong');
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(await future, isFalse);
+  });
 }


### PR DESCRIPTION
## Summary
- add new translation `deleteAccountVerify`
- implement `DialogService.confirmWithText`
- require typing `delete` to remove account
- cover new dialog service method in tests

## Testing
- `flutter test test/services_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688a3e793ac483289ca9547c7aa36530