### PR TITLE
Fix Cloud Functions build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The backend includes a trigger named `onAuthUserDeleted` that runs whenever a Fi
 
 Another trigger, `onNotificationCreated`, sends a push notification via OneSignal whenever a new notification document is added for a user. Set the environment variables `ONESIGNAL_APP_ID` and `ONESIGNAL_API_KEY` in your Firebase project so this function can authenticate with the OneSignal API.
 
+Cloud Functions are built for Node.js 22 (see `functions/package.json`). Run `npm install` inside the `functions/` directory before executing `npm run build` or `firebase deploy`.
+
 ## Contributing
 
 Read the [contributing guidelines](CONTRIBUTING.md) for information on preferred patterns and example usage of services.

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
   "engines": {
     "node": "22"
   },
-  "main": "lib/index.js",
+  "main": "lib/src/index.js",
   "dependencies": {
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.0.1"

--- a/functions/src/triggers/onAuthUserDeleted.ts
+++ b/functions/src/triggers/onAuthUserDeleted.ts
@@ -1,9 +1,9 @@
-import { onUserDeleted } from "firebase-functions/v2/auth";
+import { auth } from "firebase-functions/v1";
 import { FieldValue } from "firebase-admin/firestore";
 import { db } from "../config";
 
-export const onAuthUserDeleted = onUserDeleted(async (event) => {
-  const uid = event.data.uid;
+export const onAuthUserDeleted = auth.user().onDelete(async (user) => {
+  const uid = user.uid;
 
   // Remove the main user document if it still exists.
   await db.collection("users").doc(uid).delete().catch(() => undefined);


### PR DESCRIPTION
## Summary
- update `onAuthUserDeleted` trigger import for Node compatibility
- set build output path in `functions/package.json`
- document Node version and dependency install steps

## Testing
- `npm run build`
- `firebase deploy --only functions` *(fails: Failed to authenticate)*
- `flutter test` *(fails: unable to find directory entry in pubspec.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_688ceb985db48328bb737dca0f247516