### PR TITLE
Add controller unit tests

### DIFF
--- a/test/feed_page_controller_test.dart
+++ b/test/feed_page_controller_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/pages/feed_page/controllers/feed_page_controller.dart';
+import 'package:hoot/models/feed_join_request.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hoot/util/routes/args/feed_page_args.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/feed_service.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/subscription_manager.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U? user;
+  FakeAuthService(this.user);
+  @override
+  U? get currentUser => user;
+  @override
+  Stream<U?> get currentUserStream => Stream.value(user);
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = user;
+  @override
+  Future<U?> fetchUser() async => user;
+  @override
+  Future<U?> fetchUserById(String uid) async => user;
+  @override
+  Future<U?> fetchUserByUsername(String username) async => user;
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+  @override
+  Future<void> signOut() async {}
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+  @override
+  Future<void> deleteAccount() async {}
+  @override
+  Future<U?> refreshUser() async => user;
+  @override
+  Future<void> createUserDocumentIfNeeded(User user) async {}
+}
+
+class FakeFeedService implements BaseFeedService {
+  PostPage? nextPage;
+  @override
+  Future<PostPage> fetchSubscribedPosts({DocumentSnapshot? startAfter, int limit = 10}) async {
+    return PostPage(posts: []);
+  }
+
+  @override
+  Future<PostPage> fetchFeedPosts(String feedId, {DocumentSnapshot? startAfter, int limit = 10}) async {
+    return nextPage ?? PostPage(posts: []);
+  }
+}
+
+class FakeSubscriptionService extends SubscriptionService {
+  final Set<String> subs;
+  FakeSubscriptionService(this.subs) : super(firestore: FakeFirebaseFirestore());
+  @override
+  Future<Set<String>> fetchSubscriptions(String userId) async => subs;
+}
+
+class FakeFeedRequestService extends FeedRequestService {
+  bool existsResult = false;
+  FakeFeedRequestService()
+      : super(firestore: FakeFirebaseFirestore(), subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()), authService: FakeAuthService(null));
+  @override
+  Future<List<FeedJoinRequest>> fetchRequests(String feedId) async => [];
+  @override
+  Future<void> submit(String feedId, String userId) async {}
+  @override
+  Future<void> accept(String feedId, String userId) async {}
+  @override
+  Future<void> reject(String feedId, String userId) async {}
+  @override
+  Future<bool> exists(String feedId, String userId) async => existsResult;
+  @override
+  Future<int> pendingRequestCount() async => 0;
+}
+
+class FakeSubscriptionManager extends SubscriptionManager {
+  final SubscriptionResult result;
+  final List<List<String>> calls = [];
+  FakeSubscriptionManager(this.result)
+      : super(
+          firestore: FakeFirebaseFirestore(),
+          subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()),
+          feedRequestService: FeedRequestService(firestore: FakeFirebaseFirestore(), subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()), authService: FakeAuthService(null)),
+        );
+  @override
+  Future<SubscriptionResult> toggle(String feedId, U user) async {
+    calls.add([feedId, user.uid]);
+    return result;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('onInit sets nsfw warning when not subscribed', () async {
+    final auth = FakeAuthService(U(uid: 'u1'));
+    final feedService = FakeFeedService();
+    final subService = FakeSubscriptionService({});
+    final requestService = FakeFeedRequestService();
+    final manager = FakeSubscriptionManager(SubscriptionResult.subscribed);
+    final controller = FeedPageController(
+      args: FeedPageArgs(feed: Feed(id: 'f1', userId: 'u2', nsfw: true, title: 't', description: 'd')),
+      authService: auth,
+      feedService: feedService,
+      subscriptionService: subService,
+      feedRequestService: requestService,
+      subscriptionManager: manager,
+    );
+    controller.onInit();
+    expect(controller.showNsfwWarning.value, isTrue);
+  });
+
+  test('toggleSubscription updates requested state', () async {
+    final user = U(uid: 'u1');
+    final auth = FakeAuthService(user);
+    final feedService = FakeFeedService();
+    final subService = FakeSubscriptionService({});
+    final requestService = FakeFeedRequestService();
+    final manager = FakeSubscriptionManager(SubscriptionResult.requested);
+    final controller = FeedPageController(
+      args: FeedPageArgs(feed: Feed(id: 'f1', userId: 'u2', title: 't', description: 'd')),
+      authService: auth,
+      feedService: feedService,
+      subscriptionService: subService,
+      feedRequestService: requestService,
+      subscriptionManager: manager,
+    );
+    controller.onInit();
+    await controller.toggleSubscription();
+    expect(manager.calls.length, 1);
+    expect(controller.requested.value, isTrue);
+  });
+
+  test('fetchNext loads posts into state', () async {
+    final user = U(uid: 'u1');
+    final auth = FakeAuthService(user);
+    final feedService = FakeFeedService();
+    feedService.nextPage = PostPage(posts: [Post(id: 'p1', user: user, text: 'hello')]);
+    final controller = FeedPageController(
+      args: FeedPageArgs(feed: Feed(id: 'f1', userId: 'u2', title: 't', description: 'd')),
+      authService: auth,
+      feedService: feedService,
+      subscriptionService: FakeSubscriptionService({}),
+      feedRequestService: FakeFeedRequestService(),
+      subscriptionManager: FakeSubscriptionManager(SubscriptionResult.subscribed),
+    );
+    controller.onInit();
+    await controller.fetchNext();
+    expect(controller.state.value.pages?.isNotEmpty, isTrue);
+    expect(controller.state.value.pages!.first.first.text, 'hello');
+  });
+}

