### PR TITLE
Add pagination to notifications

### DIFF
--- a/test/notification_service_test.dart
+++ b/test/notification_service_test.dart
@@ -54,12 +54,13 @@ void main() {
         'createdAt': newer,
       });
 
-      final result = await service.fetchNotifications('u1');
+      final page = await service.fetchNotifications('u1');
 
-      expect(result.length, 2);
-      expect(result.first.type, 1);
-      expect(result.last.type, 0);
+      expect(page.notifications.length, 2);
+      expect(page.notifications.first.type, 1);
+      expect(page.notifications.last.type, 0);
     });
+
 
     test('markAllAsRead updates unread notifications', () async {
       final firestore = FakeFirebaseFirestore();

--- a/test/notifications_controller_test.dart
+++ b/test/notifications_controller_test.dart
@@ -8,6 +8,8 @@ import 'package:hoot/models/user.dart';
 import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/services/notification_service.dart';
+import 'package:hoot/services/notification_service.dart' show NotificationPage;
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hoot/services/feed_request_service.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -54,7 +56,12 @@ class FakeNotificationService extends GetxService
   @override
   Stream<int> unreadCountStream(String userId) => FakeUnreadStream(fakeSub);
   @override
-  Future<List<HootNotification>> fetchNotifications(String userId) async => [];
+  Future<NotificationPage> fetchNotifications(
+    String userId, {
+    DocumentSnapshot? startAfter,
+    int limit = 10,
+  }) async =>
+      NotificationPage(notifications: []);
   @override
   Future<void> createNotification(
       String userId, Map<String, dynamic> data) async {}


### PR DESCRIPTION
## Summary
- extend notification service with paginated API
- track paging state in notifications controller
- update tests for new API

## Testing
- `flutter test test/notification_service_test.dart test/notifications_controller_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_688cc218816c8328ad58bd054da2dc93