### PR TITLE
Add auth user deletion cleanup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ flutter pub get
 flutter test
 ```
 
+## Cloud Functions
+
+The backend includes a trigger named `onAuthUserDeleted` that runs whenever a Firebase Auth user is removed. It removes the user's Firestore document along with posts, subscriptions and notifications to satisfy EU data deletion rules.
+
 
 ## License
 

--- a/functions/shims/firebase-functions-v2-auth.ts
+++ b/functions/shims/firebase-functions-v2-auth.ts
@@ -1,0 +1,6 @@
+import { auth } from "firebase-functions/v1";
+import { UserRecord } from "firebase-functions/v1/auth";
+
+export function onUserDeleted(handler: (event: { data: UserRecord }) => any) {
+  return auth.user().onDelete((user) => handler({ data: user }));
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,6 +12,7 @@ import {setGlobalOptions} from "firebase-functions";
 import {initializeApp} from "firebase-admin/app";
 import {getFirestore, FieldValue} from "firebase-admin/firestore";
 import {onDocumentCreated, onDocumentDeleted, onDocumentWritten} from "firebase-functions/v2/firestore";
+import {onUserDeleted} from "firebase-functions/v2/auth";
 
 // Start writing functions
 // https://firebase.google.com/docs/functions/typescript
@@ -328,4 +329,82 @@ export const onFeedUpdated = onDocumentWritten(
     }
   }
 );
+
+// Triggered when an auth user is deleted.
+// EU GDPR: ensure all personal data is erased promptly.
+export const onAuthUserDeleted = onUserDeleted(async (event) => {
+  const uid = event.data.uid;
+
+  // Remove the main user document if it still exists.
+  await db.collection("users").doc(uid).delete().catch(() => undefined);
+
+  // Helper to commit batched deletes/updates (max 400 operations).
+  async function commitBatches(
+    refs: FirebaseFirestore.DocumentReference[],
+    update?: (batch: FirebaseFirestore.WriteBatch, ref: FirebaseFirestore.DocumentReference) => void
+  ) {
+    const batches: FirebaseFirestore.WriteBatch[] = [];
+    let batch = db.batch();
+    let count = 0;
+    for (const ref of refs) {
+      update ? update(batch, ref) : batch.delete(ref);
+      count++;
+      if (count === 400) {
+        batches.push(batch);
+        batch = db.batch();
+        count = 0;
+      }
+    }
+    if (count > 0) batches.push(batch);
+    for (const b of batches) {
+      await b.commit();
+    }
+  }
+
+  // Delete all posts created by the user.
+  const postsSnap = await db
+    .collection("posts")
+    .where("userId", "==", uid)
+    .get();
+  await commitBatches(postsSnap.docs.map((d) => d.ref));
+
+  // Delete notifications belonging to the user.
+  const notifsSnap = await db
+    .collection("users")
+    .doc(uid)
+    .collection("notifications")
+    .get();
+  await commitBatches(notifsSnap.docs.map((d) => d.ref));
+
+  // Remove subscriptions from user profile and feeds.
+  const subsSnap = await db
+    .collection("users")
+    .doc(uid)
+    .collection("subscriptions")
+    .get();
+
+  const batches: FirebaseFirestore.WriteBatch[] = [];
+  let batch = db.batch();
+  let count = 0;
+  for (const doc of subsSnap.docs) {
+    const feedId = doc.id;
+    batch.delete(doc.ref);
+    batch.delete(db.collection("feeds").doc(feedId).collection("subscribers").doc(uid));
+    batch.update(db.collection("feeds").doc(feedId), {
+      subscriberCount: FieldValue.increment(-1),
+    });
+    count += 3;
+    if (count >= 400) {
+      batches.push(batch);
+      batch = db.batch();
+      count = 0;
+    }
+  }
+  if (count > 0) batches.push(batch);
+  for (const b of batches) {
+    await b.commit();
+  }
+
+  // EU GDPR: ensure complete personal data removal after account deletion.
+});
 

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -8,7 +8,11 @@
     "outDir": "lib",
     "sourceMap": true,
     "strict": true,
-    "target": "es2017"
+    "target": "es2017",
+    "baseUrl": ".",
+    "paths": {
+      "firebase-functions/v2/auth": ["./shims/firebase-functions-v2-auth"]
+    }
   },
   "compileOnSave": true,
   "include": [


### PR DESCRIPTION
## Summary
- clean up user data when an auth user is removed
- document Cloud Function in README
- provide module alias for `onUserDeleted`

## Testing
- `npm run build`
- `flutter test test/post_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688a430aa664832881d79c11b57eb94a