### PR TITLE
Add customizable theme color

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -23,7 +23,7 @@ class DependencyInjector {
     Get.put(SubscriptionManager(), permanent: true);
     Get.put(QuickActionsService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
-    await theme.loadThemeMode();
+    await theme.loadThemeSettings();
     await Get.find<QuickActionsService>().init();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:hoot/theme/theme.dart';
+import 'package:hoot/util/enums/app_colors.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:toastification/toastification.dart';
 import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
@@ -53,8 +54,8 @@ void main() {
               debugShowCheckedModeBanner: false,
               getPages: AppPages.pages,
               initialRoute: AppRoutes.home,
-              theme: AppTheme.lightTheme,
-              darkTheme: AppTheme.darkTheme,
+              theme: AppTheme.lightTheme(themeService.appColor.value.color),
+              darkTheme: AppTheme.darkTheme(themeService.appColor.value.color),
               themeMode: themeService.themeMode.value,
               translations: AppTranslations(),
               locale: Get.deviceLocale,

--- a/lib/pages/app_color/bindings/app_color_binding.dart
+++ b/lib/pages/app_color/bindings/app_color_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/app_color_controller.dart';
+
+class AppColorBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => AppColorController());
+  }
+}

--- a/lib/pages/app_color/controllers/app_color_controller.dart
+++ b/lib/pages/app_color/controllers/app_color_controller.dart
@@ -1,0 +1,17 @@
+import 'package:get/get.dart';
+import '../../../services/theme_service.dart';
+import '../../../util/enums/app_colors.dart';
+
+class AppColorController extends GetxController {
+  final _theme = Get.find<ThemeService>();
+
+  AppColor get selectedColor => _theme.appColor.value;
+
+  Future<void> selectColor(AppColor color) async {
+    await _theme.updateAppColor(color);
+  }
+
+  Future<void> resetColor() async {
+    await _theme.resetAppColor();
+  }
+}

--- a/lib/pages/app_color/views/app_color_view.dart
+++ b/lib/pages/app_color/views/app_color_view.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../components/appbar_component.dart';
+import '../../../util/enums/app_colors.dart';
+import '../controllers/app_color_controller.dart';
+
+class AppColorView extends GetView<AppColorController> {
+  const AppColorView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBarComponent(
+        title: 'appColor'.tr,
+      ),
+      body: Column(
+        children: [
+          const SizedBox(height: 16),
+          Obx(() {
+            final selected = controller.selectedColor;
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: GridView.count(
+                crossAxisCount: 3,
+                mainAxisSpacing: 16,
+                crossAxisSpacing: 16,
+                shrinkWrap: true,
+                children: [
+                  for (final color in AppColor.values)
+                    GestureDetector(
+                      onTap: () => controller.selectColor(color),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          gradient: LinearGradient(
+                            begin: Alignment.topLeft,
+                            end: Alignment.bottomRight,
+                            colors: [
+                              color.color.withOpacity(0.6),
+                              color.color.withOpacity(0.9),
+                            ],
+                          ),
+                          border: selected == color
+                              ? Border.all(
+                                  color: Theme.of(context).colorScheme.primary,
+                                  width: 3,
+                                )
+                              : null,
+                        ),
+                        child: selected == color
+                            ? const Center(
+                                child: Icon(Icons.check, color: Colors.white),
+                              )
+                            : null,
+                      ),
+                    ),
+                ],
+              ),
+            );
+          }),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: controller.resetColor,
+            child: Text('resetColor'.tr),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/home/views/home_view.dart
+++ b/lib/pages/home/views/home_view.dart
@@ -11,6 +11,8 @@ import '../../notifications/controllers/notifications_controller.dart';
 import '../../profile/views/profile_view.dart';
 import '../controllers/home_controller.dart';
 import 'package:hoot/services/haptic_service.dart';
