### PR TITLE
Compute blurhash for post images

### DIFF
--- a/lib/pages/create_post/controllers/create_post_controller.dart
+++ b/lib/pages/create_post/controllers/create_post_controller.dart
@@ -41,10 +41,12 @@ class CreatePostController extends GetxController {
   final textController = TextEditingController();
 
   /// Controller for mention text field.
-  final GlobalKey<FlutterMentionsState> mentionKey = GlobalKey<FlutterMentionsState>();
+  final GlobalKey<FlutterMentionsState> mentionKey =
+      GlobalKey<FlutterMentionsState>();
 
   /// Mention suggestions for the text field.
-  final RxList<Map<String, dynamic>> mentionSuggestions = <Map<String, dynamic>>[].obs;
+  final RxList<Map<String, dynamic>> mentionSuggestions =
+      <Map<String, dynamic>>[].obs;
 
   /// Picked image files, up to 4.
   final RxList<File> imageFiles = <File>[].obs;
@@ -165,8 +167,12 @@ class CreatePostController extends GetxController {
 
       final postId = _postService.newPostId();
       List<String>? imageUrls;
+      List<String>? hashes;
       if (imageFiles.isNotEmpty) {
-        imageUrls = await _storageService.uploadPostImages(postId, imageFiles);
+        final uploaded =
+            await _storageService.uploadPostImages(postId, imageFiles);
+        imageUrls = uploaded.map((e) => e.url).toList();
+        hashes = uploaded.map((e) => e.blurHash).toList();
       }
 
       await _postService.createPost(
@@ -175,6 +181,7 @@ class CreatePostController extends GetxController {
             'feedId': feed.id,
             'feed': feedData,
             if (imageUrls != null) 'images': imageUrls,
+            if (hashes != null) 'hashes': hashes,
             if (gifUrl.value != null) 'gifs': [gifUrl.value],
             'userId': _userId,
             if (userData != null) 'user': userData,

--- a/lib/services/storage_service.dart
+++ b/lib/services/storage_service.dart
@@ -3,10 +3,19 @@ import 'dart:typed_data';
 
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:image/image.dart' as img;
+import 'package:blurhash/blurhash.dart';
 
 /// Interface for uploading post media to Firebase Storage.
+class UploadedPostImage {
+  final String url;
+  final String blurHash;
+
+  UploadedPostImage({required this.url, required this.blurHash});
+}
+
 abstract class BaseStorageService {
-  Future<List<String>> uploadPostImages(String postId, List<File> files);
+  Future<List<UploadedPostImage>> uploadPostImages(
+      String postId, List<File> files);
 }
 
 /// Default implementation uploading to the `posts` folder.
@@ -17,13 +26,15 @@ class StorageService implements BaseStorageService {
       : _storage = storage ?? FirebaseStorage.instance;
 
   @override
-  Future<List<String>> uploadPostImages(String postId, List<File> files) async {
-    final urls = <String>[];
+  Future<List<UploadedPostImage>> uploadPostImages(
+      String postId, List<File> files) async {
+    final results = <UploadedPostImage>[];
     for (var i = 0; i < files.length; i++) {
       final file = files[i];
       final ref = _storage.ref().child('posts').child(postId).child('$i.jpg');
 
       Uint8List data = await file.readAsBytes();
+      String hash = '';
       final decoded = img.decodeImage(data);
       if (decoded != null) {
         img.Image processed = decoded;
@@ -32,12 +43,13 @@ class StorageService implements BaseStorageService {
           processed = img.copyResize(processed, width: 1080);
         }
         data = Uint8List.fromList(img.encodeJpg(processed, quality: 85));
+        hash = await BlurHash.encode(data, 4, 3);
       }
 
       await ref.putData(data, SettableMetadata(contentType: 'image/jpeg'));
       final url = await ref.getDownloadURL();
-      urls.add(url);
+      results.add(UploadedPostImage(url: url, blurHash: hash));
     }
-    return urls;
+    return results;
   }
 }

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -48,7 +48,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }
@@ -57,10 +57,13 @@ class FakeStorageService extends GetxService implements BaseStorageService {
   List<List<File>> calls = [];
 
   @override
-  Future<List<String>> uploadPostImages(String postId, List<File> files) async {
+  Future<List<UploadedPostImage>> uploadPostImages(
+      String postId, List<File> files) async {
     calls.add(files);
     return files
-        .map((f) => 'https://example.com/${f.path.split('/').last}')
+        .map((f) => UploadedPostImage(
+            url: 'https://example.com/${f.path.split('/').last}',
+            blurHash: 'hash'))
         .toList();
   }
 }
@@ -236,6 +239,7 @@ void main() {
       final posts = await firestore.collection('posts').get();
       expect(
           posts.docs.first.data()['images'][0], 'https://example.com/img.jpg');
+      expect(posts.docs.first.data()['hashes'][0], 'hash');
     });
 
     testWidgets('available feeds loaded on init', (tester) async {

--- a/test/create_post_view_test.dart
+++ b/test/create_post_view_test.dart
@@ -47,14 +47,15 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }
 
 class FakeStorageService extends GetxService implements BaseStorageService {
   @override
-  Future<List<String>> uploadPostImages(String postId, List<File> files) async {
+  Future<List<UploadedPostImage>> uploadPostImages(
+      String postId, List<File> files) async {
     return [];
   }
 }


### PR DESCRIPTION
## Summary
- compute blurhash while uploading post images
- store blurhashes alongside image URLs in posts
- adjust tests for new upload result type

## Testing
- `flutter test` *(fails: SubscriptionService fetchSubscribers returns all users even when more than 10)*

------
https://chatgpt.com/codex/tasks/task_e_688a7709d22083288cadab7624f8a4f7