### PR TITLE
Cascade delete reposts

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -231,15 +231,41 @@ export const onSubscriptionCreated = onDocumentCreated(
 export const onPostDeleted = onDocumentDeleted(
   "posts/{postId}",
   async (event) => {
+    const { postId } = event.params;
     const post = event.data?.data();
     if (!post) return;
 
+    // Delete all posts that reFeed this post
+    const reFeedSnap = await db
+      .collection("posts")
+      .where("reFeededFrom.id", "==", postId)
+      .get();
+
+    const batches: FirebaseFirestore.WriteBatch[] = [];
+    let batch = db.batch();
+    let count = 0;
+    for (const doc of reFeedSnap.docs) {
+      batch.delete(doc.ref);
+      count++;
+      if (count === 400) {
+        batches.push(batch);
+        batch = db.batch();
+        count = 0;
+      }
+    }
+    if (count > 0) batches.push(batch);
+    for (const b of batches) {
+      await b.commit();
+    }
+
+    // If this post is itself a reFeed, decrement the original's count
     if (post.reFeeded && post.reFeededFrom?.id) {
       const originalId = post.reFeededFrom.id as string;
-      await db
-        .collection("posts")
-        .doc(originalId)
-        .update({ reFeeds: FieldValue.increment(-1) });
+      const originalRef = db.collection("posts").doc(originalId);
+      const originalSnap = await originalRef.get();
+      if (originalSnap.exists) {
+        await originalRef.update({ reFeeds: FieldValue.increment(-1) });
+      }
     }
     await db
       .collection("users")


### PR DESCRIPTION
## Summary
- delete all reposts in Firestore when a post is removed
- avoid errors when updating repost count if original post is gone

## Testing
- `npm run build`
- `flutter test` *(fails: TestDeviceException & PathNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_688a6a1628848328bebc7a0d3cc41291