### PR TITLE
Implement push notification deep links

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:hoot/services/theme_service.dart';
 import 'package:hoot/services/quick_actions_service.dart';
+import 'package:hoot/services/onesignal_service.dart';
 import 'package:hoot/firebase_options.dart';
 
 void main() {
@@ -30,6 +31,7 @@ void main() {
     );
     await DependencyInjector.init();
     final quickActions = Get.find<QuickActionsService>();
+    final oneSignal = Get.find<OneSignalService>();
     await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
     FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
 
@@ -66,6 +68,7 @@ void main() {
       ),
     );
     quickActions.handlePendingAction();
+    oneSignal.handlePendingNotification();
     FlutterNativeSplash.remove();
   }, (error, stack) {
     FirebaseCrashlytics.instance.recordError(error, stack);

--- a/lib/services/onesignal_service.dart
+++ b/lib/services/onesignal_service.dart
@@ -1,12 +1,22 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
+import 'package:flutter/widgets.dart';
 import 'package:onesignal_flutter/onesignal_flutter.dart';
+import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/util/routes/args/feed_page_args.dart';
+import 'package:hoot/util/routes/args/profile_args.dart';
 
 /// Wrapper around the OneSignal SDK.
 class OneSignalService extends GetxService {
+  Map<String, dynamic>? _pendingData;
   /// Initializes the OneSignal SDK.
   Future<void> init() async {
     OneSignal.initialize(dotenv.env['ONESIGNAL_APP_ID']!);
+    OneSignal.Notifications.addClickListener((event) {
+      _pendingData = event.notification.additionalData;
+      WidgetsBinding.instance
+          .addPostFrameCallback((_) => handlePendingNotification());
+    });
   }
 
   /// Logs the user with [uid] into OneSignal.
@@ -22,5 +32,24 @@ class OneSignalService extends GetxService {
   /// Returns whether requesting permission will show a prompt.
   Future<bool> canRequestPermission() {
     return OneSignal.Notifications.canRequest();
+  }
+
+  void handlePendingNotification() {
+    final data = _pendingData;
+    if (data == null) return;
+    _pendingData = null;
+    if (data['postId'] != null) {
+      Get.toNamed(AppRoutes.post, arguments: {'id': data['postId']});
+      return;
+    }
+    if (data['feedId'] != null) {
+      Get.toNamed(AppRoutes.feed,
+          arguments: FeedPageArgs(feedId: data['feedId']));
+      return;
+    }
+    if (data['uid'] != null) {
+      Get.toNamed(AppRoutes.profile,
+          arguments: ProfileArgs(uid: data['uid']));
+    }
   }
 }


### PR DESCRIPTION
## Summary
- listen for OneSignal notification clicks
- open app routes from stored notification data
- trigger pending notification handler after startup
- test OneSignalService click navigation

## Testing
- `flutter test test/onesignal_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688d00381ae08328ab04e6d172144071