### PR TITLE
Implement blurred background for FeedCard

### DIFF
--- a/lib/components/feed_card.dart
+++ b/lib/components/feed_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hash_cached_image/hash_cached_image.dart';
+import 'package:blur/blur.dart';
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/services/haptic_service.dart';
 
@@ -37,18 +38,28 @@ class FeedCard extends StatelessWidget {
                 hash: feed.bigAvatarHash,
                 fit: BoxFit.cover,
               ),
-              Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: [
-                      Colors.black12,
-                      Colors.black87,
-                    ],
+              Positioned.fill(
+                child: Blur(
+                  blur: 8,
+                  blurColor: Colors.black,
+                  colorOpacity: 0.3,
+                  overlay: Container(
+                    decoration: const BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          Colors.transparent,
+                          Colors.black87,
+                        ],
+                      ),
+                    ),
                   ),
+                  child: const SizedBox.shrink(),
                 ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.end,
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.1.4"
+  blur:
+    dependency: "direct main"
+    description:
+      name: blur
+      sha256: 1318cf79c735784eda8dffc77b1085b757373d233c1c8d94dc0cfd81530a3574
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   blurhash:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   google_sign_in: ^6.3.0
   hash_cached_image: ^0.0.2
   blurhash: ^1.2.0
+  blur: ^4.0.2
   image_picker: ^1.0.0
   firebase_storage: ^12.4.10
   image: ^4.5.4


### PR DESCRIPTION
## Summary
- add the `blur` package
- use a Blur overlay in `FeedCard` so images fade into a blurred, darker version

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_688b7714f4688328802d2de07001dae2