### PR TITLE
Make currentUser reactive

### DIFF
--- a/test/create_feed_controller_test.dart
+++ b/test/create_feed_controller_test.dart
@@ -22,6 +22,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override
@@ -47,7 +53,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -23,6 +23,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override

--- a/test/create_post_view_test.dart
+++ b/test/create_post_view_test.dart
@@ -22,6 +22,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override

--- a/test/feed_request_service_test.dart
+++ b/test/feed_request_service_test.dart
@@ -17,6 +17,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override
@@ -42,7 +48,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/feed_service_test.dart
+++ b/test/feed_service_test.dart
@@ -16,6 +16,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override
@@ -41,7 +47,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/home_view_test.dart
+++ b/test/home_view_test.dart
@@ -25,6 +25,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override
@@ -50,7 +56,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/invitation_view_test.dart
+++ b/test/invitation_view_test.dart
@@ -23,6 +23,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => U(uid: 'u1');
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(U(uid: 'u1'));
+
+  @override
+  Rxn<U> get currentUserRx => (Rxn<U>()..value = U(uid: 'u1'));
+
+  @override
   Future<U?> fetchUser() async => currentUser;
 
   @override
@@ -48,7 +54,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => currentUser;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/login_view_test.dart
+++ b/test/login_view_test.dart
@@ -15,6 +15,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => null;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(null);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>();
+
+  @override
   Future<U?> fetchUser() async => null;
 
   @override
@@ -40,7 +46,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => currentUser;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/notifications_view_test.dart
+++ b/test/notifications_view_test.dart
@@ -22,6 +22,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override
@@ -47,7 +53,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/post_component_test.dart
+++ b/test/post_component_test.dart
@@ -19,6 +19,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override
@@ -44,7 +50,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/post_service_test.dart
+++ b/test/post_service_test.dart
@@ -19,6 +19,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override

--- a/test/profile_controller_test.dart
+++ b/test/profile_controller_test.dart
@@ -23,6 +23,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override

--- a/test/profile_view_test.dart
+++ b/test/profile_view_test.dart
@@ -19,6 +19,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override
@@ -47,7 +53,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/subscription_manager_test.dart
+++ b/test/subscription_manager_test.dart
@@ -19,6 +19,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override

--- a/test/subscriptions_view_test.dart
+++ b/test/subscriptions_view_test.dart
@@ -20,6 +20,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => _user;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(_user);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = _user;
+
+  @override
   Future<U?> fetchUser() async => _user;
 
   @override
@@ -45,7 +51,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => _user;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }

--- a/test/theme_toggle_test.dart
+++ b/test/theme_toggle_test.dart
@@ -17,6 +17,12 @@ class FakeAuthService extends GetxService implements AuthService {
   U? get currentUser => null;
 
   @override
+  Stream<U?> get currentUserStream => Stream.value(null);
+
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>();
+
+  @override
   Future<U?> fetchUser() async => null;
 
   @override
@@ -42,7 +48,7 @@ class FakeAuthService extends GetxService implements AuthService {
 
   @override
   Future<U?> refreshUser() async => currentUser;
-  
+
   @override
   Future<void> createUserDocumentIfNeeded(User user) async {}
 }


### PR DESCRIPTION
## Summary
- make the cached user an `Rxn` so changes emit updates
- expose `currentUserStream` and `currentUserRx`
- update tests to implement the new getters

## Testing
- `flutter test` *(fails: TestDeviceException, SubscriptionService fetchSubscribers returns all users even when more than 10)*

------
https://chatgpt.com/codex/tasks/task_e_688b24ef4b548328bbf4e2181deb6c93