### PR TITLE
Add subscription manager service

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -5,6 +5,7 @@ import 'services/theme_service.dart';
 import 'services/post_service.dart';
 import 'services/subscription_service.dart';
 import 'services/feed_request_service.dart';
+import 'services/subscription_manager.dart';
 import 'services/quick_actions_service.dart';
 
 /// Registers global dependencies for the application.
@@ -19,6 +20,7 @@ class DependencyInjector {
     Get.put<BasePostService>(PostService(authService: auth), permanent: true);
     Get.put(SubscriptionService(), permanent: true);
     Get.put(FeedRequestService(), permanent: true);
+    Get.put(SubscriptionManager(), permanent: true);
     Get.put(QuickActionsService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeMode();

--- a/lib/services/subscription_manager.dart
+++ b/lib/services/subscription_manager.dart
@@ -1,0 +1,57 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:get/get.dart';
+
+import '../models/user.dart';
+import 'feed_request_service.dart';
+import 'subscription_service.dart';
+
+/// Possible outcomes when toggling a feed subscription.
+enum SubscriptionResult { subscribed, unsubscribed, requested }
+
+/// Service handling subscription and join request logic.
+class SubscriptionManager {
+  final FirebaseFirestore _firestore;
+  final SubscriptionService _subscriptionService;
+  final FeedRequestService _feedRequestService;
+
+  SubscriptionManager({
+    FirebaseFirestore? firestore,
+    SubscriptionService? subscriptionService,
+    FeedRequestService? feedRequestService,
+  })  : _firestore = firestore ?? FirebaseFirestore.instance,
+        _subscriptionService =
+            subscriptionService ?? Get.find<SubscriptionService>(),
+        _feedRequestService =
+            feedRequestService ?? Get.find<FeedRequestService>();
+
+  /// Toggles the current subscription state for [feedId] and [user].
+  ///
+  /// Returns a [SubscriptionResult] describing the new state.
+  Future<SubscriptionResult> toggle(String feedId, U user) async {
+    final subDoc = await _firestore
+        .collection('users')
+        .doc(user.uid)
+        .collection('subscriptions')
+        .doc(feedId)
+        .get();
+
+    if (subDoc.exists) {
+      await _subscriptionService.unsubscribe(user.uid, feedId);
+      return SubscriptionResult.unsubscribed;
+    }
+
+    final feedDoc = await _firestore.collection('feeds').doc(feedId).get();
+    final isPrivate = feedDoc.data()?['private'] == true;
+
+    if (isPrivate) {
+      final hasRequest = await _feedRequestService.exists(feedId, user.uid);
+      if (!hasRequest) {
+        await _feedRequestService.submit(feedId, user.uid);
+      }
+      return SubscriptionResult.requested;
+    }
+
+    await _subscriptionService.subscribe(user.uid, feedId);
+    return SubscriptionResult.subscribed;
+  }
+}

--- a/test/subscription_manager_test.dart
+++ b/test/subscription_manager_test.dart
@@ -1,0 +1,163 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:get/get.dart';
+
+import 'package:hoot/services/subscription_manager.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/models/user.dart';
+
+import 'package:firebase_auth/firebase_auth.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U _user;
+  FakeAuthService(this._user);
+
+  @override
+  U? get currentUser => _user;
+
+  @override
+  Future<U?> fetchUser() async => _user;
+
+  @override
+  Future<U?> fetchUserById(String uid) async => _user;
+
+  @override
+  Future<U?> fetchUserByUsername(String username) async => _user;
+
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+
+  @override
+  Future<void> signOut() async {}
+
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+
+  @override
+  Future<void> deleteAccount() async {}
+
+  @override
+  Future<U?> refreshUser() async => _user;
+
+  @override
+  Future<void> createUserDocumentIfNeeded(User user) async {}
+}
+
+void main() {
+  group('SubscriptionManager.toggle', () {
+    test('unsubscribes when already subscribed', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('feeds').doc('f1').set({
+        'userId': 'owner',
+        'subscriberCount': 1,
+      });
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+      await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('subscriptions')
+          .doc('f1')
+          .set({'createdAt': Timestamp.now()});
+      await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('subscribers')
+          .doc('u1')
+          .set({'createdAt': Timestamp.now()});
+
+      final subscriptionService = SubscriptionService(firestore: firestore);
+      final feedRequestService = FeedRequestService(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+        authService: FakeAuthService(U(uid: 'owner')),
+      );
+      final manager = SubscriptionManager(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+        feedRequestService: feedRequestService,
+      );
+
+      final result = await manager.toggle('f1', U(uid: 'u1'));
+
+      expect(result, SubscriptionResult.unsubscribed);
+      final userSub = await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('subscriptions')
+          .doc('f1')
+          .get();
+      expect(userSub.exists, isFalse);
+    });
+
+    test('subscribes when not subscribed and feed is public', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('feeds').doc('f1').set({
+        'userId': 'owner',
+        'private': false,
+        'subscriberCount': 0,
+      });
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+
+      final subscriptionService = SubscriptionService(firestore: firestore);
+      final feedRequestService = FeedRequestService(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+        authService: FakeAuthService(U(uid: 'owner')),
+      );
+      final manager = SubscriptionManager(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+        feedRequestService: feedRequestService,
+      );
+
+      final result = await manager.toggle('f1', U(uid: 'u1'));
+
+      expect(result, SubscriptionResult.subscribed);
+      final userSub = await firestore
+          .collection('users')
+          .doc('u1')
+          .collection('subscriptions')
+          .doc('f1')
+          .get();
+      expect(userSub.exists, isTrue);
+    });
+
+    test('requests when feed is private', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('feeds').doc('f1').set({
+        'userId': 'owner',
+        'private': true,
+      });
+      await firestore.collection('users').doc('u1').set({'uid': 'u1'});
+
+      final subscriptionService = SubscriptionService(firestore: firestore);
+      final feedRequestService = FeedRequestService(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+        authService: FakeAuthService(U(uid: 'owner')),
+      );
+      final manager = SubscriptionManager(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+        feedRequestService: feedRequestService,
+      );
+
+      final result = await manager.toggle('f1', U(uid: 'u1'));
+
+      expect(result, SubscriptionResult.requested);
+      final request = await firestore
+          .collection('feeds')
+          .doc('f1')
+          .collection('requests')
+          .doc('u1')
+          .get();
+      expect(request.exists, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement `SubscriptionManager` with `toggle` logic
- register new service in `DependencyInjector`
- update feed and profile controllers to use `SubscriptionManager`
- add unit tests for the new service
- adjust profile controller tests

## Testing
- `flutter test test/profile_controller_test.dart --no-pub`
- `flutter test --no-pub` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688b175ceac483289464a4700617ab8f