### PR TITLE
Add OneSignal service integration

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -7,6 +7,7 @@ import 'package:hoot/services/subscription_service.dart';
 import 'package:hoot/services/feed_request_service.dart';
 import 'package:hoot/services/subscription_manager.dart';
 import 'package:hoot/services/quick_actions_service.dart';
+import 'package:hoot/services/onesignal_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -22,8 +23,10 @@ class DependencyInjector {
     Get.put(FeedRequestService(), permanent: true);
     Get.put(SubscriptionManager(), permanent: true);
     Get.put(QuickActionsService(), permanent: true);
+    Get.put(OneSignalService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeSettings();
+    await Get.find<OneSignalService>().init();
     await Get.find<QuickActionsService>().init();
   }
 }

--- a/lib/services/onesignal_service.dart
+++ b/lib/services/onesignal_service.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:get/get.dart';
+import 'package:onesignal_flutter/onesignal_flutter.dart';
+
+/// Wrapper around the OneSignal SDK.
+class OneSignalService extends GetxService {
+  /// Initializes the OneSignal SDK.
+  Future<void> init() async {
+    OneSignal.initialize(dotenv.env['ONESIGNAL_APP_ID']!);
+  }
+
+  /// Logs the user with [uid] into OneSignal.
+  Future<void> login(String uid) {
+    return OneSignal.login(uid);
+  }
+
+  /// Prompts the user for notification permissions.
+  Future<bool> requestPermission() {
+    return OneSignal.Notifications.requestPermission(true);
+  }
+}


### PR DESCRIPTION
## Summary
- add new OneSignalService
- register OneSignalService on startup

## Testing
- `flutter analyze`
- `flutter test` *(fails: unable to find directory entry in pubspec.yaml /workspace/hoot/assets/videos)*

------
https://chatgpt.com/codex/tasks/task_e_688cb48914a08328942fa2aa82d47cc2