### PR TITLE
Add icons to Settings navigation tiles

### DIFF
--- a/lib/pages/settings/views/settings_view.dart
+++ b/lib/pages/settings/views/settings_view.dart
@@ -40,11 +40,15 @@ class SettingsView extends GetView<SettingsController> {
             ),
           ),
           ListTile(
+            leading: const Icon(Icons.palette_outlined),
             title: Text('appColor'.tr),
+            trailing: const Icon(Icons.chevron_right),
             onTap: () => Get.toNamed(AppRoutes.appColor),
           ),
           ListTile(
+            leading: const Icon(Icons.person_outline),
             title: Text('editProfile'.tr),
+            trailing: const Icon(Icons.chevron_right),
             onTap: controller.goToEditProfile,
           ),
           ListTile(
@@ -53,20 +57,28 @@ class SettingsView extends GetView<SettingsController> {
             onTap: controller.findFriends,
           ),
           ListTile(
+            leading: const Icon(Icons.subscriptions_outlined),
             title: Text('subscriptions'.tr),
+            trailing: const Icon(Icons.chevron_right),
             onTap: () => Get.toNamed(AppRoutes.subscriptions),
           ),
           ListTile(
+            leading: const Icon(Icons.description_outlined),
             title: Text('termsOfService'.tr),
+            trailing: const Icon(Icons.chevron_right),
             onTap: () => Get.toNamed(AppRoutes.terms),
           ),
           ListTile(
+            leading: const Icon(Icons.delete_outline),
             title: Text('deleteAccount'.tr),
             subtitle: Text('deleteAccountDescription'.tr),
+            trailing: const Icon(Icons.chevron_right),
             onTap: () => controller.deleteAccount(context),
           ),
           ListTile(
+            leading: const Icon(Icons.logout_outlined),
             title: Text('signOut'.tr),
+            trailing: const Icon(Icons.chevron_right),
             onTap: () => controller.signOut(context),
           ),
           const Divider(),


### PR DESCRIPTION
## Summary
- add leading icons and chevron-right indicators to settings navigation rows

## Testing
- `flutter test` *(fails: stuck while loading login_view_test.dart)*
- `dart analyze lib/pages/settings/views/settings_view.dart`


------
https://chatgpt.com/codex/tasks/task_e_688e28795cd88328b1aece8e64f1f711