### PR TITLE
Add typed route args

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -18,6 +18,7 @@ import '../services/report_service.dart';
 import '../util/mention_utils.dart';
 import '../util/extensions/datetime_extension.dart';
 import '../services/haptic_service.dart';
+import '../util/routes/args/profile_args.dart';
 
 class PostComponent extends StatefulWidget {
   final Post post;
@@ -208,7 +209,10 @@ class _PostComponentState extends State<PostComponent> {
                   horizontal: 16,
                 ),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surfaceContainer.withAlpha(100),
+                  color: Theme.of(context)
+                      .colorScheme
+                      .surfaceContainer
+                      .withAlpha(100),
                   border: Border(
                     bottom: BorderSide(
                       color: Theme.of(context).dividerColor.withAlpha(25),
@@ -228,13 +232,14 @@ class _PostComponentState extends State<PostComponent> {
                           if (_post.reFeededFrom?.user != null)
                             TextSpan(
                               text:
-                              '@${_post.reFeededFrom!.user!.username ?? ''}',
+                                  '@${_post.reFeededFrom!.user!.username ?? ''}',
                               style: const TextStyle(color: Colors.blue),
                               recognizer: TapGestureRecognizer()
                                 ..onTap = () {
                                   if (_post.reFeededFrom?.id != null) {
-                                    Get.toNamed(AppRoutes.post,
-                                        arguments: {'id': _post.reFeededFrom!.id});
+                                    Get.toNamed(AppRoutes.post, arguments: {
+                                      'id': _post.reFeededFrom!.id
+                                    });
                                   }
                                 },
                             )
@@ -257,7 +262,10 @@ class _PostComponentState extends State<PostComponent> {
                         onTap: () {
                           HapticService.lightImpact();
                           if (_post.user != null) {
-                            Get.toNamed(AppRoutes.profile, arguments: _post.user!.uid);
+                            Get.toNamed(
+                              AppRoutes.profile,
+                              arguments: ProfileArgs(uid: _post.user!.uid),
+                            );
                           }
                         },
                         child: ProfileAvatarComponent(
@@ -272,7 +280,10 @@ class _PostComponentState extends State<PostComponent> {
                         GestureDetector(
                           onTap: () {
                             HapticService.lightImpact();
-                            Get.toNamed(AppRoutes.profile, arguments: _post.user!.uid);
+                            Get.toNamed(
+                              AppRoutes.profile,
+                              arguments: ProfileArgs(uid: _post.user!.uid),
+                            );
                           },
                           child: NameComponent(
                             user: _post.user!,

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -7,6 +7,7 @@ import 'package:hoot/util/extensions/feed_extension.dart';
 import 'package:hoot/components/avatar_component.dart';
 import 'package:hoot/components/post_component.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../../util/routes/args/profile_args.dart';
 import '../controllers/explore_controller.dart';
 import 'package:hoot/services/haptic_service.dart';
 
@@ -31,7 +32,10 @@ class ExploreView extends GetView<ExploreController> {
               (u) => ListTile(
                 title: Text(u.name ?? ''),
                 subtitle: Text('@${u.username ?? ''}'),
-                onTap: () => Get.toNamed(AppRoutes.profile, arguments: u.uid),
+                onTap: () => Get.toNamed(
+                  AppRoutes.profile,
+                  arguments: ProfileArgs(uid: u.uid),
+                ),
               ),
             ),
             ...controller.feedSuggestions.map(
@@ -47,7 +51,7 @@ class ExploreView extends GetView<ExploreController> {
                 subtitle: Text('feed'.tr),
                 onTap: () => Get.toNamed(
                   AppRoutes.profile,
-                  arguments: {'uid': f.userId, 'feedId': f.id},
+                  arguments: ProfileArgs(uid: f.userId, feedId: f.id),
                 ),
               ),
             ),
@@ -106,13 +110,15 @@ class ExploreView extends GetView<ExploreController> {
                       return GestureDetector(
                         onTap: () {
                           HapticService.lightImpact();
-                          Get.toNamed(AppRoutes.profile, arguments: u.uid);
+                          Get.toNamed(
+                            AppRoutes.profile,
+                            arguments: ProfileArgs(uid: u.uid),
+                          );
                         },
                         child: Padding(
                           padding: const EdgeInsets.symmetric(horizontal: 8),
                           child: ProfileAvatarComponent(
-                            image: u.largeProfilePictureUrl ??
-                                '',
+                            image: u.largeProfilePictureUrl ?? '',
                             hash: u.bigAvatarHash ?? u.smallAvatarHash,
                             size: 80,
                           ),
@@ -147,7 +153,8 @@ class ExploreView extends GetView<ExploreController> {
                             HapticService.lightImpact();
                             Get.toNamed(
                               AppRoutes.profile,
-                              arguments: {'uid': f.userId, 'feedId': f.id},
+                              arguments:
+                                  ProfileArgs(uid: f.userId, feedId: f.id),
                             );
                           },
                           child: ListItemComponent(
@@ -219,11 +226,13 @@ class ExploreView extends GetView<ExploreController> {
                     final p = controller.topPosts[index];
                     return Padding(
                       padding: const EdgeInsets.only(bottom: 16.0),
-                      child: PostComponent(post: p,
+                      child: PostComponent(
+                        post: p,
                         margin: const EdgeInsets.symmetric(
                           horizontal: 16,
                           vertical: 0,
-                        ),),
+                        ),
+                      ),
                     );
                   },
                 ),

--- a/lib/pages/feed_page/bindings/feed_page_binding.dart
+++ b/lib/pages/feed_page/bindings/feed_page_binding.dart
@@ -1,9 +1,11 @@
 import 'package:get/get.dart';
 import '../controllers/feed_page_controller.dart';
+import '../../../util/routes/args/feed_page_args.dart';
 
 class FeedPageBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut(() => FeedPageController());
+    final args = Get.arguments as FeedPageArgs?;
+    Get.lazyPut(() => FeedPageController(args: args));
   }
 }

--- a/lib/pages/feed_page/controllers/feed_page_controller.dart
+++ b/lib/pages/feed_page/controllers/feed_page_controller.dart
@@ -11,8 +11,10 @@ import '../../../services/feed_request_service.dart';
 import '../../../services/subscription_manager.dart';
 import '../../../services/error_service.dart';
 import '../../../services/toast_service.dart';
+import '../../../util/routes/args/feed_page_args.dart';
 
 class FeedPageController extends GetxController {
+  final FeedPageArgs? args;
   final AuthService _authService;
   final BaseFeedService _feedService;
   final SubscriptionService _subscriptionService;
@@ -20,6 +22,7 @@ class FeedPageController extends GetxController {
   final SubscriptionManager _subscriptionManager;
 
   FeedPageController({
+    this.args,
     AuthService? authService,
     BaseFeedService? feedService,
     SubscriptionService? subscriptionService,
@@ -47,17 +50,12 @@ class FeedPageController extends GetxController {
   @override
   void onInit() {
     super.onInit();
-    final args = Get.arguments;
-    if (args is Feed) {
-      feed.value = args;
+    final a = args;
+    if (a?.feed != null) {
+      feed.value = a!.feed;
       _initState();
-    } else if (args is Map && args['feed'] is Feed) {
-      feed.value = args['feed'];
-      _initState();
-    } else if (args is String) {
-      _loadFeed(args);
-    } else if (args is Map && args['id'] is String) {
-      _loadFeed(args['id']);
+    } else if (a?.feedId != null) {
+      _loadFeed(a!.feedId!);
     }
   }
 

--- a/lib/pages/feed_requests/controllers/feed_requests_controller.dart
+++ b/lib/pages/feed_requests/controllers/feed_requests_controller.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import '../../../models/feed_join_request.dart';
 import '../../../services/feed_request_service.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../../util/routes/args/profile_args.dart';
 
 class FeedRequestsController extends GetxController {
   final FeedRequestService _service;
@@ -42,6 +43,6 @@ class FeedRequestsController extends GetxController {
   }
 
   void openProfile(String userId) {
-    Get.toNamed(AppRoutes.profile, arguments: userId);
+    Get.toNamed(AppRoutes.profile, arguments: ProfileArgs(uid: userId));
   }
 }

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -7,6 +7,7 @@ import 'package:hoot/components/list_item_component.dart';
 import 'package:hoot/util/extensions/datetime_extension.dart';
 import 'package:solar_icons/solar_icons.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../../util/routes/args/profile_args.dart';
 import '../controllers/notifications_controller.dart';
 import 'package:hoot/services/haptic_service.dart';
 
@@ -84,8 +85,11 @@ class NotificationsView extends GetView<NotificationsController> {
                       }
                       break;
                     case 3:
-                      Get.toNamed(AppRoutes.profile, arguments: user.uid);
-                    break;
+                      Get.toNamed(
+                        AppRoutes.profile,
+                        arguments: ProfileArgs(uid: user.uid),
+                      );
+                      break;
                   }
                 },
                 child: Padding(
@@ -98,7 +102,10 @@ class NotificationsView extends GetView<NotificationsController> {
                     leading: GestureDetector(
                       onTap: () {
                         HapticService.lightImpact();
-                        Get.toNamed(AppRoutes.profile, arguments: user.uid);
+                        Get.toNamed(
+                          AppRoutes.profile,
+                          arguments: ProfileArgs(uid: user.uid),
+                        );
                       },
                       child: ProfileAvatarComponent(
                         image: user.largeProfilePictureUrl ?? '',

--- a/lib/pages/profile/bindings/profile_binding.dart
+++ b/lib/pages/profile/bindings/profile_binding.dart
@@ -1,16 +1,12 @@
 import 'package:get/get.dart';
 import '../controllers/profile_controller.dart';
+import '../../../util/routes/args/profile_args.dart';
 
 class ProfileBinding extends Bindings {
   @override
   void dependencies() {
-    final args = Get.arguments;
-    String? uid;
-    if (args is String) {
-      uid = args;
-    } else if (args is Map && args['uid'] is String) {
-      uid = args['uid'] as String;
-    }
-    Get.lazyPut(() => ProfileController(), tag: uid ?? 'current');
+    final args = Get.arguments as ProfileArgs?;
+    Get.lazyPut(() => ProfileController(args: args),
+        tag: args?.uid ?? 'current');
   }
 }

--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -12,9 +12,11 @@ import '../../../services/error_service.dart';
 import '../../../services/feed_request_service.dart';
 import '../../../services/toast_service.dart';
 import '../../../services/subscription_manager.dart';
+import '../../../util/routes/args/profile_args.dart';
 
 /// Loads the current user profile data and owned feeds.
 class ProfileController extends GetxController {
+  final ProfileArgs? args;
   final AuthService _authService;
   final BaseFeedService _feedService;
   final SubscriptionService _subscriptionService;
@@ -22,12 +24,15 @@ class ProfileController extends GetxController {
   final SubscriptionManager _subscriptionManager;
 
   ProfileController({
+    this.args,
     AuthService? authService,
     BaseFeedService? feedService,
     SubscriptionService? subscriptionService,
     FeedRequestService? feedRequestService,
     SubscriptionManager? subscriptionManager,
-  })  : _authService = authService ?? Get.find<AuthService>(),
+  })  : uid = args?.uid,
+        initialFeedId = args?.feedId,
+        _authService = authService ?? Get.find<AuthService>(),
         _feedService = feedService ?? Get.find<BaseFeedService>(),
         _subscriptionService =
             subscriptionService ?? Get.find<SubscriptionService>(),
@@ -50,17 +55,6 @@ class ProfileController extends GetxController {
   @override
   void onInit() {
     super.onInit();
-    final args = Get.arguments;
-    if (args is String) {
-      uid = args;
-    } else if (args is Map) {
-      if (args['uid'] is String) {
-        uid = args['uid'] as String;
-      }
-      if (args['feedId'] is String) {
-        initialFeedId = args['feedId'] as String;
-      }
-    }
     loadProfile();
   }
 

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -10,6 +10,8 @@ import 'package:hoot/components/image_component.dart';
 import 'package:hoot/components/name_component.dart';
 import 'package:hoot/components/empty_message.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../../util/routes/args/profile_args.dart';
+import '../../../util/routes/args/feed_page_args.dart';
 import '../controllers/profile_controller.dart';
 import '../../../services/report_service.dart';
 import '../../../services/toast_service.dart';
@@ -29,14 +31,8 @@ class _ProfileViewState extends State<ProfileView> {
   @override
   void initState() {
     super.initState();
-    final args = Get.arguments;
-    String? uid;
-    if (args is String) {
-      uid = args;
-    } else if (args is Map && args['uid'] is String) {
-      uid = args['uid'] as String;
-    }
-    controller = Get.find<ProfileController>(tag: uid ?? 'current');
+    final args = Get.arguments as ProfileArgs?;
+    controller = Get.find<ProfileController>(tag: args?.uid ?? 'current');
   }
 
   Future<void> reportUser(BuildContext context) async {
@@ -217,7 +213,7 @@ class _ProfileViewState extends State<ProfileView> {
                             HapticService.lightImpact();
                             Get.toNamed(
                               AppRoutes.feed,
-                              arguments: feed.id,
+                              arguments: FeedPageArgs(feedId: feed.id),
                             );
                           },
                           splashColor: Colors.white.withAlpha(50),

--- a/lib/pages/search_by_genre/views/search_by_genre_view.dart
+++ b/lib/pages/search_by_genre/views/search_by_genre_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/util/routes/args/profile_args.dart';
 import 'package:hoot/services/haptic_service.dart';
 import '../controllers/search_by_genre_controller.dart';
 import '../../../components/list_item_component.dart';
@@ -30,7 +31,7 @@ class SearchByGenreView extends GetView<SearchByGenreController> {
                   HapticService.lightImpact();
                   Get.toNamed(
                     AppRoutes.profile,
-                    arguments: {'uid': feed.userId, 'feedId': feed.id},
+                    arguments: ProfileArgs(uid: feed.userId, feedId: feed.id),
                   );
                 },
                 child: ListItemComponent(

--- a/lib/pages/subscribers/views/subscribers_view.dart
+++ b/lib/pages/subscribers/views/subscribers_view.dart
@@ -6,6 +6,7 @@ import '../../../components/avatar_component.dart';
 import '../../../components/name_component.dart';
 import '../../../components/empty_message.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../../util/routes/args/profile_args.dart';
 import '../../../services/dialog_service.dart';
 
 class SubscribersView extends GetView<SubscribersController> {
@@ -34,7 +35,10 @@ class SubscribersView extends GetView<SubscribersController> {
           itemBuilder: (context, index) {
             final user = controller.subscribers[index];
             return ListTile(
-              onTap: () => Get.toNamed(AppRoutes.profile, arguments: user.uid),
+              onTap: () => Get.toNamed(
+                AppRoutes.profile,
+                arguments: ProfileArgs(uid: user.uid),
+              ),
               leading: ProfileAvatarComponent(
                 image: user.smallProfilePictureUrl ?? '',
                 hash: user.smallAvatarHash ?? user.bigAvatarHash,

--- a/lib/pages/subscriptions/views/subscriptions_view.dart
+++ b/lib/pages/subscriptions/views/subscriptions_view.dart
@@ -6,6 +6,7 @@ import '../../../components/avatar_component.dart';
 import '../../../components/list_item_component.dart';
 import '../../../components/empty_message.dart';
 import '../../../util/routes/app_routes.dart';
+import '../../../util/routes/args/profile_args.dart';
 import 'package:hoot/services/haptic_service.dart';
 import '../controllers/subscriptions_controller.dart';
 import '../../../util/extensions/feed_extension.dart';
@@ -40,7 +41,7 @@ class SubscriptionsView extends GetView<SubscriptionsController> {
                 HapticService.lightImpact();
                 Get.toNamed(
                   AppRoutes.profile,
-                  arguments: {'uid': feed.userId, 'feedId': feed.id},
+                  arguments: ProfileArgs(uid: feed.userId, feedId: feed.id),
                 );
               },
               child: ListItemComponent(
@@ -52,8 +53,7 @@ class SubscriptionsView extends GetView<SubscriptionsController> {
                   foregroundColor: feed.foregroundColor,
                 ),
                 title: feed.title,
-                subtitle:
-                    '${feed.subscriberCount ?? 0} ${'followers'.tr}',
+                subtitle: '${feed.subscriberCount ?? 0} ${'followers'.tr}',
                 trailing: IconButton(
                   icon: const Icon(Icons.cancel),
                   tooltip: 'unsubscribe'.tr,

--- a/lib/util/mention_utils.dart
+++ b/lib/util/mention_utils.dart
@@ -4,6 +4,7 @@ import 'package:get/get.dart';
 
 import '../services/auth_service.dart';
 import '../util/routes/app_routes.dart';
+import '../util/routes/args/profile_args.dart';
 
 /// Parses [text] and returns spans where @username mentions are highlighted
 /// in blue and tappable to open the mentioned user's profile.
@@ -26,7 +27,8 @@ List<TextSpan> parseMentions(String text) {
         ..onTap = () async {
           final user = await authService.fetchUserByUsername(username);
           if (user != null) {
-            Get.toNamed(AppRoutes.profile, arguments: user.uid);
+            Get.toNamed(AppRoutes.profile,
+                arguments: ProfileArgs(uid: user.uid));
           }
         },
     ));

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -44,143 +44,145 @@ import 'package:hoot/pages/contacts/views/contacts_view.dart';
 import 'package:hoot/pages/terms.dart';
 import 'package:hoot/pages/about_us.dart';
 import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/util/routes/args/profile_args.dart';
+import 'package:hoot/util/routes/args/feed_page_args.dart';
 import 'package:hoot/middleware/auth_middleware.dart';
 
 class AppPages {
   static final List<GetPage> pages = [
-      GetPage(
-        name: AppRoutes.login,
-        page: () => LoginView(),
-        binding: LoginBinding(),
-      ),
-      GetPage(
-        name: AppRoutes.welcome,
-        page: () => const WelcomeView(),
-        binding: WelcomeBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.username,
-        page: () => const WelcomeView(initialIndex: 1),
-        binding: UsernameBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.avatar,
-        page: () => const WelcomeView(initialIndex: 2),
-        binding: AvatarBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.invitation,
-        page: () => const InvitationView(),
-        binding: InvitationBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.home,
-        page: () => const HomeView(),
-        binding: HomeBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.createPost,
-        page: () => const CreatePostView(),
-        binding: CreatePostBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.settings,
-        page: () => const SettingsView(),
-        binding: SettingsBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.profile,
-        page: () => const ProfileView(),
-        binding: ProfileBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.editProfile,
-        page: () => const EditProfileView(),
-        binding: EditProfileBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.search,
-        page: () => const SearchView(),
-        binding: SearchBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.searchByGenre,
-        page: () => const SearchByGenreView(),
-        binding: SearchByGenreBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.createFeed,
-        page: () => const CreateFeedView(),
-        binding: CreateFeedBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.editFeed,
-        page: () => const EditFeedView(),
-        binding: EditFeedBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.feedRequests,
-        page: () => const FeedRequestsView(),
-        binding: FeedRequestsBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.subscriptions,
-        page: () => const SubscriptionsView(),
-        binding: SubscriptionsBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.subscribers,
-        page: () => const SubscribersView(),
-        binding: SubscribersBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.feed,
-        page: () => const FeedPageView(),
-        binding: FeedPageBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.post,
-        page: () => const PostView(),
-        binding: PostBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.report,
-        page: () => const ReportView(),
-        binding: ReportBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
-      GetPage(
-        name: AppRoutes.terms,
-        page: () => const TermsOfService(),
-      ),
-      GetPage(
-        name: AppRoutes.aboutUs,
-        page: () => const AboutUsPage(),
-      ),
-      GetPage(
-        name: AppRoutes.contacts,
-        page: () => const ContactsView(),
-        binding: ContactsBinding(),
-        middlewares: [AuthMiddleware()],
-      ),
+    GetPage(
+      name: AppRoutes.login,
+      page: () => LoginView(),
+      binding: LoginBinding(),
+    ),
+    GetPage(
+      name: AppRoutes.welcome,
+      page: () => const WelcomeView(),
+      binding: WelcomeBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.username,
+      page: () => const WelcomeView(initialIndex: 1),
+      binding: UsernameBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.avatar,
+      page: () => const WelcomeView(initialIndex: 2),
+      binding: AvatarBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.invitation,
+      page: () => const InvitationView(),
+      binding: InvitationBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.home,
+      page: () => const HomeView(),
+      binding: HomeBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.createPost,
+      page: () => const CreatePostView(),
+      binding: CreatePostBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.settings,
+      page: () => const SettingsView(),
+      binding: SettingsBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage<ProfileArgs>(
+      name: AppRoutes.profile,
+      page: () => const ProfileView(),
+      binding: ProfileBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.editProfile,
+      page: () => const EditProfileView(),
+      binding: EditProfileBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.search,
+      page: () => const SearchView(),
+      binding: SearchBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.searchByGenre,
+      page: () => const SearchByGenreView(),
+      binding: SearchByGenreBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.createFeed,
+      page: () => const CreateFeedView(),
+      binding: CreateFeedBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.editFeed,
+      page: () => const EditFeedView(),
+      binding: EditFeedBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.feedRequests,
+      page: () => const FeedRequestsView(),
+      binding: FeedRequestsBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.subscriptions,
+      page: () => const SubscriptionsView(),
+      binding: SubscriptionsBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.subscribers,
+      page: () => const SubscribersView(),
+      binding: SubscribersBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage<FeedPageArgs>(
+      name: AppRoutes.feed,
+      page: () => const FeedPageView(),
+      binding: FeedPageBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.post,
+      page: () => const PostView(),
+      binding: PostBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.report,
+      page: () => const ReportView(),
+      binding: ReportBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.terms,
+      page: () => const TermsOfService(),
+    ),
+    GetPage(
+      name: AppRoutes.aboutUs,
+      page: () => const AboutUsPage(),
+    ),
+    GetPage(
+      name: AppRoutes.contacts,
+      page: () => const ContactsView(),
+      binding: ContactsBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
     GetPage(
       name: AppRoutes.photoViewer,
       page: () => const PhotoZoomView(),

--- a/lib/util/routes/args/feed_page_args.dart
+++ b/lib/util/routes/args/feed_page_args.dart
@@ -1,0 +1,8 @@
+import '../../../models/feed.dart';
+
+class FeedPageArgs {
+  final Feed? feed;
+  final String? feedId;
+
+  const FeedPageArgs({this.feed, this.feedId});
+}

--- a/lib/util/routes/args/profile_args.dart
+++ b/lib/util/routes/args/profile_args.dart
@@ -1,0 +1,6 @@
+class ProfileArgs {
+  final String? uid;
+  final String? feedId;
+
+  const ProfileArgs({this.uid, this.feedId});
+}


### PR DESCRIPTION
## Summary
- add `ProfileArgs` and `FeedPageArgs` for typed routing
- require the new args in `AppPages` definitions
- pass typed arguments through bindings and controllers
- update navigation calls to use the new argument objects

## Testing
- `flutter pub get`
- `flutter test` *(fails: Shows Subscriber Requests button when there are requests)*

------
https://chatgpt.com/codex/tasks/task_e_688b426212ec8328aa4d7733dde8fcd1