### PR TITLE
Integrate haptic feedback via service helpers

### DIFF
--- a/lib/components/image_component.dart
+++ b/lib/components/image_component.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/services/haptic_service.dart';
 import 'package:liquid_glass_renderer/liquid_glass_renderer.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
 import 'package:hash_cached_image/hash_cached_image.dart';
@@ -40,7 +41,10 @@ class _ImageComponentState extends State<ImageComponent> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-      onTap: _openViewer,
+      onTap: () {
+        HapticService.lightImpact();
+        _openViewer();
+      },
       child: LiquidGlass(
         shape: LiquidRoundedRectangle(
           borderRadius: Radius.circular(widget.radius),

--- a/lib/components/like_button_component.dart
+++ b/lib/components/like_button_component.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:solar_icons/solar_icons.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 class LikeButtonComponent extends StatefulWidget {
   final bool liked;
@@ -65,7 +66,10 @@ class _LikeButtonComponentState extends State<LikeButtonComponent>
         ? Colors.red
         : Theme.of(context).iconTheme.color;
     return GestureDetector(
-      onTap: widget.onTap,
+      onTap: () {
+        HapticService.lightImpact();
+        widget.onTap();
+      },
       child: SizedBox(
         width: widget.size + 20,
         height: widget.size + 20,

--- a/lib/components/name_component.dart
+++ b/lib/components/name_component.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/models/user.dart';
 import 'package:hoot/services/toast_service.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 class NameComponent extends StatelessWidget {
   final U user;
@@ -60,7 +61,10 @@ class NameComponent extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(left: 4),
                 child: GestureDetector(
-                    onTap: _onTapVerified,
+                    onTap: () {
+                      HapticService.lightImpact();
+                      _onTapVerified();
+                    },
                     child: color != Colors.blue
                         ? Icon(
                             Icons.verified_rounded,
@@ -77,7 +81,10 @@ class NameComponent extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.only(left: 4),
                 child: GestureDetector(
-                    onTap: _onTapTester,
+                    onTap: () {
+                      HapticService.lightImpact();
+                      _onTapTester();
+                    },
                     child: color != Colors.blue
                         ? Icon(
                             Icons.bug_report_rounded,

--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -17,6 +17,7 @@ import '../services/toast_service.dart';
 import '../services/report_service.dart';
 import '../util/mention_utils.dart';
 import '../util/extensions/datetime_extension.dart';
+import '../services/haptic_service.dart';
 
 class PostComponent extends StatefulWidget {
   final Post post;
@@ -188,7 +189,10 @@ class _PostComponentState extends State<PostComponent> {
         ],
       ),
       child: InkWell(
-        onTap: _openPostDetails,
+        onTap: () {
+          HapticService.lightImpact();
+          _openPostDetails();
+        },
         borderRadius: BorderRadius.circular(16),
         child: Padding(
           padding: const EdgeInsets.all(16.0),
@@ -232,6 +236,7 @@ class _PostComponentState extends State<PostComponent> {
                 children: [
                   GestureDetector(
                     onTap: () {
+                      HapticService.lightImpact();
                       if (_post.user != null) {
                         Get.toNamed(AppRoutes.profile, arguments: _post.user!.uid);
                       }
@@ -246,6 +251,7 @@ class _PostComponentState extends State<PostComponent> {
                   if (_post.user != null)
                     GestureDetector(
                       onTap: () {
+                        HapticService.lightImpact();
                         Get.toNamed(AppRoutes.profile, arguments: _post.user!.uid);
                       },
                       child: NameComponent(

--- a/lib/components/post_media_preview.dart
+++ b/lib/components/post_media_preview.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:hoot/components/image_component.dart';
 import 'package:solar_icons/solar_icons.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 class PostMediaPreview extends StatelessWidget {
   final List<File> imageFiles;
@@ -37,7 +38,10 @@ class PostMediaPreview extends StatelessWidget {
               child: Stack(
                 children: [
                   GestureDetector(
-                    onTap: () => onOpenViewer(file.path),
+                    onTap: () {
+                      HapticService.lightImpact();
+                      onOpenViewer(file.path);
+                    },
                     child: Container(
                       width: 100,
                       height: 100,
@@ -54,7 +58,10 @@ class PostMediaPreview extends StatelessWidget {
                     top: 4,
                     right: 4,
                     child: GestureDetector(
-                      onTap: () => onRemoveImage(i),
+                      onTap: () {
+                        HapticService.lightImpact();
+                        onRemoveImage(i);
+                      },
                       child: Container(
                         width: 24,
                         height: 24,
@@ -71,7 +78,10 @@ class PostMediaPreview extends StatelessWidget {
                     bottom: 4,
                     right: 4,
                     child: GestureDetector(
-                      onTap: () => onCropImage(i),
+                      onTap: () {
+                        HapticService.lightImpact();
+                        onCropImage(i);
+                      },
                       child: Container(
                         width: 24,
                         height: 24,
@@ -109,7 +119,10 @@ class PostMediaPreview extends StatelessWidget {
                 top: 4,
                 right: 4,
                 child: GestureDetector(
-                  onTap: onRemoveGif,
+                  onTap: () {
+                    HapticService.lightImpact();
+                    onRemoveGif();
+                  },
                   child: Container(
                     width: 24,
                     height: 24,

--- a/lib/components/url_preview_component.dart
+++ b/lib/components/url_preview_component.dart
@@ -5,6 +5,7 @@ import 'package:ogp_data_extract/ogp_data_extract.dart';
 import 'package:hoot/components/shimmer_skeletons.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:url_launcher/url_launcher_string.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 class UrlPreviewComponent extends StatefulWidget {
   final String url;
@@ -41,7 +42,12 @@ class _UrlPreviewComponentState extends State<UrlPreviewComponent> {
   Widget build(BuildContext context) {
     return _isLoading
         ? GestureDetector(
-            onTap: widget.isClickable ? _visitUrl : null,
+            onTap: widget.isClickable
+                ? () {
+                    HapticService.lightImpact();
+                    _visitUrl();
+                  }
+                : null,
             child: Container(
               decoration: BoxDecoration(
                 border: Border.all(
@@ -84,7 +90,12 @@ class _UrlPreviewComponentState extends State<UrlPreviewComponent> {
             ),
           )
         : GestureDetector(
-            onTap: widget.isClickable ? _visitUrl : null,
+            onTap: widget.isClickable
+                ? () {
+                    HapticService.lightImpact();
+                    _visitUrl();
+                  }
+                : null,
             child: Container(
               width: double.infinity,
               height: 100,

--- a/lib/pages/edit_profile/views/edit_profile_view.dart
+++ b/lib/pages/edit_profile/views/edit_profile_view.dart
@@ -4,6 +4,7 @@ import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/components/image_component.dart';
 import 'package:hoot/components/avatar_component.dart';
 import 'package:solar_icons/solar_icons.dart';
+import 'package:hoot/services/haptic_service.dart';
 import '../controllers/edit_profile_controller.dart';
 
 class EditProfileView extends GetView<EditProfileController> {
@@ -72,7 +73,10 @@ class EditProfileView extends GetView<EditProfileController> {
         child: Stack(
           children: [
             GestureDetector(
-              onTap: controller.pickBanner,
+              onTap: () {
+                HapticService.lightImpact();
+                controller.pickBanner();
+              },
               child: Stack(
                 children: [
                   Container(
@@ -110,7 +114,10 @@ class EditProfileView extends GetView<EditProfileController> {
               right: 16,
               child: Center(
                 child: GestureDetector(
-                  onTap: controller.pickAvatar,
+                  onTap: () {
+                    HapticService.lightImpact();
+                    controller.pickAvatar();
+                  },
                   child: Container(
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(32),

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -8,6 +8,7 @@ import 'package:hoot/components/avatar_component.dart';
 import 'package:hoot/components/post_component.dart';
 import '../../../util/routes/app_routes.dart';
 import '../controllers/explore_controller.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 class ExploreView extends GetView<ExploreController> {
   const ExploreView({super.key});
@@ -103,8 +104,10 @@ class ExploreView extends GetView<ExploreController> {
                     itemBuilder: (context, index) {
                       final u = controller.popularUsers[index];
                       return GestureDetector(
-                        onTap: () =>
-                            Get.toNamed(AppRoutes.profile, arguments: u.uid),
+                        onTap: () {
+                          HapticService.lightImpact();
+                          Get.toNamed(AppRoutes.profile, arguments: u.uid);
+                        },
                         child: Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 8),
                           child: ProfileAvatarComponent(
@@ -140,10 +143,13 @@ class ExploreView extends GetView<ExploreController> {
                       return SizedBox(
                         width: 250,
                         child: GestureDetector(
-                          onTap: () => Get.toNamed(
-                            AppRoutes.profile,
-                            arguments: {'uid': f.userId, 'feedId': f.id},
-                          ),
+                          onTap: () {
+                            HapticService.lightImpact();
+                            Get.toNamed(
+                              AppRoutes.profile,
+                              arguments: {'uid': f.userId, 'feedId': f.id},
+                            );
+                          },
                           child: ListItemComponent(
                             leading: ProfileAvatarComponent(
                               image: f.bigAvatar ?? '',
@@ -183,10 +189,13 @@ class ExploreView extends GetView<ExploreController> {
                       itemBuilder: (context, index) {
                         final type = controller.genres[index];
                         return GestureDetector(
-                          onTap: () => Get.toNamed(
-                            AppRoutes.searchByGenre,
-                            arguments: type,
-                          ),
+                          onTap: () {
+                            HapticService.lightImpact();
+                            Get.toNamed(
+                              AppRoutes.searchByGenre,
+                              arguments: type,
+                            );
+                          },
                           child: TypeBoxComponent(type: type),
                         );
                       },

--- a/lib/pages/feed/widgets/feed_avatar_picker.dart
+++ b/lib/pages/feed/widgets/feed_avatar_picker.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:solar_icons/solar_icons.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 import '../../../components/avatar_component.dart';
 
@@ -57,7 +58,10 @@ class FeedAvatarPicker extends StatelessWidget {
     }
 
     return GestureDetector(
-      onTap: onTap,
+      onTap: () {
+        HapticService.lightImpact();
+        onTap();
+      },
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(32),

--- a/lib/pages/feed/widgets/feed_form.dart
+++ b/lib/pages/feed/widgets/feed_form.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
 import 'package:dropdown_button2/dropdown_button2.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 import '../../../util/enums/feed_types.dart';
 
@@ -79,6 +80,7 @@ class FeedForm extends StatelessWidget {
                 const SizedBox(width: 8),
                 GestureDetector(
                   onTap: () async {
+                    HapticService.lightImpact();
                     final color = await showColorPickerDialog(
                       context,
                       selectedColor.value,

--- a/lib/pages/home/views/home_view.dart
+++ b/lib/pages/home/views/home_view.dart
@@ -11,6 +11,7 @@ import '../../notifications/views/notifications_view.dart';
 import '../../notifications/controllers/notifications_controller.dart';
 import '../../profile/views/profile_view.dart';
 import '../controllers/home_controller.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 class HomeView extends GetView<HomeController> {
   const HomeView({super.key});
@@ -30,6 +31,7 @@ class HomeView extends GetView<HomeController> {
       return GestureDetector(
         onHorizontalDragEnd: (details) {
           if (details.primaryVelocity != null && details.primaryVelocity! < 0) {
+            HapticService.lightImpact();
             Get.toNamed(AppRoutes.createPost);
           }
         },

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -8,6 +8,7 @@ import 'package:hoot/util/extensions/datetime_extension.dart';
 import 'package:solar_icons/solar_icons.dart';
 import '../../../util/routes/app_routes.dart';
 import '../controllers/notifications_controller.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 class NotificationsView extends GetView<NotificationsController> {
   const NotificationsView({super.key});
@@ -66,6 +67,7 @@ class NotificationsView extends GetView<NotificationsController> {
               }
               return GestureDetector(
                 onTap: () {
+                  HapticService.lightImpact();
                   switch (n.type) {
                     case 0:
                     case 1:
@@ -83,7 +85,7 @@ class NotificationsView extends GetView<NotificationsController> {
                       break;
                     case 3:
                       Get.toNamed(AppRoutes.profile, arguments: user.uid);
-                      break;
+                    break;
                   }
                 },
                 child: Padding(
@@ -94,8 +96,10 @@ class NotificationsView extends GetView<NotificationsController> {
                     small: true,
                     leadingRadius: 16,
                     leading: GestureDetector(
-                      onTap: () =>
-                          Get.toNamed(AppRoutes.profile, arguments: user.uid),
+                      onTap: () {
+                        HapticService.lightImpact();
+                        Get.toNamed(AppRoutes.profile, arguments: user.uid);
+                      },
                       child: ProfileAvatarComponent(
                         image: user.largeProfilePictureUrl ?? '',
                         size: 60,

--- a/lib/pages/photo_view/views/photo_view.dart
+++ b/lib/pages/photo_view/views/photo_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/pages/photo_view/controllers/photo_view_controller.dart';
 import 'package:photo_view/photo_view.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 class PhotoZoomView extends GetView<PhotoZoomViewController> {
   const PhotoZoomView({super.key});
@@ -24,7 +25,10 @@ class PhotoZoomView extends GetView<PhotoZoomViewController> {
       ),
       extendBodyBehindAppBar: true,
       body: GestureDetector(
-        onTap: () => Navigator.pop(context),
+        onTap: () {
+          HapticService.lightImpact();
+          Navigator.pop(context);
+        },
         child: PhotoView(
           heroAttributes: PhotoViewHeroAttributes(tag: controller.imageUrl),
           imageProvider: provider,

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -14,6 +14,7 @@ import '../controllers/profile_controller.dart';
 import '../../../services/report_service.dart';
 import '../../../services/toast_service.dart';
 import 'package:adaptive_dialog/adaptive_dialog.dart';
+import '../../../services/haptic_service.dart';
 
 class ProfileView extends StatefulWidget {
   const ProfileView({super.key});
@@ -165,7 +166,10 @@ class _ProfileViewState extends State<ProfileView> {
             (context, index) {
               if (controller.isCurrentUser && index == 0) {
                 return GestureDetector(
-                  onTap: () => Get.toNamed(AppRoutes.createFeed),
+                  onTap: () {
+                    HapticService.lightImpact();
+                    Get.toNamed(AppRoutes.createFeed);
+                  },
                   child: Container(
                     decoration: BoxDecoration(
                       borderRadius: BorderRadius.circular(8),
@@ -207,10 +211,13 @@ class _ProfileViewState extends State<ProfileView> {
                         padding: const EdgeInsets.all(16),
                         color: color.withAlpha(200),
                         child: InkWell(
-                          onTap: () => Get.toNamed(
-                            AppRoutes.feed,
-                            arguments: feed.id,
-                          ),
+                          onTap: () {
+                            HapticService.lightImpact();
+                            Get.toNamed(
+                              AppRoutes.feed,
+                              arguments: feed.id,
+                            );
+                          },
                           splashColor: Colors.white.withAlpha(50),
                           highlightColor: Colors.white.withAlpha(50),
                           borderRadius: BorderRadius.circular(16),

--- a/lib/pages/search_by_genre/views/search_by_genre_view.dart
+++ b/lib/pages/search_by_genre/views/search_by_genre_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/services/haptic_service.dart';
 import '../controllers/search_by_genre_controller.dart';
 import '../../../components/list_item_component.dart';
 import '../../../components/avatar_component.dart';
@@ -25,10 +26,13 @@ class SearchByGenreView extends GetView<SearchByGenreController> {
             itemBuilder: (context, index) {
               final feed = controller.feeds[index];
               return GestureDetector(
-                onTap: () => Get.toNamed(
-                  AppRoutes.profile,
-                  arguments: {'uid': feed.userId, 'feedId': feed.id},
-                ),
+                onTap: () {
+                  HapticService.lightImpact();
+                  Get.toNamed(
+                    AppRoutes.profile,
+                    arguments: {'uid': feed.userId, 'feedId': feed.id},
+                  );
+                },
                 child: ListItemComponent(
                   leading: ProfileAvatarComponent(
                     image: feed.bigAvatar ?? '',

--- a/lib/pages/subscriptions/views/subscriptions_view.dart
+++ b/lib/pages/subscriptions/views/subscriptions_view.dart
@@ -6,6 +6,7 @@ import '../../../components/avatar_component.dart';
 import '../../../components/list_item_component.dart';
 import '../../../components/empty_message.dart';
 import '../../../util/routes/app_routes.dart';
+import 'package:hoot/services/haptic_service.dart';
 import '../controllers/subscriptions_controller.dart';
 import '../../../util/extensions/feed_extension.dart';
 
@@ -35,10 +36,13 @@ class SubscriptionsView extends GetView<SubscriptionsController> {
           itemBuilder: (context, index) {
             final feed = controller.feeds[index];
             return GestureDetector(
-              onTap: () => Get.toNamed(
-                AppRoutes.profile,
-                arguments: {'uid': feed.userId, 'feedId': feed.id},
-              ),
+              onTap: () {
+                HapticService.lightImpact();
+                Get.toNamed(
+                  AppRoutes.profile,
+                  arguments: {'uid': feed.userId, 'feedId': feed.id},
+                );
+              },
               child: ListItemComponent(
                 leading: ProfileAvatarComponent(
                   image: feed.bigAvatar ?? '',

--- a/lib/pages/welcome/views/welcome_view.dart
+++ b/lib/pages/welcome/views/welcome_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:card_swiper/card_swiper.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
+import 'package:hoot/services/haptic_service.dart';
 
 import '../../avatar/controllers/avatar_controller.dart';
 import '../controllers/welcome_controller.dart';
@@ -284,7 +285,10 @@ class _WelcomeViewState extends State<WelcomeView> {
                   child: Column(
                     children: [
                       GestureDetector(
-                        onTap: _avatarController.pickAvatar,
+                        onTap: () {
+                          HapticService.lightImpact();
+                          _avatarController.pickAvatar();
+                        },
                         child: CircleAvatar(
                           radius: 64,
                           backgroundColor:

--- a/lib/services/haptic_service.dart
+++ b/lib/services/haptic_service.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class HapticService {
+  HapticService._();
+
+  static void lightImpact() {
+    HapticFeedback.lightImpact();
+  }
+
+  static void tap(BuildContext context) {
+    Feedback.forTap(context);
+  }
+}

--- a/test/like_button_component_test.dart
+++ b/test/like_button_component_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hoot/components/like_button_component.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('tapping like button triggers haptic feedback', (tester) async {
+    final calls = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (call) async {
+        calls.add(call);
+        return null;
+      },
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: LikeButtonComponent(
+          liked: false,
+          onTap: () {},
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byType(LikeButtonComponent));
+    await tester.pump();
+
+    expect(calls.any((c) => c.method == 'HapticFeedback.vibrate'), isTrue);
+
+    tester.binding.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+}


### PR DESCRIPTION
## Summary
- add `HapticService` with static tap and lightImpact helpers
- trigger `HapticService.lightImpact` from GestureDetector and InkWell handlers
- keep default feedback for standard buttons
- add widget test ensuring `LikeButtonComponent` invokes `HapticFeedback`

## Testing
- `flutter analyze`
- `flutter test test/like_button_component_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688a79a9f8588328919151d7e34a8b5d