--- a/test/feed_requests_controller_test.dart
+++ b/test/feed_requests_controller_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'package:hoot/models/feed_join_request.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/pages/feed_requests/controllers/feed_requests_controller.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/auth_service.dart';
+
+class FakeAuthService extends GetxService implements AuthService {
+  @override
+  U? get currentUser => null;
+  @override
+  Stream<U?> get currentUserStream => const Stream.empty();
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>();
+  @override
+  Future<U?> fetchUser() async => null;
+  @override
+  Future<U?> fetchUserById(String uid) async => null;
+  @override
+  Future<U?> fetchUserByUsername(String username) async => null;
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+  @override
+  Future<void> signOut() async {}
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+  @override
+  Future<void> deleteAccount() async {}
+  @override
+  Future<U?> refreshUser() async => null;
+  @override
+  Future<void> createUserDocumentIfNeeded(User user) async {}
+}
+
+class FakeFeedRequestService extends FeedRequestService {
+  List<String> acceptCalls = [];
+  List<String> rejectCalls = [];
+  List<String> fetchCalls = [];
+  List<FeedJoinRequest> requests = [];
+  FakeFeedRequestService()
+      : super(
+          firestore: FakeFirebaseFirestore(),
+          subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()),
+          authService: FakeAuthService());
+  @override
+  Future<void> accept(String feedId, String userId) async {
+    acceptCalls.add(userId);
+  }
+  @override
+  Future<void> reject(String feedId, String userId) async {
+    rejectCalls.add(userId);
+  }
+  @override
+  Future<List<FeedJoinRequest>> fetchRequests(String feedId) async {
+    fetchCalls.add(feedId);
+    return requests;
+  }
+  @override
+  Future<void> submit(String feedId, String userId) async {}
+  @override
+  Future<bool> exists(String feedId, String userId) async => false;
+  @override
+  Future<int> pendingRequestCount() async => 0;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loadRequests populates list', () async {
+    final service = FakeFeedRequestService();
+    service.requests = [FeedJoinRequest(user: U(uid: 'u1'), createdAt: DateTime.now())];
+    final controller = FeedRequestsController(service: service);
+    controller.feedId = "f1";
+    await controller.loadRequests();
+    expect(service.fetchCalls, contains("f1"));
+    expect(controller.requests.length, 1);
+  });
+  test('accept removes request', () async {
+    final service = FakeFeedRequestService();
+    service.requests = [FeedJoinRequest(user: U(uid: 'u1'), createdAt: DateTime.now())];
+    final controller = FeedRequestsController(service: service);
+    controller.feedId = 'f1';
+    controller.requests.assignAll(service.requests);
+    await controller.accept('u1');
+    expect(service.acceptCalls, ['u1']);
+    expect(controller.requests.isEmpty, isTrue);
+  });
+
+  test('reject removes request', () async {
+    final service = FakeFeedRequestService();
+    service.requests = [FeedJoinRequest(user: U(uid: 'u1'), createdAt: DateTime.now())];
+    final controller = FeedRequestsController(service: service);
+    controller.feedId = 'f1';
+    controller.requests.assignAll(service.requests);
+    await controller.reject('u1');
+    expect(service.rejectCalls, ['u1']);
+    expect(controller.requests.isEmpty, isTrue);
+  });
+}
+

