### PR TITLE
Disable repost on private feeds

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -378,13 +378,26 @@ class _PostComponentState extends State<PostComponent> {
                       const Spacer(
                         flex: 2,
                       ),
-                      IconButton(
-                        icon: Icon(
-                          SolarIconsOutline.refreshSquare,
-                          color: _post.reFeededByMe ? Colors.green : null,
-                        ),
-                        iconSize: 20,
-                        onPressed: _post.reFeededByMe ? null : _reFeed,
+                      Builder(
+                        builder: (context) {
+                          final bool isPrivateFeed =
+                              _post.reFeeded
+                                  ? _post.reFeededFrom?.feed?.private ?? false
+                                  : _post.feed?.private ?? false;
+                          return Opacity(
+                            opacity: isPrivateFeed ? 0.5 : 1,
+                            child: IconButton(
+                              icon: Icon(
+                                SolarIconsOutline.refreshSquare,
+                                color: _post.reFeededByMe ? Colors.green : null,
+                              ),
+                              iconSize: 20,
+                              onPressed: (_post.reFeededByMe || isPrivateFeed)
+                                  ? null
+                                  : _reFeed,
+                            ),
+                          );
+                        },
                       ),
                       if ((_post.reFeeds ?? 0) > 0)
                         Padding(


### PR DESCRIPTION
## Summary
- prevent reposting of posts from private feeds
- show disabled repost button with opacity when private

## Testing
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688bc8599c048328ac0a2b7376eb1121