### PR TITLE
Animate FeedCard blur

### DIFF
--- a/lib/components/feed_card.dart
+++ b/lib/components/feed_card.dart
@@ -39,23 +39,30 @@ class FeedCard extends StatelessWidget {
                 fit: BoxFit.cover,
               ),
               Positioned.fill(
-                child: Blur(
-                  blur: 8,
-                  blurColor: Colors.black,
-                  colorOpacity: 0.3,
-                  overlay: Container(
-                    decoration: const BoxDecoration(
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors: [
-                          Colors.transparent,
-                          Colors.black87,
-                        ],
+                child: TweenAnimationBuilder<double>(
+                  tween: Tween<double>(begin: 0, end: 8),
+                  duration: const Duration(milliseconds: 800),
+                  curve: Curves.easeOut,
+                  builder: (context, value, _) {
+                    return Blur(
+                      blur: value,
+                      blurColor: Colors.black,
+                      colorOpacity: 0.3,
+                      overlay: Container(
+                        decoration: const BoxDecoration(
+                          gradient: LinearGradient(
+                            begin: Alignment.topCenter,
+                            end: Alignment.bottomCenter,
+                            colors: [
+                              Colors.transparent,
+                              Colors.black87,
+                            ],
+                          ),
+                        ),
                       ),
-                    ),
-                  ),
-                  child: const SizedBox.shrink(),
+                      child: const SizedBox.shrink(),
+                    );
+                  },
                 ),
               ),
               Padding(


### PR DESCRIPTION
## Summary
- add TweenAnimationBuilder to gradually blur FeedCard background

## Testing
- `flutter analyze`
- `flutter test` *(fails: InvitationView shows prompt text)*

------
https://chatgpt.com/codex/tasks/task_e_688b7914f3608328a133f98f976b216b