### PR TITLE
Add multi-feed request support

### DIFF
--- a/lib/models/feed_join_request.dart
+++ b/lib/models/feed_join_request.dart
@@ -2,13 +2,15 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'user.dart';
 
 class FeedJoinRequest {
+  final String feedId;
   final U user;
   final DateTime createdAt;
 
-  FeedJoinRequest({required this.user, required this.createdAt});
+  FeedJoinRequest({required this.feedId, required this.user, required this.createdAt});
 
   factory FeedJoinRequest.fromJson(Map<String, dynamic> json) {
     return FeedJoinRequest(
+      feedId: json['feedId'] ?? '',
       user: U.fromJson(json['user']),
       createdAt: json['createdAt'] is Timestamp
           ? (json['createdAt'] as Timestamp).toDate()

--- a/lib/pages/feed_requests/views/feed_requests_view.dart
+++ b/lib/pages/feed_requests/views/feed_requests_view.dart
@@ -32,6 +32,7 @@ class FeedRequestsView extends GetView<FeedRequestsController> {
           itemBuilder: (context, index) {
             final request = controller.requests[index];
             final user = request.user;
+            final title = controller.feedTitles[request.feedId] ?? request.feedId;
             return ListTile(
               onTap: () => controller.openProfile(user.uid),
               leading: ProfileAvatarComponent(
@@ -40,18 +41,21 @@ class FeedRequestsView extends GetView<FeedRequestsController> {
                 size: 40,
               ),
               title: NameComponent(user: user, size: 16),
+              subtitle: Text(title),
               trailing: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
                   IconButton(
                     icon: const Icon(Icons.check),
                     tooltip: 'approve'.tr,
-                    onPressed: () => controller.accept(user.uid),
+                    onPressed: () =>
+                        controller.accept(request.feedId, user.uid),
                   ),
                   IconButton(
                     icon: const Icon(Icons.close),
                     tooltip: 'reject'.tr,
-                    onPressed: () => controller.reject(user.uid),
+                    onPressed: () =>
+                        controller.reject(request.feedId, user.uid),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- include feedId in `FeedJoinRequest`
- fetch pending requests across all feeds owned by the user
- refactor `FeedRequestsController` to use new service method
- display feed title in feed request list
- update tests for new functionality

## Testing
- `flutter test test/feed_request_service_test.dart test/feed_requests_controller_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688b7107b9f883289aecb76d6bf2498f