### PR TITLE
Add press scaling and haptics in explore

### DIFF
--- a/lib/components/feed_card.dart
+++ b/lib/components/feed_card.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hash_cached_image/hash_cached_image.dart';
 import 'package:hoot/models/feed.dart';
-import 'package:hoot/services/haptic_service.dart';
+import 'package:hoot/components/scale_on_press.dart';
 
 class FeedCard extends StatelessWidget {
   final Feed feed;
@@ -27,11 +27,8 @@ class FeedCard extends StatelessWidget {
       fit: BoxFit.cover,
     );
 
-    return GestureDetector(
-      onTap: () {
-        HapticService.lightImpact();
-        onTap();
-      },
+    return ScaleOnPress(
+      onTap: onTap,
       child: Container(
         clipBehavior: Clip.antiAlias,
         decoration: BoxDecoration(

--- a/lib/components/scale_on_press.dart
+++ b/lib/components/scale_on_press.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import '../services/haptic_service.dart';
+
+/// A widget that slightly scales its child when pressed and provides
+/// light haptic feedback on tap down.
+class ScaleOnPress extends StatefulWidget {
+  final Widget child;
+  final VoidCallback? onTap;
+  final Duration duration;
+  final double scale;
+
+  const ScaleOnPress({
+    Key? key,
+    required this.child,
+    this.onTap,
+    this.duration = const Duration(milliseconds: 100),
+    this.scale = 0.95,
+  }) : super(key: key);
+
+  @override
+  State<ScaleOnPress> createState() => _ScaleOnPressState();
+}
+
+class _ScaleOnPressState extends State<ScaleOnPress> {
+  bool _pressed = false;
+
+  void _setPressed(bool value) {
+    if (_pressed == value) return;
+    setState(() => _pressed = value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: widget.onTap,
+      onTapDown: (_) {
+        HapticService.lightImpact();
+        _setPressed(true);
+      },
+      onTapUp: (_) => _setPressed(false),
+      onTapCancel: () => _setPressed(false),
+      child: AnimatedScale(
+        scale: _pressed ? widget.scale : 1.0,
+        duration: widget.duration,
+        child: widget.child,
+      ),
+    );
+  }
+}

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -10,7 +10,7 @@ import 'package:solar_icons/solar_icons.dart';
 import '../../../util/routes/app_routes.dart';
 import '../../../util/routes/args/profile_args.dart';
 import '../controllers/explore_controller.dart';
-import 'package:hoot/services/haptic_service.dart';
+import 'package:hoot/components/scale_on_press.dart';
 
 class ExploreView extends GetView<ExploreController> {
   const ExploreView({super.key});
@@ -106,9 +106,8 @@ class ExploreView extends GetView<ExploreController> {
                     itemCount: controller.popularUsers.length,
                     itemBuilder: (context, index) {
                       final u = controller.popularUsers[index];
-                      return GestureDetector(
+                      return ScaleOnPress(
                         onTap: () {
-                          HapticService.lightImpact();
                           Get.toNamed(
                             AppRoutes.profile,
                             arguments: ProfileArgs(uid: u.uid),
@@ -179,9 +178,8 @@ class ExploreView extends GetView<ExploreController> {
                       separatorBuilder: (_, __) => const SizedBox(width: 12),
                       itemBuilder: (context, index) {
                         final type = controller.genres[index];
-                        return GestureDetector(
+                        return ScaleOnPress(
                           onTap: () {
-                            HapticService.lightImpact();
                             Get.toNamed(
                               AppRoutes.searchByGenre,
                               arguments: type,


### PR DESCRIPTION
## Summary
- add `ScaleOnPress` widget for press effects
- apply `ScaleOnPress` to feed cards, type boxes, and popular user avatars in ExploreView

## Testing
- `flutter analyze`
- `flutter test` *(fails: unhandled error during finalization of test)*

------
https://chatgpt.com/codex/tasks/task_e_688bd7f4ea2c8328aa13fd76463c7290