### PR TITLE
Add blurhash for avatars

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -7,6 +7,8 @@ class U {
   String? username;
   String? smallProfilePictureUrl;
   String? largeProfilePictureUrl;
+  String? smallAvatarHash;
+  String? bigAvatarHash;
   String? bannerPictureUrl;
   double? radius;
   String? color;
@@ -35,6 +37,8 @@ class U {
     this.username,
     this.smallProfilePictureUrl,
     this.largeProfilePictureUrl,
+    this.smallAvatarHash,
+    this.bigAvatarHash,
     this.bannerPictureUrl,
     this.radius,
     this.color,
@@ -76,6 +80,8 @@ class U {
       username: json['username'],
       smallProfilePictureUrl: json['smallAvatar'],
       largeProfilePictureUrl: json['bigAvatar'],
+      smallAvatarHash: json['smallAvatarHash'],
+      bigAvatarHash: json['bigAvatarHash'],
       bannerPictureUrl: json['banner'],
       radius: double.tryParse(json['radius'].toString()),
       color: json['color'],
@@ -130,6 +136,8 @@ class U {
         'username': username,
         'smallAvatar': smallProfilePictureUrl,
         'bigAvatar': largeProfilePictureUrl,
+        'smallAvatarHash': smallAvatarHash,
+        'bigAvatarHash': bigAvatarHash,
         'banner': bannerPictureUrl,
         'radius': radius,
         'color': color,


### PR DESCRIPTION
## Summary
- calculate blurhashes for small and large avatars
- store blurhashes in Firestore and user model

## Testing
- `flutter test test/models_test.dart`
- `flutter test` *(fails: TestDeviceException)*

------
https://chatgpt.com/codex/tasks/task_e_688a7303c8048328b59c4f09873019d5