### PR TITLE
feat: paginate search by genre

### DIFF
--- a/lib/pages/search_by_genre/controllers/search_by_genre_controller.dart
+++ b/lib/pages/search_by_genre/controllers/search_by_genre_controller.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get/get.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/util/enums/feed_types.dart';
@@ -12,25 +13,59 @@ class SearchByGenreController extends GetxController {
       : _firestore = firestore ?? FirebaseFirestore.instance;
 
   late FeedType type;
-  final RxList<Feed> feeds = <Feed>[].obs;
+
+  final Rx<PagingState<DocumentSnapshot?, Feed>> state =
+      PagingState<DocumentSnapshot?, Feed>().obs;
 
   @override
   void onInit() {
     super.onInit();
     type = Get.arguments as FeedType;
-    loadFeeds();
+    fetchNextPage();
   }
 
-  /// Loads feeds of the selected [type].
-  Future<void> loadFeeds() async {
-    final snapshot = await _firestore
-        .collection('feeds')
-        .where('type', isEqualTo: type.toString().split('.').last)
-        .orderBy('subscriberCount', descending: true)
-        .limit(20)
-        .get();
-    feeds.assignAll(snapshot.docs
-        .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
-        .toList());
+  /// Loads a new page of feeds of the selected [type].
+  void fetchNextPage() async {
+    final current = state.value;
+    if (current.isLoading) return;
+
+    state.value = current.copyWith(isLoading: true, error: null);
+
+    try {
+      const limit = 20;
+      Query<Map<String, dynamic>> query = _firestore
+          .collection('feeds')
+          .where('type', isEqualTo: type.toString().split('.').last)
+          .orderBy('subscriberCount', descending: true)
+          .limit(limit);
+
+      final lastDoc = current.keys?.last;
+      if (lastDoc != null) {
+        query = query.startAfterDocument(lastDoc);
+      }
+
+      final snapshot = await query.get();
+      final feeds = snapshot.docs
+          .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
+          .toList();
+
+      state.value = state.value.copyWith(
+        pages: [...?current.pages, feeds],
+        keys: [
+          ...?current.keys,
+          snapshot.docs.isNotEmpty ? snapshot.docs.last : null
+        ],
+        hasNextPage: snapshot.docs.length == limit,
+        isLoading: false,
+      );
+    } catch (e) {
+      state.value = state.value.copyWith(error: e, isLoading: false);
+    }
+  }
+
+  @override
+  void refresh() {
+    state.value = state.value.reset();
+    fetchNextPage();
   }
 }

--- a/lib/pages/search_by_genre/views/search_by_genre_view.dart
+++ b/lib/pages/search_by_genre/views/search_by_genre_view.dart
@@ -1,7 +1,10 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/components/notification_item.dart';
+import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/routes/args/feed_page_args.dart';
 import 'package:hoot/util/routes/args/profile_args.dart';
@@ -21,64 +24,88 @@ class SearchByGenreView extends GetView<SearchByGenreController> {
       appBar: AppBarComponent(
         title: '$emoji $title',
       ),
-      body: Obx(() => Stack(
-            fit: StackFit.expand,
-            children: [
-              Positioned(
-                bottom: -8,
-                right: -32,
-                child: RotatedBox(
-                  quarterTurns: 3,
-                  child: Opacity(
-                    opacity: 0.25,
-                    child: Text(
-                      title,
-                      style: Theme.of(context).textTheme.displayLarge?.copyWith(
-                        fontSize: 120,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
+      body: Obx(() {
+        final state = controller.state.value;
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            Positioned(
+              bottom: -8,
+              right: -32,
+              child: RotatedBox(
+                quarterTurns: 3,
+                child: Opacity(
+                  opacity: 0.25,
+                  child: Text(
+                    title,
+                    style: Theme.of(context).textTheme.displayLarge?.copyWith(
+                          fontSize: 120,
+                        ),
+                    textAlign: TextAlign.center,
                   ),
                 ),
               ),
-              ListView.builder(
-                itemCount: controller.feeds.length,
-                itemBuilder: (context, index) {
-                  final feed = controller.feeds[index];
-                  String content =
-                      '${feed.subscriberCount ?? 0} ${'followers'.tr}';
-                  if (feed.description != null &&
-                      feed.description!.isNotEmpty) {
-                    content = '${feed.description}\n$content';
-                  }
-                  return GestureDetector(
-                    onTap: () {
-                      HapticService.lightImpact();
-                      Get.toNamed(
-                        AppRoutes.profile,
-                        arguments:
-                            ProfileArgs(uid: feed.userId, feedId: feed.id),
-                      );
-                    },
-                    child: ListItem(
+            ),
+            RefreshIndicator(
+              onRefresh: () => Future.sync(() => controller.refresh()),
+              child: PagedListView<DocumentSnapshot?, Feed>(
+                state: state,
+                fetchNextPage: controller.fetchNextPage,
+                builderDelegate: PagedChildBuilderDelegate<Feed>(
+                  itemBuilder: (context, feed, index) {
+                    String content =
+                        '${feed.subscriberCount ?? 0} ${'followers'.tr}';
+                    if (feed.description != null &&
+                        feed.description!.isNotEmpty) {
+                      content = '${feed.description}\n$content';
+                    }
+                    return GestureDetector(
                       onTap: () {
                         HapticService.lightImpact();
                         Get.toNamed(
-                          AppRoutes.feed,
-                          arguments: FeedPageArgs(feed: feed),
+                          AppRoutes.profile,
+                          arguments: ProfileArgs(
+                            uid: feed.userId,
+                            feedId: feed.id,
+                          ),
                         );
                       },
-                      avatarUrl: feed.bigAvatar ?? feed.smallAvatar ?? '',
-                      avatarHash: feed.bigAvatarHash ?? feed.smallAvatarHash,
-                      title: feed.title,
-                      titleStyle: Theme.of(context).textTheme.titleLarge,
-                      subtitle: content,
-                    ),
-                  );
-                },
+                      child: ListItem(
+                        onTap: () {
+                          HapticService.lightImpact();
+                          Get.toNamed(
+                            AppRoutes.feed,
+                            arguments: FeedPageArgs(feed: feed),
+                          );
+                        },
+                        avatarUrl: feed.bigAvatar ?? feed.smallAvatar ?? '',
+                        avatarHash: feed.bigAvatarHash ?? feed.smallAvatarHash,
+                        title: feed.title,
+                        titleStyle: Theme.of(context).textTheme.titleLarge,
+                        subtitle: content,
+                      ),
+                    );
+                  },
+                  firstPageProgressIndicatorBuilder: (_) =>
+                      const Center(child: CircularProgressIndicator()),
+                  newPageProgressIndicatorBuilder: (_) => const Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                  firstPageErrorIndicatorBuilder: (_) => NothingToShowComponent(
+                    icon: const Icon(Icons.error_outline),
+                    text: 'somethingWentWrong'.tr,
+                  ),
+                  noItemsFoundIndicatorBuilder: (_) => NothingToShowComponent(
+                    icon: const Icon(Icons.feed_outlined),
+                    text: 'searchForGenreFeeds'.trParams({'genre': title}),
+                  ),
+                ),
               ),
-            ],
-          )),
+            ),
+          ],
+        );
+      }),
     );
   }
 }


### PR DESCRIPTION
## Summary
- load search-by-genre feeds using a paging controller
- display paged results with pull-to-refresh on the search-by-genre view

## Testing
- `flutter test` *(fails: TimeoutException in home_view_test; some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688dc571c00c8328bf889d89dc6b87e1