+import 'package:hoot/services/theme_service.dart';
+import 'package:hoot/util/enums/app_colors.dart';
 
 class HomeView extends GetView<HomeController> {
   const HomeView({super.key});
@@ -38,10 +40,13 @@ class HomeView extends GetView<HomeController> {
           body: Stack(
             fit: StackFit.expand,
             children: [
-              Image.asset(
-                'assets/images/bottom_bar_blue.jpg',
-                fit: BoxFit.cover,
-              ),
+              Obx(() => Image.asset(
+                    Get.find<ThemeService>()
+                        .appColor
+                        .value
+                        .asset,
+                    fit: BoxFit.cover,
+                  )),
               SafeArea(
                 top: false,
                 child: AnimatedContainer(

--- a/lib/pages/settings/views/settings_view.dart
+++ b/lib/pages/settings/views/settings_view.dart
@@ -40,6 +40,10 @@ class SettingsView extends GetView<SettingsController> {
             ),
           ),
           ListTile(
+            title: Text('appColor'.tr),
+            onTap: () => Get.toNamed(AppRoutes.appColor),
+          ),
+          ListTile(
             title: Text('editProfile'.tr),
             onTap: controller.goToEditProfile,
           ),

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,26 +1,49 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../util/enums/app_colors.dart';
 
 /// Service that manages theme mode and persists the user's preference.
 class ThemeService extends GetxService {
-  static const _prefKey = 'themeMode';
+  static const _prefKeyMode = 'themeMode';
+  static const _prefKeyColor = 'appColor';
 
   /// Current theme mode. Defaults to [ThemeMode.system].
   final themeMode = ThemeMode.system.obs;
 
-  /// Loads the saved theme mode from [SharedPreferences].
-  Future<void> loadThemeMode() async {
+  /// Current app color.
+  final appColor = AppColor.blue.obs;
+
+  /// Loads the saved theme mode and color from [SharedPreferences].
+  Future<void> loadThemeSettings() async {
     final prefs = await SharedPreferences.getInstance();
-    final index = prefs.getInt(_prefKey);
+    final modeIndex = prefs.getInt(_prefKeyMode);
     themeMode.value =
-        index != null ? ThemeMode.values[index] : ThemeMode.system;
+        modeIndex != null ? ThemeMode.values[modeIndex] : ThemeMode.system;
+
+    final colorIndex = prefs.getInt(_prefKeyColor);
+    appColor.value =
+        colorIndex != null ? AppColor.values[colorIndex] : AppColor.blue;
   }
 
   /// Persists and applies the selected [mode].
   Future<void> updateThemeMode(ThemeMode mode) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_prefKey, mode.index);
+    await prefs.setInt(_prefKeyMode, mode.index);
     themeMode.value = mode;
+  }
+
+  /// Persists and applies the selected [color].
+  Future<void> updateAppColor(AppColor color) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_prefKeyColor, color.index);
+    appColor.value = color;
+  }
+
+  /// Resets the app color to default.
+  Future<void> resetAppColor() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_prefKeyColor);
+    appColor.value = AppColor.blue;
   }
 }

--- a/lib/theme/theme.dart
+++ b/lib/theme/theme.dart
@@ -2,68 +2,57 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class AppTheme {
-  static Color primaryColor = Colors.blue;
+  static ThemeData lightTheme(Color primaryColor) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: primaryColor,
+      brightness: Brightness.light,
+    );
+    return ThemeData(
+      useMaterial3: true,
+      brightness: Brightness.light,
+      colorScheme: colorScheme,
+      appBarTheme: const AppBarTheme(centerTitle: false),
+      fontFamily: 'Inter',
+      textTheme: _lightTextTheme,
+      snackBarTheme: _snackBarTheme,
+      elevatedButtonTheme: _elevatedButtonTheme(primaryColor),
+      inputDecorationTheme: _inputDecorationTheme,
+      dropdownMenuTheme:
+          DropdownMenuThemeData(inputDecorationTheme: _inputDecorationTheme),
+      chipTheme: _chipTheme(colorScheme, false),
+    );
+  }
 
