### PR TITLE
Add createdAt to feed requests

### DIFF
--- a/lib/services/feed_request_service.dart
+++ b/lib/services/feed_request_service.dart
@@ -28,10 +28,11 @@ class FeedRequestService {
         .collection('requests')
         .doc(userId);
     await _firestore.runTransaction((txn) async {
-      txn.set(
-        requestRef,
-        _authService.currentUser?.toCache(),
-      );
+      final userData = _authService.currentUser?.toCache() ?? {};
+      txn.set(requestRef, {
+        ...userData,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- include `createdAt` when submitting feed join requests
- verify timestamp in submit test
- ensure `fetchRequestsForMyFeeds` returns submitted request

## Testing
- `flutter test test/feed_request_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688c9b24f5d08328bd358e712a745405