### PR TITLE
Add avatar preview for feed requests

### DIFF
--- a/lib/components/avatar_stack.dart
+++ b/lib/components/avatar_stack.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:hoot/components/avatar_component.dart';
+import 'package:hoot/models/user.dart';
+
+class AvatarStack extends StatelessWidget {
+  final List<U> users;
+  final double size;
+  const AvatarStack({super.key, required this.users, this.size = 28});
+
+  @override
+  Widget build(BuildContext context) {
+    if (users.isEmpty) return const SizedBox.shrink();
+    final visible = users.take(3).toList();
+    return SizedBox(
+      height: size,
+      width: size + (visible.length - 1) * (size * 0.6),
+      child: Stack(
+        children: [
+          for (var i = 0; i < visible.length; i++)
+            Positioned(
+              left: i * size * 0.6,
+              child: ProfileAvatarComponent(
+                image: visible[i].smallProfilePictureUrl ?? '',
+                hash: visible[i].smallAvatarHash ?? visible[i].bigAvatarHash,
+                size: size.toInt(),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/notifications/controllers/notifications_controller.dart
+++ b/lib/pages/notifications/controllers/notifications_controller.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'package:get/get.dart';
 
 import 'package:hoot/models/hoot_notification.dart';
+import 'package:hoot/models/feed_join_request.dart';
+import 'package:hoot/models/user.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/services/notification_service.dart';
 import 'package:hoot/services/feed_request_service.dart';
@@ -23,6 +25,7 @@ class NotificationsController extends GetxController {
   final RxList<HootNotification> notifications = <HootNotification>[].obs;
   final RxInt unreadCount = 0.obs;
   final RxInt requestCount = 0.obs;
+  final RxList<U> requestUsers = <U>[].obs;
   final RxBool loading = false.obs;
 
   StreamSubscription<int>? _unreadSub;
@@ -32,6 +35,7 @@ class NotificationsController extends GetxController {
     super.onInit();
     _loadNotifications();
     _loadRequestCount();
+    _loadRequestUsers();
     _listenUnreadCount();
   }
 
@@ -44,6 +48,7 @@ class NotificationsController extends GetxController {
   Future<void> refreshNotifications() async {
     await _loadNotifications();
     await _loadRequestCount();
+    await _loadRequestUsers();
   }
 
   Future<void> markAllAsRead() async {
@@ -90,5 +95,13 @@ class NotificationsController extends GetxController {
 
   Future<void> _loadRequestCount() async {
     requestCount.value = await _feedRequestService.pendingRequestCount();
+  }
+
+  Future<void> _loadRequestUsers() async {
+    final requests = await _feedRequestService.fetchRequestsForMyFeeds();
+    final sorted = [...requests]
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    requestUsers.value =
+        sorted.map((r) => r.user).take(3).toList(growable: false);
   }
 }

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/components/notification_item.dart';
+import 'package:hoot/components/avatar_stack.dart';
 import 'package:hoot/util/extensions/datetime_extension.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:hoot/util/routes/app_routes.dart';
@@ -113,7 +114,7 @@ class NotificationsView extends GetView<NotificationsController> {
                 onTap: () => Get.toNamed(AppRoutes.feedRequests),
                 title: Text('subscriberRequestsCount'.trParams(
                     {'count': controller.requestCount.value.toString()})),
-                leading: Icon(SolarIconsBold.tickerStar),
+                leading: AvatarStack(users: controller.requestUsers.toList()),
                 trailing: const Icon(Icons.chevron_right),
               ),
             Expanded(

--- a/test/feed_page_controller_test.dart
+++ b/test/feed_page_controller_test.dart
@@ -50,19 +50,22 @@ class FakeAuthService extends GetxService implements AuthService {
 class FakeFeedService implements BaseFeedService {
   PostPage? nextPage;
   @override
-  Future<PostPage> fetchSubscribedPosts({DocumentSnapshot? startAfter, int limit = 10}) async {
+  Future<PostPage> fetchSubscribedPosts(
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
     return PostPage(posts: []);
   }
 
   @override
-  Future<PostPage> fetchFeedPosts(String feedId, {DocumentSnapshot? startAfter, int limit = 10}) async {
+  Future<PostPage> fetchFeedPosts(String feedId,
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
     return nextPage ?? PostPage(posts: []);
   }
 }
 
 class FakeSubscriptionService extends SubscriptionService {
   final Set<String> subs;
-  FakeSubscriptionService(this.subs) : super(firestore: FakeFirebaseFirestore());
+  FakeSubscriptionService(this.subs)
+      : super(firestore: FakeFirebaseFirestore());
   @override
   Future<Set<String>> fetchSubscriptions(String userId) async => subs;
 }
@@ -70,7 +73,11 @@ class FakeSubscriptionService extends SubscriptionService {
 class FakeFeedRequestService extends FeedRequestService {
   bool existsResult = false;
   FakeFeedRequestService()
-      : super(firestore: FakeFirebaseFirestore(), subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()), authService: FakeAuthService(null));
+      : super(
+            firestore: FakeFirebaseFirestore(),
+            subscriptionService:
+                SubscriptionService(firestore: FakeFirebaseFirestore()),
+            authService: FakeAuthService(null));
   @override
   Future<List<FeedJoinRequest>> fetchRequests(String feedId) async => [];
   @override
@@ -83,6 +90,8 @@ class FakeFeedRequestService extends FeedRequestService {
   Future<bool> exists(String feedId, String userId) async => existsResult;
   @override
   Future<int> pendingRequestCount() async => 0;
+  @override
+  Future<List<FeedJoinRequest>> fetchRequestsForMyFeeds() async => [];
 }
 
 class FakeSubscriptionManager extends SubscriptionManager {
@@ -91,8 +100,13 @@ class FakeSubscriptionManager extends SubscriptionManager {
   FakeSubscriptionManager(this.result)
       : super(
           firestore: FakeFirebaseFirestore(),
-          subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()),
-          feedRequestService: FeedRequestService(firestore: FakeFirebaseFirestore(), subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()), authService: FakeAuthService(null)),
+          subscriptionService:
+              SubscriptionService(firestore: FakeFirebaseFirestore()),
+          feedRequestService: FeedRequestService(
+              firestore: FakeFirebaseFirestore(),
+              subscriptionService:
+                  SubscriptionService(firestore: FakeFirebaseFirestore()),
+              authService: FakeAuthService(null)),
         );
   @override
   Future<SubscriptionResult> toggle(String feedId, U user) async {
@@ -111,7 +125,13 @@ void main() {
     final requestService = FakeFeedRequestService();
     final manager = FakeSubscriptionManager(SubscriptionResult.subscribed);
     final controller = FeedPageController(
-      args: FeedPageArgs(feed: Feed(id: 'f1', userId: 'u2', nsfw: true, title: 't', description: 'd')),
+      args: FeedPageArgs(
+          feed: Feed(
+              id: 'f1',
+              userId: 'u2',
+              nsfw: true,
+              title: 't',
+              description: 'd')),
       authService: auth,
       feedService: feedService,
       subscriptionService: subService,
@@ -130,7 +150,8 @@ void main() {
     final requestService = FakeFeedRequestService();
     final manager = FakeSubscriptionManager(SubscriptionResult.requested);
     final controller = FeedPageController(
-      args: FeedPageArgs(feed: Feed(id: 'f1', userId: 'u2', title: 't', description: 'd')),
+      args: FeedPageArgs(
+          feed: Feed(id: 'f1', userId: 'u2', title: 't', description: 'd')),
       authService: auth,
       feedService: feedService,
       subscriptionService: subService,
@@ -147,14 +168,17 @@ void main() {
     final user = U(uid: 'u1');
     final auth = FakeAuthService(user);
     final feedService = FakeFeedService();
-    feedService.nextPage = PostPage(posts: [Post(id: 'p1', user: user, text: 'hello')]);
+    feedService.nextPage =
+        PostPage(posts: [Post(id: 'p1', user: user, text: 'hello')]);
     final controller = FeedPageController(
-      args: FeedPageArgs(feed: Feed(id: 'f1', userId: 'u2', title: 't', description: 'd')),
+      args: FeedPageArgs(
+          feed: Feed(id: 'f1', userId: 'u2', title: 't', description: 'd')),
       authService: auth,
       feedService: feedService,
       subscriptionService: FakeSubscriptionService({}),
       feedRequestService: FakeFeedRequestService(),
-      subscriptionManager: FakeSubscriptionManager(SubscriptionResult.subscribed),
+      subscriptionManager:
+          FakeSubscriptionManager(SubscriptionResult.subscribed),
     );
     controller.onInit();
     await controller.fetchNext();

--- a/test/home_view_test.dart
+++ b/test/home_view_test.dart
@@ -16,6 +16,7 @@ import 'package:hoot/services/feed_request_service.dart';
 import 'package:hoot/services/subscription_service.dart';
 import 'package:hoot/services/theme_service.dart';
 import 'package:hoot/models/user.dart';
+import 'package:hoot/models/feed_join_request.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/translations/app_translations.dart';
 import 'package:solar_icons/solar_icons.dart';
@@ -74,6 +75,9 @@ class FakeFeedRequestService extends FeedRequestService {
 
   @override
   Future<int> pendingRequestCount() async => 0;
+
+  @override
+  Future<List<FeedJoinRequest>> fetchRequestsForMyFeeds() async => [];
 }
 
 class TestNotificationsController extends NotificationsController {

--- a/test/notifications_controller_test.dart
+++ b/test/notifications_controller_test.dart
@@ -17,7 +17,10 @@ import 'package:hoot/models/feed_join_request.dart';
 class FakeStreamSubscription<T> implements StreamSubscription<T> {
   bool canceled = false;
   @override
-  Future<void> cancel() async {canceled = true;}
+  Future<void> cancel() async {
+    canceled = true;
+  }
+
   @override
   void onData(void Function(T data)? handleData) {}
   @override
@@ -38,12 +41,14 @@ class FakeUnreadStream extends Stream<int> {
   final FakeStreamSubscription<int> sub;
   FakeUnreadStream(this.sub);
   @override
-  StreamSubscription<int> listen(void Function(int)? onData, {Function? onError, void Function()? onDone, bool? cancelOnError}) {
+  StreamSubscription<int> listen(void Function(int)? onData,
+      {Function? onError, void Function()? onDone, bool? cancelOnError}) {
     return sub;
   }
 }
 
-class FakeNotificationService extends GetxService implements BaseNotificationService {
+class FakeNotificationService extends GetxService
+    implements BaseNotificationService {
   final FakeStreamSubscription<int> fakeSub;
   FakeNotificationService(this.fakeSub);
   @override
@@ -51,7 +56,8 @@ class FakeNotificationService extends GetxService implements BaseNotificationSer
   @override
   Future<List<HootNotification>> fetchNotifications(String userId) async => [];
   @override
-  Future<void> createNotification(String userId, Map<String, dynamic> data) async {}
+  Future<void> createNotification(
+      String userId, Map<String, dynamic> data) async {}
   @override
   Future<void> markAsRead(String userId, String notificationId) async {}
   @override
@@ -62,12 +68,15 @@ class FakeFeedRequestService extends FeedRequestService {
   FakeFeedRequestService()
       : super(
             firestore: FakeFirebaseFirestore(),
-            subscriptionService: SubscriptionService(firestore: FakeFirebaseFirestore()),
+            subscriptionService:
+                SubscriptionService(firestore: FakeFirebaseFirestore()),
             authService: FakeAuthService(U(uid: 'u1')));
   @override
   Future<int> pendingRequestCount() async => 0;
   @override
   Future<List<FeedJoinRequest>> fetchRequests(String feedId) async => [];
+  @override
+  Future<List<FeedJoinRequest>> fetchRequestsForMyFeeds() async => [];
   @override
   Future<void> submit(String feedId, String userId) async {}
   @override


### PR DESCRIPTION
## Summary
- show up to three requester avatars on the notifications page
- support stacked avatars with new component
- expose request users list in notifications controller
- adjust tests for new preview behavior

## Testing
- `flutter test test/notifications_view_test.dart -j 1` *(fails: Expected text not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c93ae37388328b184b0ed5ca8c744