### PR TITLE
Support blur hashes in models

### DIFF
--- a/lib/models/feed.dart
+++ b/lib/models/feed.dart
@@ -8,6 +8,8 @@ class Feed {
   String userId;
   String? smallAvatar;
   String? bigAvatar;
+  String? smallAvatarHash;
+  String? bigAvatarHash;
   String title;
   String? description;
   String? icon;
@@ -24,6 +26,8 @@ class Feed {
       required this.userId,
       this.smallAvatar,
       this.bigAvatar,
+      this.smallAvatarHash,
+      this.bigAvatarHash,
       required this.title,
       required this.description,
       this.icon,
@@ -41,6 +45,8 @@ class Feed {
       userId: json['userId'],
       smallAvatar: json['smallAvatar'] ?? json['imageUrl'],
       bigAvatar: json['bigAvatar'] ?? json['imageUrl'],
+      smallAvatarHash: json['smallAvatarHash'],
+      bigAvatarHash: json['bigAvatarHash'],
       title: json['title'],
       description: json['description'],
       icon: json['icon'],
@@ -65,6 +71,8 @@ class Feed {
         'icon': icon,
         'smallAvatar': smallAvatar,
         'bigAvatar': bigAvatar,
+        'smallAvatarHash': smallAvatarHash,
+        'bigAvatarHash': bigAvatarHash,
         'color': color!.hashCode.toString(),
         'type': type.toString().split('.').last,
         'private': private,
@@ -76,6 +84,8 @@ class Feed {
         'userId': userId,
         'smallAvatar': smallAvatar,
         'bigAvatar': bigAvatar,
+        'smallAvatarHash': smallAvatarHash,
+        'bigAvatarHash': bigAvatarHash,
         'title': title,
         'description': description,
         'icon': icon,

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -6,6 +6,7 @@ class Post {
   String id;
   String? text;
   List<String>? media;
+  List<String>? hashes;
   U? user;
   String? feedId;
   Feed? feed;
@@ -24,6 +25,7 @@ class Post {
     required this.id,
     this.text,
     this.media,
+    this.hashes,
     this.user,
     this.feedId,
     this.feed,
@@ -48,6 +50,8 @@ class Post {
           : json['gifs'] != null
               ? List<String>.from(json['gifs'])
               : null,
+      hashes:
+          json['hashes'] != null ? List<String>.from(json['hashes']) : null,
       feedId: json['feedId'],
       feed: json['feed'] != null ? Feed.fromJson(json['feed']) : null,
       user: json['user'] != null ? U.fromJson(json['user']) : null,
@@ -80,6 +84,7 @@ class Post {
       id: '0',
       text: 'ABC',
       media: [],
+      hashes: [],
       feedId: '0',
       feed: null,
       user: null,
@@ -98,6 +103,7 @@ class Post {
     return {
       'text': text,
       'images': media,
+      'hashes': hashes,
       'feedId': feedId,
     };
   }
@@ -107,6 +113,7 @@ class Post {
       'id': id,
       'text': text,
       'media': media,
+      'hashes': hashes,
       'feedId': feedId,
       'feed': feed?.toCache(),
       'user': user?.toCache(),
@@ -126,6 +133,7 @@ class Post {
       id: json['id'],
       text: json['text'],
       media: json['media'] != null ? List<String>.from(json['media']) : null,
+      hashes: json['hashes'] != null ? List<String>.from(json['hashes']) : null,
       feedId: json['feedId'],
       feed: json['feed'] != null ? Feed.fromJson(json['feed']) : null,
       user: json['user'] != null ? U.fromJson(json['user']) : null,

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -114,6 +114,8 @@ class U {
       'username': username,
       'smallAvatar': smallProfilePictureUrl,
       'bigAvatar': largeProfilePictureUrl,
+      'smallAvatarHash': smallAvatarHash,
+      'bigAvatarHash': bigAvatarHash,
       'banner': bannerPictureUrl,
       'radius': radius,
       'color': color,

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -18,6 +18,8 @@ void main() {
         'icon': 'i',
         'smallAvatar': 's.png',
         'bigAvatar': 'b.png',
+        'smallAvatarHash': 'shash',
+        'bigAvatarHash': 'bhash',
         'color': '123',
         'type': 'general',
       };
@@ -27,6 +29,8 @@ void main() {
         'username': 'john',
         'smallAvatar': 's.png',
         'bigAvatar': 'b.png',
+        'smallAvatarHash': 'uhash',
+        'bigAvatarHash': 'ubhash',
         'banner': 'ban.png',
         'radius': 1,
         'color': 'blue',
@@ -52,6 +56,8 @@ void main() {
       expect(user.uid, 'u1');
       expect(user.name, 'John');
       expect(user.feeds?.first.title, 'Feed');
+      expect(user.smallAvatarHash, 'uhash');
+      expect(user.bigAvatarHash, 'ubhash');
       expect(user.invitationCode, 'ABCDEF');
       expect(user.invitedBy, 'u0');
       expect(user.invitationUses, 1);
@@ -63,10 +69,14 @@ void main() {
       expect(json['username'], 'john');
       expect(json.containsKey('uid'), isFalse);
       expect(json['invitationCode'], 'ABCDEF');
+      expect(json['smallAvatarHash'], 'uhash');
+      expect(json['bigAvatarHash'], 'ubhash');
 
       final cache = user.toCache();
       expect(cache['activityScore'], 5);
       expect(cache['popularityScore'], 10);
+      expect(cache['smallAvatarHash'], 'uhash');
+      expect(cache['bigAvatarHash'], 'ubhash');
     });
   });
 
@@ -81,6 +91,8 @@ void main() {
         'icon': 'i',
         'smallAvatar': 's.png',
         'bigAvatar': 'avatar.png',
+        'smallAvatarHash': 'fsh',
+        'bigAvatarHash': 'fbh',
         'color': color.value.toString(),
         'type': 'music',
         'private': true,
@@ -97,11 +109,15 @@ void main() {
       expect(feed.color, Color(int.parse(color.value.toString())));
       expect(feed.type, FeedType.music);
       expect(feed.posts?.first.id, 'p1');
+      expect(feed.smallAvatarHash, 'fsh');
+      expect(feed.bigAvatarHash, 'fbh');
 
       final toJson = feed.toJson();
       expect(toJson['title'], 'T');
       expect(toJson['color'], feed.color!.hashCode.toString());
       expect(toJson.containsKey('id'), isFalse);
+      expect(toJson['smallAvatarHash'], 'fsh');
+      expect(toJson['bigAvatarHash'], 'fbh');
     });
   });
 
@@ -111,6 +127,7 @@ void main() {
         'id': 'p1',
         'text': 'hello',
         'feedId': 'f1',
+        'hashes': ['h1'],
         'liked': true,
         'likes': 2,
         'reFeeded': false,
@@ -123,10 +140,12 @@ void main() {
       final post = Post.fromJson(json);
       expect(post.createdAt, DateTime.fromMillisecondsSinceEpoch(10000));
       expect(post.updatedAt, DateTime.fromMillisecondsSinceEpoch(20000));
+      expect(post.hashes?.first, 'h1');
 
       final toJson = post.toJson();
       expect(toJson['text'], 'hello');
       expect(toJson['feedId'], 'f1');
+      expect(toJson['hashes'][0], 'h1');
       expect(toJson.containsKey('id'), isFalse);
     });
   });


### PR DESCRIPTION
## Summary
- add `hashes` to `Post` with serialization updates
- include avatar blur hash fields in `U`
- support feed avatar hashes
- test model changes

## Testing
- `flutter pub get`
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a7b43a4b48328865470702cdd3dbc