-  static ThemeData lightTheme = ThemeData(
-    useMaterial3: true,
-    brightness: Brightness.light,
-    colorSchemeSeed: primaryColor,
-    appBarTheme: AppBarTheme(
-      centerTitle: false,
-    ),
-    fontFamily: 'Inter',
-    textTheme: lightTextTheme,
-    snackBarTheme: snackBarTheme,
-    elevatedButtonTheme: elevatedButtonTheme,
-    inputDecorationTheme: inputDecorationTheme,
-    dropdownMenuTheme: DropdownMenuThemeData(
-      inputDecorationTheme: inputDecorationTheme,
-    ),
-    chipTheme: chipTheme,
-  );
-
-  static ThemeData darkTheme = ThemeData(
+  static ThemeData darkTheme(Color primaryColor) {
+    final colorScheme = ColorScheme.fromSeed(
+      seedColor: primaryColor,
+      brightness: Brightness.dark,
+    );
+    return ThemeData(
       useMaterial3: true,
       brightness: Brightness.dark,
-      colorSchemeSeed: primaryColor,
-      appBarTheme: AppBarTheme(
-        centerTitle: false,
-      ),
-      textTheme: darkTextTheme,
-      snackBarTheme: snackBarTheme,
-      elevatedButtonTheme: elevatedButtonTheme,
-      inputDecorationTheme: inputDecorationTheme.copyWith(
+      colorScheme: colorScheme,
+      appBarTheme: const AppBarTheme(centerTitle: false),
+      textTheme: _darkTextTheme,
+      snackBarTheme: _snackBarTheme,
+      elevatedButtonTheme: _elevatedButtonTheme(primaryColor),
+      inputDecorationTheme: _inputDecorationTheme.copyWith(
         labelStyle: const TextStyle(color: Colors.white),
         fillColor: Colors.grey.shade800,
       ),
       dropdownMenuTheme:
-          DropdownMenuThemeData(inputDecorationTheme: inputDecorationTheme),
-      chipTheme: chipTheme.copyWith(
-        backgroundColor: darkColorScheme.onPrimary,
-        labelStyle: TextStyle(
-          fontSize: 12,
-          color: darkColorScheme.primary,
-        ),
-        iconTheme: IconThemeData(size: 16, color: darkColorScheme.primary),
-      ));
+          DropdownMenuThemeData(inputDecorationTheme: _inputDecorationTheme),
+      chipTheme: _chipTheme(colorScheme, true),
+    );
+  }
 
-  static ColorScheme lightColorScheme = ColorScheme.fromSeed(
-    seedColor: primaryColor,
-    brightness: Brightness.light,
-  );
-
-  static ColorScheme darkColorScheme = ColorScheme.fromSeed(
-    seedColor: primaryColor,
-    brightness: Brightness.dark,
-  );
-
-  static TextTheme get lightTextTheme => GoogleFonts.lexendTextTheme().copyWith(
+  static TextTheme get _lightTextTheme => GoogleFonts.lexendTextTheme().copyWith(
         bodySmall: GoogleFonts.interTextTheme().bodySmall,
         bodyMedium: GoogleFonts.interTextTheme().bodyMedium,
         bodyLarge: GoogleFonts.interTextTheme().bodyLarge,
       );
 
-  static TextTheme get darkTextTheme =>
+  static TextTheme get _darkTextTheme =>
       GoogleFonts.lexendTextTheme(ThemeData.dark().textTheme).copyWith(
         bodySmall:
             GoogleFonts.interTextTheme(ThemeData.dark().textTheme).bodySmall,
@@ -73,67 +62,63 @@ class AppTheme {
             GoogleFonts.interTextTheme(ThemeData.dark().textTheme).bodyLarge,
       );
 
-  static SnackBarThemeData snackBarTheme = SnackBarThemeData(
-    behavior: SnackBarBehavior.floating,
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.circular(10),
-    ),
-  );
-
-  static ElevatedButtonThemeData elevatedButtonTheme = ElevatedButtonThemeData(
-    style: ButtonStyle(
-      textStyle: WidgetStateProperty.all(
-        const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-      ),
-      elevation: WidgetStateProperty.all(0),
-      shape: WidgetStateProperty.all(
-        RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(20),
-          side: BorderSide.none,
+  static SnackBarThemeData get _snackBarTheme => SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
         ),
-      ),
-      backgroundColor: WidgetStateProperty.all(
-        primaryColor,
-      ),
-      foregroundColor: WidgetStateProperty.all(
-        Colors.white,
-      ),
-      padding: WidgetStateProperty.all(
-        const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-      ),
-    ),
-  );
+      );
 
