### PR TITLE
Make explore search case insensitive

### DIFF
--- a/lib/pages/explore/controllers/explore_controller.dart
+++ b/lib/pages/explore/controllers/explore_controller.dart
@@ -141,7 +141,8 @@ class ExploreController extends GetxController {
   /// Searches for users and feeds matching [query].
   Future<void> search(String value) async {
     query.value = value;
-    if (value.isEmpty) {
+    final lower = value.toLowerCase();
+    if (lower.isEmpty) {
       userSuggestions.clear();
       feedSuggestions.clear();
       return;
@@ -152,14 +153,14 @@ class ExploreController extends GetxController {
       final futures = await Future.wait([
         _firestore
             .collection('users')
-            .where('username', isGreaterThanOrEqualTo: value)
-            .where('username', isLessThanOrEqualTo: '$value\uf8ff')
+            .where('usernameLowercase', isGreaterThanOrEqualTo: lower)
+            .where('usernameLowercase', isLessThanOrEqualTo: '$lower\uf8ff')
             .limit(5)
             .get(),
         _firestore
             .collection('feeds')
-            .where('title', isGreaterThanOrEqualTo: value)
-            .where('title', isLessThanOrEqualTo: '$value\uf8ff')
+            .where('titleLowercase', isGreaterThanOrEqualTo: lower)
+            .where('titleLowercase', isLessThanOrEqualTo: '$lower\uf8ff')
             .limit(5)
             .get(),
       ]);

--- a/test/explore_view_test.dart
+++ b/test/explore_view_test.dart
@@ -15,9 +15,11 @@ void main() {
       'uid': 'u1',
       'displayName': 'Tester',
       'username': 'tester',
+      'usernameLowercase': 'tester',
     });
     await firestore.collection('feeds').doc('f1').set({
       'title': 'test feed',
+      'titleLowercase': 'test feed',
       'description': 'D',
       'color': '0',
       'type': 'music',
@@ -36,9 +38,10 @@ void main() {
       ),
     );
 
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
 
-    await tester.enterText(find.byType(TextField), 'test');
+    await tester.enterText(find.byType(TextField), 'TEST');
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 
@@ -58,6 +61,7 @@ void main() {
       'uid': 'u1',
       'displayName': 'Tester',
       'username': 'tester',
+      'usernameLowercase': 'tester',
     });
 
     Get.put(ExploreController(firestore: firestore));
@@ -79,9 +83,10 @@ void main() {
       ),
     );
 
-    await tester.pumpAndSettle();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
 
-    await tester.enterText(find.byType(TextField), 'test');
+    await tester.enterText(find.byType(TextField), 'TEST');
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
 


### PR DESCRIPTION
## Summary
- Normalize explore searches to lowercase and query lowercase fields
- Cover case-insensitive searching in ExploreView tests

## Testing
- `flutter test test/explore_view_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688dc11ae0a48328a1bd99bec5d492e2