--- a/test/notifications_controller_test.dart
+++ b/test/notifications_controller_test.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+import 'package:hoot/models/hoot_notification.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/notification_service.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/models/feed_join_request.dart';
+
+class FakeStreamSubscription<T> implements StreamSubscription<T> {
+  bool canceled = false;
+  @override
+  Future<void> cancel() async {canceled = true;}
+  @override
+  void onData(void Function(T data)? handleData) {}
+  @override
+  void onError(Function? handleError) {}
+  @override
+  void onDone(void Function()? handleDone) {}
+  @override
+  void pause([Future<void>? resumeSignal]) {}
+  @override
+  void resume() {}
+  @override
+  bool get isPaused => false;
+  @override
+  Future<E> asFuture<E>([E? futureValue]) => Future.value(futureValue);
+}
+
+class FakeUnreadStream extends Stream<int> {
+  final FakeStreamSubscription<int> sub;
+  FakeUnreadStream(this.sub);
+  @override
+  StreamSubscription<int> listen(void Function(int)? onData, {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+    return sub;
+  }
+}
+
+class FakeNotificationService extends GetxService implements BaseNotificationService {
+  final FakeStreamSubscription<int> fakeSub;
+  FakeNotificationService(this.fakeSub);
+  @override
+  Stream<int> unreadCountStream(String userId) => FakeUnreadStream(fakeSub);
+  @override
+  Future<List<HootNotification>> fetchNotifications(String userId) async => [];
+  @override
+  Future<void> createNotification(String userId, Map<String, dynamic> data) async {}
+  @override
+  Future<void> markAsRead(String userId, String notificationId) async {}
+  @override
+  Future<void> markAllAsRead(String userId) async {}
+}
+
+class FakeFeedRequestService extends FeedRequestService {
+  FakeFeedRequestService()
+      : super(
+            firestore: FakeFirebaseFirestore(),
+            subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()),
+            authService: FakeAuthService(U(uid: 'u1')));
+  @override
+  Future<int> pendingRequestCount() async => 0;
+  @override
+  Future<List<FeedJoinRequest>> fetchRequests(String feedId) async => [];
+  @override
+  Future<void> submit(String feedId, String userId) async {}
+  @override
+  Future<void> accept(String feedId, String userId) async {}
+  @override
+  Future<void> reject(String feedId, String userId) async {}
+  @override
+  Future<bool> exists(String feedId, String userId) async => false;
+}
+
+class FakeAuthService extends GetxService implements AuthService {
+  final U user;
+  FakeAuthService(this.user);
+  @override
+  U? get currentUser => user;
+  @override
+  Stream<U?> get currentUserStream => Stream.value(user);
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>()..value = user;
+  @override
+  Future<U?> fetchUser() async => user;
+  @override
+  Future<U?> fetchUserById(String uid) async => user;
+  @override
+  Future<U?> fetchUserByUsername(String username) async => user;
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+  @override
+  Future<void> signOut() async {}
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+  @override
+  Future<void> deleteAccount() async {}
+  @override
+  Future<U?> refreshUser() async => user;
+  @override
+  Future<void> createUserDocumentIfNeeded(User user) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('onClose cancels unread subscription', () {
+    final fakeSub = FakeStreamSubscription<int>();
+    final controller = NotificationsController(
+      authService: FakeAuthService(U(uid: 'u1')),
+      notificationService: FakeNotificationService(fakeSub),
+      feedRequestService: FakeFeedRequestService(),
+    );
+    controller.onInit();
+    controller.onClose();
+    expect(fakeSub.canceled, isTrue);
+  });
+}

