### PR TITLE
Show blur hash instead of loading indicator

### DIFF
--- a/lib/components/avatar_component.dart
+++ b/lib/components/avatar_component.dart
@@ -126,7 +126,9 @@ class _AvatarState extends State<Avatar> {
       child: HashCachedImage(
         imageUrl: widget.image,
         hash: widget.hash,
-        placeholder: (context) => const SizedBox.shrink(),
+        // When a blur hash is provided, `HashCachedImage` will automatically
+        // render the blurred placeholder while loading. Removing the custom
+        // placeholder ensures the blur hash is shown instead of an empty box.
         errorWidget: (context, error, stackTrace) => Icon(
           Icons.error,
           color: Theme.of(context).colorScheme.error,

--- a/lib/components/image_component.dart
+++ b/lib/components/image_component.dart
@@ -61,15 +61,10 @@ class _ImageComponentState extends State<ImageComponent> {
             fit: widget.fit,
             alignment: widget.alignment ?? Alignment.center,
             repeat: widget.repeat ?? ImageRepeat.noRepeat,
-            placeholder: (context) => Container(
-              color: Theme.of(context).colorScheme.secondaryContainer,
-              child: Center(
-                child: LoadingAnimationWidget.inkDrop(
-                  color: Theme.of(context).colorScheme.onSecondaryContainer,
-                  size: 50,
-                ),
-              ),
-            ),
+            // Show the blur hash while the image loads instead of a loading
+            // animation. Removing the placeholder parameter lets
+            // `HashCachedImage` fall back to its default behaviour, which
+            // uses the provided blur hash as a placeholder when available.
             errorWidget: (context, error, stackTrace) => Container(
               color: Colors.grey.shade800,
               child: const Icon(Icons.error, color: Colors.white),


### PR DESCRIPTION
## Summary
- switch image components to rely on blur hash placeholders
- remove empty placeholders from avatar component and other images

## Testing
- `flutter pub get`
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688a8eac65748328a0c21747e1baeb4b