### PR TITLE
fix: ensure case-insensitive explore search

### DIFF
--- a/lib/pages/explore/controllers/explore_controller.dart
+++ b/lib/pages/explore/controllers/explore_controller.dart
@@ -153,12 +153,14 @@ class ExploreController extends GetxController {
       final futures = await Future.wait([
         _firestore
             .collection('users')
+            .orderBy('usernameLowercase')
             .where('usernameLowercase', isGreaterThanOrEqualTo: lower)
             .where('usernameLowercase', isLessThanOrEqualTo: '$lower\uf8ff')
             .limit(5)
             .get(),
         _firestore
             .collection('feeds')
+            .orderBy('titleLowercase')
             .where('titleLowercase', isGreaterThanOrEqualTo: lower)
             .where('titleLowercase', isLessThanOrEqualTo: '$lower\uf8ff')
             .limit(5)


### PR DESCRIPTION
## Summary
- enforce orderBy on lowercase fields before range filtering in explore search

## Testing
- `flutter test test/explore_view_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688dc626a63c8328a34d4ab70650bc43