### PR TITLE
Fix duplicate likes on posts

### DIFF
--- a/lib/services/post_service.dart
+++ b/lib/services/post_service.dart
@@ -57,10 +57,12 @@ class PostService implements BasePostService {
     final postRef = _firestore.collection('posts').doc(postId);
     final likeRef = postRef.collection('likes').doc(userId);
     await _firestore.runTransaction((txn) async {
-      if (like) {
+      final likeSnap = await txn.get(likeRef);
+      final currentlyLiked = likeSnap.exists;
+      if (like && !currentlyLiked) {
         txn.set(likeRef, {'createdAt': FieldValue.serverTimestamp()});
         txn.update(postRef, {'likes': FieldValue.increment(1)});
-      } else {
+      } else if (!like && currentlyLiked) {
         txn.delete(likeRef);
         txn.update(postRef, {'likes': FieldValue.increment(-1)});
       }

--- a/test/post_service_test.dart
+++ b/test/post_service_test.dart
@@ -43,6 +43,30 @@ void main() {
           isFalse);
     });
 
+    test('toggleLike does not duplicate likes', () async {
+      final firestore = FakeFirebaseFirestore();
+      final service = PostService(
+        firestore: firestore,
+      );
+      await firestore.collection('posts').doc('p1').set({'likes': 0});
+
+      await service.toggleLike('p1', 'u1', true);
+      // Attempt to like again when already liked
+      await service.toggleLike('p1', 'u1', true);
+
+      final post = await firestore.collection('posts').doc('p1').get();
+      expect(post.get('likes'), 1);
+      expect(
+          (await firestore
+                  .collection('posts')
+                  .doc('p1')
+                  .collection('likes')
+                  .doc('u1')
+                  .get())
+              .exists,
+          isTrue);
+    });
+
     test('reFeed creates new post', () async {
       final firestore = FakeFirebaseFirestore();
       final service = PostService(


### PR DESCRIPTION
## Summary
- avoid incrementing likes multiple times
- add regression test for duplicate likes

## Testing
- `flutter test test/post_service_test.dart -r json`

------
https://chatgpt.com/codex/tasks/task_e_688a74409374832897b605f812d52883