### PR TITLE
Ensure OneSignal user login in HomeController

### DIFF
--- a/lib/pages/home/controllers/home_controller.dart
+++ b/lib/pages/home/controllers/home_controller.dart
@@ -36,6 +36,7 @@ class HomeController extends GetxController {
     }
     if (user.isUninvited) {
       Get.offAllNamed(AppRoutes.invitation);
+      return;
     }
 
     final oneSignal = Get.find<OneSignalService>();


### PR DESCRIPTION
## Summary
- exit verification early for uninvited users
- log in with OneSignal once the user is verified and invited

## Testing
- `flutter pub get`
- `flutter test` *(fails: pumpAndSettle timed out)*

------
https://chatgpt.com/codex/tasks/task_e_688cbad6f0588328af09aa508ada8326