### PR TITLE
Add invitation used trigger

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,3 +7,4 @@ export * from "./triggers/onSubscriptionCreated";
 export * from "./triggers/onPostDeleted";
 export * from "./triggers/onUserUpdated";
 export * from "./triggers/onFeedUpdated";
+export * from "./triggers/onInvitationUsed";

--- a/functions/src/triggers/onInvitationUsed.ts
+++ b/functions/src/triggers/onInvitationUsed.ts
@@ -1,0 +1,28 @@
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+import { FieldValue } from "firebase-admin/firestore";
+import { db } from "../config";
+
+export const onInvitationUsed = onDocumentWritten(
+  "users/{userId}",
+  async (event) => {
+    const { userId } = event.params;
+    const before = event.data?.before?.data();
+    const after = event.data?.after?.data();
+    if (!after) return;
+
+    if (!before?.invitedBy && after.invitedBy) {
+      const inviterId = after.invitedBy as string;
+      const userData = { ...after, uid: userId };
+      await db
+        .collection("users")
+        .doc(inviterId)
+        .collection("notifications")
+        .add({
+          user: userData,
+          type: 5,
+          read: false,
+          createdAt: FieldValue.serverTimestamp(),
+        });
+    }
+  }
+);


### PR DESCRIPTION
## Summary
- add Firestore trigger to notify inviter when their code is redeemed
- export the new trigger

## Testing
- `npm --prefix functions run build`
- `flutter test` *(fails: unhandled test errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d004f42fc83289ce1757e2683aed1