-  static InputDecorationTheme inputDecorationTheme = InputDecorationTheme(
-    border: const OutlineInputBorder(
-      borderRadius: BorderRadius.all(Radius.circular(15)),
-      borderSide: BorderSide.none,
-    ),
-    focusedBorder: const OutlineInputBorder(
-      borderRadius: BorderRadius.all(Radius.circular(15)),
-      borderSide: BorderSide(color: Colors.blue, width: 2),
-    ),
-    filled: true,
-    fillColor: Colors.grey.shade200,
-    contentPadding: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
-    alignLabelWithHint: true,
-  );
+  static ElevatedButtonThemeData _elevatedButtonTheme(Color color) =>
+      ElevatedButtonThemeData(
+        style: ButtonStyle(
+          textStyle: WidgetStateProperty.all(
+            const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          ),
+          elevation: WidgetStateProperty.all(0),
+          shape: WidgetStateProperty.all(
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+              side: BorderSide.none,
+            ),
+          ),
+          backgroundColor: WidgetStateProperty.all(color),
+          foregroundColor: WidgetStateProperty.all(Colors.white),
+          padding: WidgetStateProperty.all(
+            const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+          ),
+        ),
+      );
 
-  static ChipThemeData chipTheme = ChipThemeData(
-    padding: const EdgeInsets.all(8),
-    shape: const RoundedRectangleBorder(
-      side: BorderSide.none,
-      borderRadius: BorderRadius.all(Radius.circular(100)),
-    ),
-    side: BorderSide.none,
-    backgroundColor: lightColorScheme.primary.withValues(alpha: 0.25),
-    labelStyle: TextStyle(
-      fontSize: 12,
-      color: lightColorScheme.primary,
-    ),
-    iconTheme: IconThemeData(
-      color: lightColorScheme.primary,
-      size: 16,
-    ),
-  );
+  static InputDecorationTheme get _inputDecorationTheme => InputDecorationTheme(
+        border: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(15)),
+          borderSide: BorderSide.none,
+        ),
+        focusedBorder: const OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(15)),
+          borderSide: BorderSide(color: Colors.blue, width: 2),
+        ),
+        filled: true,
+        fillColor: Colors.grey.shade200,
+        contentPadding:
+            const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+        alignLabelWithHint: true,
+      );
+
+  static ChipThemeData _chipTheme(ColorScheme scheme, bool dark) => ChipThemeData(
+        padding: const EdgeInsets.all(8),
+        shape: const RoundedRectangleBorder(
+          side: BorderSide.none,
+          borderRadius: BorderRadius.all(Radius.circular(100)),
+        ),
+        side: BorderSide.none,
+        backgroundColor:
+            dark ? scheme.onPrimary : scheme.primary.withAlpha(64),
+        labelStyle: TextStyle(
+          fontSize: 12,
+          color: scheme.primary,
+        ),
+        iconTheme: IconThemeData(color: scheme.primary, size: 16),
+      );
 }