--- a/test/subscribers_controller_test.dart
+++ b/test/subscribers_controller_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import 'package:hoot/models/user.dart';
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/pages/subscribers/controllers/subscribers_controller.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/auth_service.dart';
+
+class FakeSubscriptionService extends SubscriptionService {
+  List<String> removeCalls = [];
+  List<String> banCalls = [];
+  List<String> fetchCalls = [];
+  List<U> subs = [];
+  FakeSubscriptionService() : super(firestore: FakeFirebaseFirestore());
+  @override
+  Future<List<U>> fetchSubscribers(String feedId) async {
+    fetchCalls.add(feedId);
+    return subs;
+  }
+  @override
+  Future<void> removeSubscriber(String feedId, String userId) async {
+    removeCalls.add(userId);
+  }
+  @override
+  Future<void> banSubscriber(String feedId, String userId) async {
+    banCalls.add(userId);
+  }
+  @override
+  Future<void> subscribe(String userId, String feedId) async {}
+  @override
+  Future<void> unsubscribe(String userId, String feedId) async {}
+  @override
+  Future<Set<String>> fetchSubscriptions(String userId) async => {};
+  @override
+  Future<List<Feed>> fetchSubscribedFeeds(String userId) async => [];
+}
+
+class FakeAuthService extends GetxService implements AuthService {
+  @override
+  U? get currentUser => null;
+  @override
+  Stream<U?> get currentUserStream => const Stream.empty();
+  @override
+  Rxn<U> get currentUserRx => Rxn<U>();
+  @override
+  Future<U?> fetchUser() async => null;
+  @override
+  Future<U?> fetchUserById(String uid) async => null;
+  @override
+  Future<U?> fetchUserByUsername(String username) async => null;
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async => [];
+  @override
+  Future<void> signOut() async {}
+  @override
+  Future<UserCredential> signInWithGoogle() async => throw UnimplementedError();
+  @override
+  Future<UserCredential> signInWithApple() async => throw UnimplementedError();
+  @override
+  Future<void> deleteAccount() async {}
+  @override
+  Future<U?> refreshUser() async => null;
+  @override
+  Future<void> createUserDocumentIfNeeded(User user) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('loadSubscribers populates list', () async {
+    final service = FakeSubscriptionService();
+    service.subs = [U(uid: 'u1')];
+    final controller = SubscribersController(subscriptionService: service);
+    controller.feedId = "f1";
+    await controller.loadSubscribers();
+    expect(service.fetchCalls, contains("f1"));
+  });
+
+  test('removeSubscriber updates list', () async {
+    final service = FakeSubscriptionService();
+    service.subs = [U(uid: 'u1')];
+    final controller = SubscribersController(subscriptionService: service);
+    controller.feedId = 'f1';
+    controller.subscribers.assignAll(service.subs);
+    await controller.removeSubscriber('u1');
+    expect(service.removeCalls, ['u1']);
+    expect(controller.subscribers.isEmpty, isTrue);
+  });
+
+  test('banSubscriber updates list', () async {
+    final service = FakeSubscriptionService();
+    service.subs = [U(uid: 'u1')];
+    final controller = SubscribersController(subscriptionService: service);
+    controller.feedId = 'f1';
+    controller.subscribers.assignAll(service.subs);
+    await controller.banSubscriber('u1');
+    expect(service.banCalls, ['u1']);
+    expect(controller.subscribers.isEmpty, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add unit tests for `FeedPageController`, `FeedRequestsController`, `SubscribersController` and `NotificationsController`
- verify NSFW warnings and subscription toggles
- ensure unread subscription is cancelled on `NotificationsController.onClose`

## Testing
- `flutter analyze`
- `flutter test test/feed_page_controller_test.dart test/feed_requests_controller_test.dart test/notifications_controller_test.dart test/subscribers_controller_test.dart` *(fails: Firebase initialization issues)*

------
https://chatgpt.com/codex/tasks/task_e_688b4a1585988328bff008ddbd03d738