### PR TITLE
Update image dependency and imports

### DIFF
--- a/lib/components/avatar_component.dart
+++ b/lib/components/avatar_component.dart
@@ -1,7 +1,7 @@
 import 'package:figma_squircle/figma_squircle.dart';
 import 'package:flutter/material.dart';
 import 'package:full_screen_image_null_safe/full_screen_image_null_safe.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:hash_cached_image/hash_cached_image.dart';
 import 'package:solar_icons/solar_icons.dart';
 
 class ProfileAvatarComponent extends StatefulWidget {
@@ -117,10 +117,10 @@ class _AvatarState extends State<Avatar> {
         ),
       ),
       clipBehavior: Clip.hardEdge,
-      child: CachedNetworkImage(
+      child: HashCachedImage(
         imageUrl: widget.image,
-        placeholder: (context, url) => const SizedBox.shrink(),
-        errorWidget: (context, url, error) => Icon(
+        placeholder: (context) => const SizedBox.shrink(),
+        errorWidget: (context, error, stackTrace) => Icon(
           Icons.error,
           color: Theme.of(context).colorScheme.error,
         ),

--- a/lib/components/image_component.dart
+++ b/lib/components/image_component.dart
@@ -3,7 +3,7 @@ import 'package:get/get.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:liquid_glass_renderer/liquid_glass_renderer.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:hash_cached_image/hash_cached_image.dart';
 
 class ImageComponent extends StatefulWidget {
   final String url;
@@ -47,14 +47,14 @@ class _ImageComponentState extends State<ImageComponent> {
         ),
         child: ClipRRect(
           borderRadius: BorderRadius.circular(widget.radius),
-          child: CachedNetworkImage(
+          child: HashCachedImage(
             imageUrl: widget.url,
             width: widget.width,
             height: widget.height,
             fit: widget.fit,
             alignment: widget.alignment ?? Alignment.center,
             repeat: widget.repeat ?? ImageRepeat.noRepeat,
-            placeholder: (context, url) => Container(
+            placeholder: (context) => Container(
               color: Theme.of(context).colorScheme.secondaryContainer,
               child: Center(
                 child: LoadingAnimationWidget.inkDrop(
@@ -63,7 +63,7 @@ class _ImageComponentState extends State<ImageComponent> {
                 ),
               ),
             ),
-            errorWidget: (context, url, error) => Container(
+            errorWidget: (context, error, stackTrace) => Container(
               color: Colors.grey.shade800,
               child: const Icon(Icons.error, color: Colors.white),
             ),

--- a/lib/components/url_preview_component.dart
+++ b/lib/components/url_preview_component.dart
@@ -1,6 +1,6 @@
 import 'package:get/get.dart';
 import 'package:flutter/material.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:hash_cached_image/hash_cached_image.dart';
 import 'package:ogp_data_extract/ogp_data_extract.dart';
 import 'package:hoot/components/shimmer_skeletons.dart';
 import 'package:solar_icons/solar_icons.dart';
@@ -115,13 +115,13 @@ class _UrlPreviewComponentState extends State<UrlPreviewComponent> {
                       topLeft: Radius.circular(15),
                       bottomLeft: Radius.circular(15),
                     ),
-                    child: CachedNetworkImage(
+                    child: HashCachedImage(
                       imageUrl: _ogp.image ?? "https://i.gifer.com/DXKg.gif",
-                      errorWidget: (context, url, error) => Icon(
+                      errorWidget: (context, error, stackTrace) => Icon(
                         SolarIconsBold.shieldNetwork,
                         color: Theme.of(context).colorScheme.secondary,
                       ),
-                      placeholder: (context, url) => const SizedBox.shrink(),
+                      placeholder: (context) => const SizedBox.shrink(),
                       width: 100,
                       height: 100,
                       fit: BoxFit.cover,

--- a/lib/pages/about_your_data.dart
+++ b/lib/pages/about_your_data.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:hash_cached_image/hash_cached_image.dart';
 
 class AboutYourDataPage extends StatelessWidget {
   const AboutYourDataPage({super.key});
@@ -41,12 +41,12 @@ class AboutYourDataPage extends StatelessWidget {
     return Stack(
       children: [
         Positioned.fill(
-          child: CachedNetworkImage(
+          child: HashCachedImage(
             imageUrl: backgroundImage ??
                 'https://i.pinimg.com/originals/7b/84/9b/7b849be9e09eb87ddaa2a732ab2c8034.gif',
             fit: BoxFit.cover,
-            placeholder: (context, url) => const SizedBox.shrink(),
-            errorWidget: (context, url, error) =>
+            placeholder: (context) => const SizedBox.shrink(),
+            errorWidget: (context, error, stackTrace) =>
                 const Icon(Icons.error, color: Colors.red),
           ),
         ),
@@ -56,11 +56,11 @@ class AboutYourDataPage extends StatelessWidget {
                 left: 20,
                 right: 20,
                 bottom: 50,
-                child: CachedNetworkImage(
+                child: HashCachedImage(
                   imageUrl: image!,
                   fit: BoxFit.contain,
-                  placeholder: (context, url) => const SizedBox.shrink(),
-                  errorWidget: (context, url, error) =>
+                  placeholder: (context) => const SizedBox.shrink(),
+                  errorWidget: (context, error, stackTrace) =>
                       const Icon(Icons.error, color: Colors.red),
                 ),
               )

--- a/lib/pages/invitation/views/invitation_view.dart
+++ b/lib/pages/invitation/views/invitation_view.dart
@@ -1,5 +1,5 @@
 import 'package:animate_do/animate_do.dart';
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:hash_cached_image/hash_cached_image.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
@@ -18,7 +18,7 @@ class InvitationView extends GetView<InvitationController> {
             child: FadeIn(
               duration: const Duration(milliseconds: 500),
               delay: const Duration(milliseconds: 1000),
-              child: CachedNetworkImage(
+              child: HashCachedImage(
                 imageUrl:
                     'https://r1.ilikewallpaper.net/ipad-pro-wallpapers/download/100031/dark-blur-abstract-4k-ipad-pro-wallpaper-ilikewallpaper_com.jpg',
                 fit: BoxFit.cover,

--- a/lib/pages/photo_view/views/photo_view.dart
+++ b/lib/pages/photo_view/views/photo_view.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/pages/photo_view/controllers/photo_view_controller.dart';
@@ -10,7 +9,7 @@ class PhotoZoomView extends GetView<PhotoZoomViewController> {
   ImageProvider get provider {
     final imageUrl = controller.imageUrl;
     if (imageUrl.startsWith('http')) {
-      return CachedNetworkImageProvider(imageUrl);
+      return NetworkImage(imageUrl);
     } else {
       return AssetImage(imageUrl);
     }

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -1,4 +1,4 @@
-import 'package:cached_network_image/cached_network_image.dart';
+import 'package:hash_cached_image/hash_cached_image.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/util/extensions/feed_extension.dart';
@@ -193,7 +193,7 @@ class _ProfileViewState extends State<ProfileView> {
                   fit: StackFit.expand,
                   children: [
                     Positioned.fill(
-                      child: CachedNetworkImage(
+                      child: HashCachedImage(
                         imageUrl: feed.bigAvatar ??
                             controller.user.value?.largeProfilePictureUrl ??
                             '',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
+  blurhash:
+    dependency: "direct main"
+    description:
+      name: blurhash
+      sha256: d46ea05db7f5eceb9a1da6374e764adbdecb0b56bcd7e85d841496e51d880d5e
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  blurhash_dart:
+    dependency: transitive
+    description:
+      name: blurhash_dart
+      sha256: "43955b6c2e30a7d440028d1af0fa185852f3534b795cc6eb81fbf397b464409f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +122,7 @@ packages:
     source: hosted
     version: "2.1.2"
   cached_network_image:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: cached_network_image
       sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
@@ -518,6 +534,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.6"
+  flutter_blurhash:
+    dependency: transitive
+    description:
+      name: flutter_blurhash
+      sha256: "5e67678e479ac639069d7af1e133f4a4702311491188ff3e0227486430db0c06"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.2"
   flutter_cache_manager:
     dependency: transitive
     description:
@@ -720,6 +744,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  hash_cached_image:
+    dependency: "direct main"
+    description:
+      name: hash_cached_image
+      sha256: d18b79015662365da17174fb319f85ac450e01e10aa9af436d3e2df0d90ca617
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.2"
   html:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,8 @@ dependencies:
   flutter_signin_button: ^2.0.0
   sign_in_with_apple: ^7.0.1
   google_sign_in: ^6.3.0
-  cached_network_image: ^3.4.1
+  hash_cached_image: ^0.0.2
+  blurhash: ^1.2.0
   image_picker: ^1.0.0
   firebase_storage: ^12.4.10
   image: ^4.5.4


### PR DESCRIPTION
## Summary
- use `hash_cached_image` and remove direct `cached_network_image` usage
- add `blurhash` dependency
- update imports and widgets to use `HashCachedImage`

## Testing
- `flutter pub get`
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a6a93dfc08328a826b4b5a82ba333