### PR TITLE
Create shared lane for GitHub releases

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,6 +59,7 @@ lane :deploy do
     deploy_google_play
     #deploy_huawei
     deploy_ios
+    publish_github_release
 end
 
 desc "Deploy to Google Play Store"
@@ -121,5 +122,27 @@ lane :deploy_testflight do
         ipa: "./build/ios/ipa/hoot.ipa",
         team_id: "125395078",
         skip_waiting_for_build_processing: true,
+    )
+    publish_github_release(prerelease: true)
+end
+
+desc "Tag and publish a GitHub release"
+lane :publish_github_release do |options|
+    # Determine the version from pubspec.yaml
+    pubspec_path = File.expand_path('../pubspec.yaml', __dir__)
+    version_line = File.read(pubspec_path).match(/version:\s*(.*)/)[1].strip
+    tag = "v#{version_line}"
+    add_git_tag(tag: tag)
+    push_git_tags
+
+    changelog = changelog_from_git_commits
+    github_release(
+      repository_name: "your-org/Hoot",
+      tag_name: tag,
+      name: tag,
+      description: changelog,
+      commitish: 'main',
+      api_token: 'GITHUB_TOKEN_PLACEHOLDER',
+      prerelease: options && options[:prerelease]
     )
 end


### PR DESCRIPTION
## Summary
- refactor Fastlane deploy lanes to call a new `publish_github_release` lane
- `publish_github_release` tags the repo and creates a GitHub release using a placeholder token

## Testing
- `bundle install >/tmp/bundle.log && tail -n 20 /tmp/bundle.log`
- `bundle exec fastlane --version`
- `flutter --version`
- `flutter test --no-pub` *(fails: FeedRequestService and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d196cc87c83289cf60a580509836d