### PR TITLE
Add blur hash support for avatars and post images

### DIFF
--- a/lib/components/avatar_component.dart
+++ b/lib/components/avatar_component.dart
@@ -9,6 +9,7 @@ class ProfileAvatarComponent extends StatefulWidget {
   final int size;
   final bool preview;
   final String url;
+  final String? hash;
   final double radius;
   final Color? color;
   final Color? foregroundColor;
@@ -19,6 +20,7 @@ class ProfileAvatarComponent extends StatefulWidget {
       required this.size,
       this.preview = false,
       this.url = '',
+      this.hash,
       this.radius = -1,
       this.color,
       this.foregroundColor});
@@ -38,6 +40,7 @@ class _ProfileAvatarComponentState extends State<ProfileAvatarComponent> {
             tag: widget.image,
             child: Avatar(
               image: widget.image,
+              hash: widget.hash,
               size: widget.size,
               radius: widget.radius,
               color: widget.color,
@@ -49,6 +52,7 @@ class _ProfileAvatarComponentState extends State<ProfileAvatarComponent> {
     } else {
       return Avatar(
         image: widget.image,
+        hash: widget.hash,
         size: widget.size,
         radius: widget.radius,
         color: widget.color,
@@ -60,6 +64,7 @@ class _ProfileAvatarComponentState extends State<ProfileAvatarComponent> {
 
 class Avatar extends StatefulWidget {
   final String image;
+  final String? hash;
   final int size;
   final double radius;
   final Color? color;
@@ -68,6 +73,7 @@ class Avatar extends StatefulWidget {
   const Avatar(
       {super.key,
       required this.image,
+      this.hash,
       required this.size,
       required this.radius,
       this.color,
@@ -119,6 +125,7 @@ class _AvatarState extends State<Avatar> {
       clipBehavior: Clip.hardEdge,
       child: HashCachedImage(
         imageUrl: widget.image,
+        hash: widget.hash,
         placeholder: (context) => const SizedBox.shrink(),
         errorWidget: (context, error, stackTrace) => Icon(
           Icons.error,

--- a/lib/components/comment_component.dart
+++ b/lib/components/comment_component.dart
@@ -14,6 +14,7 @@ class CommentComponent extends StatelessWidget {
     return ListTile(
       leading: ProfileAvatarComponent(
         image: comment.user?.smallProfilePictureUrl ?? '',
+        hash: comment.user?.smallAvatarHash,
         size: 32,
         radius: 16,
       ),

--- a/lib/components/image_component.dart
+++ b/lib/components/image_component.dart
@@ -8,6 +8,7 @@ import 'package:hash_cached_image/hash_cached_image.dart';
 
 class ImageComponent extends StatefulWidget {
   final String url;
+  final String? hash;
   final double? width;
   final double? height;
   final BoxFit? fit;
@@ -18,6 +19,7 @@ class ImageComponent extends StatefulWidget {
   const ImageComponent(
       {super.key,
       required this.url,
+      this.hash,
       this.width,
       this.height,
       this.fit,
@@ -53,6 +55,7 @@ class _ImageComponentState extends State<ImageComponent> {
           borderRadius: BorderRadius.circular(widget.radius),
           child: HashCachedImage(
             imageUrl: widget.url,
+            hash: widget.hash,
             width: widget.width,
             height: widget.height,
             fit: widget.fit,

--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -243,6 +243,7 @@ class _PostComponentState extends State<PostComponent> {
                     },
                     child: ProfileAvatarComponent(
                       image: _post.user?.smallProfilePictureUrl ?? '',
+                      hash: _post.user?.smallAvatarHash,
                       size: 40,
                       radius: 12,
                     ),
@@ -290,6 +291,7 @@ class _PostComponentState extends State<PostComponent> {
                     aspectRatio: 1,
                     child: ImageComponent(
                       url: _post.media!.first,
+                      hash: _post.hashes?.first,
                       width: double.infinity,
                       fit: BoxFit.cover,
                       radius: 16,
@@ -314,6 +316,7 @@ class _PostComponentState extends State<PostComponent> {
                       itemBuilder: (context, i) {
                         return ImageComponent(
                           url: _post.media![i],
+                          hash: _post.hashes?[i],
                           fit: BoxFit.cover,
                           radius: 8,
                         );

--- a/lib/pages/edit_feed/views/edit_feed_view.dart
+++ b/lib/pages/edit_feed/views/edit_feed_view.dart
@@ -44,6 +44,8 @@ class EditFeedView extends GetView<EditFeedController> {
                     file: controller.avatarFile.value,
                     imageUrl: controller.feed.bigAvatar ??
                         controller.feed.smallAvatar,
+                    hash: controller.feed.bigAvatarHash ??
+                        controller.feed.smallAvatarHash,
                     color: controller.feed.color,
                     foregroundColor: controller.feed.foregroundColor,
                     onTap: controller.pickAvatar,

--- a/lib/pages/edit_profile/views/edit_profile_view.dart
+++ b/lib/pages/edit_profile/views/edit_profile_view.dart
@@ -63,6 +63,7 @@ class EditProfileView extends GetView<EditProfileController> {
       } else {
         avatarWidget = ProfileAvatarComponent(
           image: user?.largeProfilePictureUrl ?? '',
+          hash: user?.bigAvatarHash,
           size: 120,
           radius: 32,
         );

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -38,6 +38,7 @@ class ExploreView extends GetView<ExploreController> {
               (f) => ListTile(
                 leading: ProfileAvatarComponent(
                   image: f.smallAvatar ?? f.bigAvatar ?? '',
+                  hash: f.smallAvatarHash ?? f.bigAvatarHash,
                   size: 40,
                   radius: 20,
                   color: f.color,
@@ -113,6 +114,7 @@ class ExploreView extends GetView<ExploreController> {
                           child: ProfileAvatarComponent(
                             image: u.largeProfilePictureUrl ??
                                 '',
+                            hash: u.bigAvatarHash,
                             size: 80,
                             radius: 16,
                           ),
@@ -153,6 +155,7 @@ class ExploreView extends GetView<ExploreController> {
                           child: ListItemComponent(
                             leading: ProfileAvatarComponent(
                               image: f.bigAvatar ?? '',
+                              hash: f.bigAvatarHash,
                               size: 100,
                               radius: 16,
                               color: f.color,

--- a/lib/pages/feed/widgets/feed_avatar_picker.dart
+++ b/lib/pages/feed/widgets/feed_avatar_picker.dart
@@ -9,6 +9,7 @@ import '../../../components/avatar_component.dart';
 class FeedAvatarPicker extends StatelessWidget {
   final File? file;
   final String? imageUrl;
+  final String? hash;
   final VoidCallback onTap;
   final Color? color;
   final Color? foregroundColor;
@@ -17,6 +18,7 @@ class FeedAvatarPicker extends StatelessWidget {
     super.key,
     required this.file,
     this.imageUrl,
+    this.hash,
     required this.onTap,
     this.color,
     this.foregroundColor,
@@ -40,6 +42,7 @@ class FeedAvatarPicker extends StatelessWidget {
     } else if (imageUrl != null && imageUrl!.isNotEmpty) {
       avatarWidget = ProfileAvatarComponent(
         image: imageUrl!,
+        hash: hash,
         size: 120,
         radius: 32,
         color: color,

--- a/lib/pages/feed_page/views/feed_page_view.dart
+++ b/lib/pages/feed_page/views/feed_page_view.dart
@@ -60,6 +60,7 @@ class FeedPageView extends GetView<FeedPageController> {
         children: [
           ProfileAvatarComponent(
             image: feed.bigAvatar ?? '',
+            hash: feed.bigAvatarHash,
             size: 120,
             radius: 32,
             color: feed.color,

--- a/lib/pages/feed_requests/views/feed_requests_view.dart
+++ b/lib/pages/feed_requests/views/feed_requests_view.dart
@@ -36,6 +36,7 @@ class FeedRequestsView extends GetView<FeedRequestsController> {
               onTap: () => controller.openProfile(user.uid),
               leading: ProfileAvatarComponent(
                 image: user.smallProfilePictureUrl ?? '',
+                hash: user.smallAvatarHash,
                 size: 40,
                 radius: 20,
               ),

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -102,6 +102,7 @@ class NotificationsView extends GetView<NotificationsController> {
                       },
                       child: ProfileAvatarComponent(
                         image: user.largeProfilePictureUrl ?? '',
+                        hash: user.bigAvatarHash,
                         size: 60,
                         radius: 16,
                       ),

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -113,6 +113,7 @@ class _ProfileViewState extends State<ProfileView> {
                     ),
                     child: ProfileAvatarComponent(
                       image: user.largeProfilePictureUrl ?? '',
+                      hash: user.bigAvatarHash,
                       size: 120,
                       radius: 16,
                     ),
@@ -201,6 +202,8 @@ class _ProfileViewState extends State<ProfileView> {
                         imageUrl: feed.bigAvatar ??
                             controller.user.value?.largeProfilePictureUrl ??
                             '',
+                        hash: feed.bigAvatarHash ??
+                            controller.user.value?.bigAvatarHash,
                         width: double.infinity,
                         height: double.infinity,
                         fit: BoxFit.cover,

--- a/lib/pages/search_by_genre/views/search_by_genre_view.dart
+++ b/lib/pages/search_by_genre/views/search_by_genre_view.dart
@@ -36,6 +36,7 @@ class SearchByGenreView extends GetView<SearchByGenreController> {
                 child: ListItemComponent(
                   leading: ProfileAvatarComponent(
                     image: feed.bigAvatar ?? '',
+                    hash: feed.bigAvatarHash,
                     size: 100,
                     radius: 25,
                     color: feed.color,

--- a/lib/pages/subscribers/views/subscribers_view.dart
+++ b/lib/pages/subscribers/views/subscribers_view.dart
@@ -37,6 +37,7 @@ class SubscribersView extends GetView<SubscribersController> {
               onTap: () => Get.toNamed(AppRoutes.profile, arguments: user.uid),
               leading: ProfileAvatarComponent(
                 image: user.smallProfilePictureUrl ?? '',
+                hash: user.smallAvatarHash,
                 size: 40,
                 radius: 20,
               ),

--- a/lib/pages/subscriptions/views/subscriptions_view.dart
+++ b/lib/pages/subscriptions/views/subscriptions_view.dart
@@ -46,6 +46,7 @@ class SubscriptionsView extends GetView<SubscriptionsController> {
               child: ListItemComponent(
                 leading: ProfileAvatarComponent(
                   image: feed.bigAvatar ?? '',
+                  hash: feed.bigAvatarHash,
                   size: 100,
                   radius: 25,
                   color: feed.color,


### PR DESCRIPTION
## Summary
- support blur hashes in ImageComponent and Avatar
- plumb hash values through ProfileAvatarComponent and FeedAvatarPicker
- pass avatar and post image hashes throughout the UI

## Testing
- `flutter test` *(fails: Dart compiler exited unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_688a8018419883288ba1be85ba5bd49c