### PR TITLE
Implement liked flag retrieval

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -16,7 +16,7 @@ class DependencyInjector {
     final auth = Get.put(AuthService(), permanent: true);
     await auth.fetchUser();
     Get.put<BaseFeedService>(FeedService(), permanent: true);
-    Get.put<BasePostService>(PostService(), permanent: true);
+    Get.put<BasePostService>(PostService(authService: auth), permanent: true);
     Get.put(SubscriptionService(), permanent: true);
     Get.put(FeedRequestService(), permanent: true);
     Get.put(QuickActionsService(), permanent: true);

--- a/lib/services/feed_service.dart
+++ b/lib/services/feed_service.dart
@@ -69,6 +69,16 @@ class FeedService implements BaseFeedService {
         .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
         .toList();
 
+    for (final post in posts) {
+      final likeDoc = await _firestore
+          .collection('posts')
+          .doc(post.id)
+          .collection('likes')
+          .doc(user.uid)
+          .get();
+      post.liked = likeDoc.exists;
+    }
+
     return PostPage(
       posts: posts,
       lastDoc: postsSnapshot.docs.isNotEmpty ? postsSnapshot.docs.last : null,
@@ -119,6 +129,16 @@ class FeedService implements BaseFeedService {
     final posts = snapshot.docs
         .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
         .toList();
+
+    for (final post in posts) {
+      final likeDoc = await _firestore
+          .collection('posts')
+          .doc(post.id)
+          .collection('likes')
+          .doc(user.uid)
+          .get();
+      post.liked = likeDoc.exists;
+    }
 
     return PostPage(
       posts: posts,


### PR DESCRIPTION
## Summary
- track user likes when fetching posts
- propagate liked status to feed queries
- allow injecting `AuthService` into `PostService`
- register `PostService` with `AuthService`
- test liked flag handling

## Testing
- `flutter test test/post_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688a797e23b48328b3cbb2fbec3c1359