--- a/lib/util/enums/app_colors.dart
+++ b/lib/util/enums/app_colors.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+enum AppColor { blue, green, orange, pink, purple, red, yellow }
+
+extension AppColorExtension on AppColor {
+  Color get color {
+    switch (this) {
+      case AppColor.green:
+        return Colors.green;
+      case AppColor.orange:
+        return Colors.orange;
+      case AppColor.pink:
+        return Colors.pink;
+      case AppColor.purple:
+        return Colors.purple;
+      case AppColor.red:
+        return Colors.red;
+      case AppColor.yellow:
+        return Colors.yellow;
+      case AppColor.blue:
+      default:
+        return Colors.blue;
+    }
+  }
+
+  String get asset => 'assets/images/bottom_bar_${name}.jpg';
+}

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -17,6 +17,8 @@ import 'package:hoot/pages/profile/bindings/profile_binding.dart';
 import 'package:hoot/pages/profile/views/profile_view.dart';
 import 'package:hoot/pages/settings/bindings/settings_binding.dart';
 import 'package:hoot/pages/settings/views/settings_view.dart';
+import 'package:hoot/pages/app_color/bindings/app_color_binding.dart';
+import 'package:hoot/pages/app_color/views/app_color_view.dart';
 import 'package:hoot/pages/edit_profile/bindings/edit_profile_binding.dart';
 import 'package:hoot/pages/edit_profile/views/edit_profile_view.dart';
 import 'package:hoot/pages/search/bindings/search_binding.dart';
