### PR TITLE
Add notifications permission route

### DIFF
--- a/lib/pages/home/controllers/home_controller.dart
+++ b/lib/pages/home/controllers/home_controller.dart
@@ -1,6 +1,7 @@
 import 'package:get/get.dart';
 import 'package:screen_corner_radius/screen_corner_radius.dart';
 import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/onesignal_service.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
 
@@ -35,6 +36,12 @@ class HomeController extends GetxController {
     }
     if (user.isUninvited) {
       Get.offAllNamed(AppRoutes.invitation);
+    }
+
+    final oneSignal = Get.find<OneSignalService>();
+    await oneSignal.login(user.uid);
+    if (await oneSignal.canRequestPermission()) {
+      Get.toNamed(AppRoutes.notificationsPermission);
     }
     _setRadius();
   }

--- a/lib/pages/notifications_permission/bindings/notification_permission_binding.dart
+++ b/lib/pages/notifications_permission/bindings/notification_permission_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import '../controllers/notification_permission_controller.dart';
+
+class NotificationPermissionBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => NotificationPermissionController());
+  }
+}

--- a/lib/pages/notifications_permission/controllers/notification_permission_controller.dart
+++ b/lib/pages/notifications_permission/controllers/notification_permission_controller.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+import 'package:hoot/services/onesignal_service.dart';
+import 'package:hoot/util/routes/app_routes.dart';
+
+class NotificationPermissionController extends GetxController {
+  final OneSignalService _oneSignalService = Get.find<OneSignalService>();
+
+  Future<void> requestPermission() async {
+    await _oneSignalService.requestPermission();
+    Get.offAllNamed(AppRoutes.home);
+  }
+}

--- a/lib/pages/notifications_permission/views/notification_permission_view.dart
+++ b/lib/pages/notifications_permission/views/notification_permission_view.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/notification_permission_controller.dart';
+
+class NotificationPermissionView
+    extends GetView<NotificationPermissionController> {
+  const NotificationPermissionView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('enableNotifications'.tr),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'notificationsPermission'.tr,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: controller.requestPermission,
+              child: Text('continueButton'.tr),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/onesignal_service.dart
+++ b/lib/services/onesignal_service.dart
@@ -18,4 +18,9 @@ class OneSignalService extends GetxService {
   Future<bool> requestPermission() {
     return OneSignal.Notifications.requestPermission(true);
   }
+
+  /// Returns whether requesting permission will show a prompt.
+  Future<bool> canRequestPermission() {
+    return OneSignal.Notifications.canRequest();
+  }
 }

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -11,6 +11,8 @@ import 'package:hoot/pages/home/bindings/home_binding.dart';
 import 'package:hoot/pages/home/views/home_view.dart';
 import 'package:hoot/pages/invitation/bindings/invitation_binding.dart';
 import 'package:hoot/pages/invitation/views/invitation_view.dart';
+import 'package:hoot/pages/notifications_permission/bindings/notification_permission_binding.dart';
+import 'package:hoot/pages/notifications_permission/views/notification_permission_view.dart';
 import 'package:hoot/pages/create_post/bindings/create_post_binding.dart';
 import 'package:hoot/pages/create_post/views/create_post_view.dart';
 import 'package:hoot/pages/profile/bindings/profile_binding.dart';
@@ -79,6 +81,12 @@ class AppPages {
       name: AppRoutes.invitation,
       page: () => const InvitationView(),
       binding: InvitationBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.notificationsPermission,
+      page: () => const NotificationPermissionView(),
+      binding: NotificationPermissionBinding(),
       middlewares: [AuthMiddleware()],
     ),
     GetPage(

--- a/lib/util/routes/app_routes.dart
+++ b/lib/util/routes/app_routes.dart
@@ -6,6 +6,7 @@ class AppRoutes {
   static const username = '/username';
   static const avatar = '/avatar';
   static const invitation = '/invitation';
+  static const notificationsPermission = '/notifications_permission';
   static const createPost = '/create_post';
   static const settings = '/settings';
   static const profile = '/profile';

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -344,6 +344,9 @@ class AppTranslations extends Translations {
           'findFriendsFromContacts': 'Find friends from your contacts list',
           'contactsPermission':
               'We need your permission to access your contacts',
+          'enableNotifications': 'Enable Notifications',
+          'notificationsPermission':
+              'Stay updated by enabling push notifications',
           'contacts': 'Contacts',
           'refresh': 'Refresh',
           'report': 'Report',
@@ -695,6 +698,9 @@ class AppTranslations extends Translations {
           'findFriendsFromContacts': 'Buscar amigos en tu lista de contactos',
           'contactsPermission':
               'Necesitamos tu permiso para acceder a tus contactos',
+          'enableNotifications': 'Activar Notificaciones',
+          'notificationsPermission':
+              'Mantente al día activando las notificaciones',
           'contacts': 'Contactos',
           'refresh': 'Actualizar',
           'report': 'Reportar',
@@ -1048,6 +1054,9 @@ class AppTranslations extends Translations {
               'Encontrar amigos a partir da tua lista de contactos',
           'contactsPermission':
               'Precisamos da tua permissão para aceder aos teus contactos',
+          'enableNotifications': 'Ativar Notificações',
+          'notificationsPermission':
+              'Fica a par de tudo ativando as notificações',
           'contacts': 'Contactos',
           'refresh': 'Atualizar',
           'report': 'Reportar',
@@ -1397,6 +1406,9 @@ class AppTranslations extends Translations {
               'Encontrar amigos na sua lista de contatos',
           'contactsPermission':
               'Precisamos da sua permissão para acessar seus contatos',
+          'enableNotifications': 'Ativar Notificações',
+          'notificationsPermission':
+              'Mantenha-se atualizado ativando as notificações',
           'contacts': 'Contatos',
           'refresh': 'Atualizar',
           'report': 'Denunciar',


### PR DESCRIPTION
## Summary
- add NotificationPermissionView, controller, and binding
- register notificationsPermission route
- add 'notificationsPermission' translations
- integrate OneSignal permission prompt in HomeController
- expose canRequestPermission in OneSignalService

## Testing
- `flutter test` *(fails: unable to find directory entry in pubspec.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_688cb72534b48328ae9179c68e40270a