@@ -95,6 +97,12 @@ class AppPages {
       name: AppRoutes.settings,
       page: () => const SettingsView(),
       binding: SettingsBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.appColor,
+      page: () => const AppColorView(),
+      binding: AppColorBinding(),
       middlewares: [AuthMiddleware()],
     ),
     GetPage<ProfileArgs>(

--- a/lib/util/routes/app_routes.dart
+++ b/lib/util/routes/app_routes.dart
@@ -23,4 +23,5 @@ class AppRoutes {
   static const aboutUs = '/about_us';
   static const contacts = '/contacts';
   static const photoViewer = '/photo_view';
+  static const appColor = '/app_color';
 }

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -289,6 +289,8 @@ class AppTranslations extends Translations {
           'syncedWithSystem': 'Synced with system',
           'light': 'Light',
           'dark': 'Dark',
+          'appColor': 'App Color',
+          'resetColor': 'Revert to default color',
           'version': 'Version',
           'deleteAccount': 'Delete Account',
           'deleteAccountDescription':
@@ -632,6 +634,8 @@ class AppTranslations extends Translations {
           'syncedWithSystem': 'Sincronizado con el sistema',
           'light': 'Claro',
           'dark': 'Oscuro',
+          'appColor': 'Color de la App',
+          'resetColor': 'Restablecer color por defecto',
           'version': 'Versión',
           'deleteAccount': 'Eliminar Cuenta',
           'deleteAccountDescription':
@@ -976,6 +980,8 @@ class AppTranslations extends Translations {
           'syncedWithSystem': 'Sincronizado com o sistema',
           'light': 'Claro',
           'dark': 'Escuro',
+          'appColor': 'Cor da App',
+          'resetColor': 'Repor cor padrão',
           'version': 'Versão',
           'deleteAccount': 'Eliminar Conta',
           'deleteAccountDescription':
@@ -1317,6 +1323,8 @@ class AppTranslations extends Translations {
           'syncedWithSystem': 'Sincronizado com o sistema',
           'light': 'Claro',
           'dark': 'Escuro',
+          'appColor': 'Cor do App',
+          'resetColor': 'Restaurar cor padrão',
           'version': 'Versão',
           'deleteAccount': 'Excluir Conta',
           'deleteAccountDescription':

--- a/test/app_color_test.dart
+++ b/test/app_color_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:hoot/pages/app_color/controllers/app_color_controller.dart';
+import 'package:hoot/pages/app_color/views/app_color_view.dart';
+import 'package:hoot/util/enums/app_colors.dart';
+import 'package:hoot/services/theme_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Selecting color updates service', (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final themeService = ThemeService();
+    await themeService.loadThemeSettings();
+    Get.put(themeService);
+    Get.put(AppColorController());
+
+    await tester.pumpWidget(
+      Obx(() => GetMaterialApp(
+            theme: ThemeData.light(),
+            home: const AppColorView(),
+          )),
+    );
+    await tester.pumpAndSettle();
+
+    expect(themeService.appColor.value, AppColor.blue);
+    await tester.tap(find.byType(GestureDetector).at(1));
+    await tester.pumpAndSettle();
+    expect(themeService.appColor.value, AppColor.values[1]);
+  });
+}

--- a/test/invitation_view_test.dart
+++ b/test/invitation_view_test.dart
@@ -5,6 +5,7 @@ import 'package:get/get.dart';
 import 'package:hoot/pages/invitation/controllers/invitation_controller.dart';
 import 'package:hoot/pages/invitation/views/invitation_view.dart';
 import 'package:hoot/theme/theme.dart';
+import 'package:hoot/util/enums/app_colors.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:hoot/services/invitation_service.dart';
 import 'package:hoot/services/auth_service.dart';
@@ -69,7 +70,7 @@ void main() {
       GetMaterialApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
-        theme: AppTheme.lightTheme,
+        theme: AppTheme.lightTheme(AppColor.blue.color),
         home: const InvitationView(),
       ),
     );

--- a/test/login_view_test.dart
+++ b/test/login_view_test.dart
@@ -5,6 +5,7 @@ import 'package:get/get.dart';
 import 'package:hoot/pages/login/controllers/login_controller.dart';
 import 'package:hoot/pages/login/views/login_view.dart';
 import 'package:hoot/theme/theme.dart';
+import 'package:hoot/util/enums/app_colors.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -69,7 +70,7 @@ void main() {
       GetMaterialApp(
         translations: AppTranslations(),
         locale: const Locale('en'),
-        theme: AppTheme.lightTheme,
+        theme: AppTheme.lightTheme(AppColor.blue.color),
         home: const LoginView(),
       ),
     );

--- a/test/theme_toggle_test.dart
+++ b/test/theme_toggle_test.dart
@@ -7,6 +7,7 @@ import 'package:hoot/pages/settings/controllers/settings_controller.dart';
 import 'package:hoot/pages/settings/views/settings_view.dart';
 import 'package:hoot/services/theme_service.dart';
 import 'package:hoot/theme/theme.dart';
+import 'package:hoot/util/enums/app_colors.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -59,7 +60,7 @@ void main() {
   testWidgets('Selecting dark mode updates theme', (tester) async {
     SharedPreferences.setMockInitialValues({});
     final themeService = ThemeService();
-    await themeService.loadThemeMode();
+    await themeService.loadThemeSettings();
     Get.put(themeService);
     Get.put<AuthService>(FakeAuthService());
     Get.put(SettingsController());
@@ -68,8 +69,8 @@ void main() {
       Obx(() => GetMaterialApp(
             translations: AppTranslations(),
             locale: const Locale('en'),
-            theme: AppTheme.lightTheme,
-            darkTheme: AppTheme.darkTheme,
+            theme: AppTheme.lightTheme(themeService.appColor.value.color),
+            darkTheme: AppTheme.darkTheme(themeService.appColor.value.color),
             themeMode: themeService.themeMode.value,
             home: const SettingsView(),
           )),


### PR DESCRIPTION
## Summary
- allow setting app color through new settings page
- load/save chosen color in ThemeService
- regenerate themes with selected color
- update HomeView to change bottom bar background
- add translations for new settings entry
- extend tests for color selection and update existing ones

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b54f58ec88328b3883db71c752a07