### PR TITLE
Add location and website preview to profile

### DIFF
--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -8,6 +8,7 @@ import 'package:solar_icons/solar_icons.dart';
 import 'package:hoot/models/user.dart';
 import 'package:hoot/components/image_component.dart';
 import 'package:hoot/components/empty_message.dart';
+import 'package:hoot/components/url_preview_component.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/routes/args/profile_args.dart';
 import 'package:hoot/util/routes/args/feed_page_args.dart';
@@ -112,9 +113,10 @@ class _ProfileViewState extends State<ProfileView> {
                   Glassify(
                     settings: LiquidGlassSettings(
                       blur: 16,
-                      glassColor: Theme.of(context).brightness == Brightness.light
-                          ? Colors.black54
-                          : Colors.white38,
+                      glassColor:
+                          Theme.of(context).brightness == Brightness.light
+                              ? Colors.black54
+                              : Colors.white38,
                     ),
                     child: Text(
                       user.name ?? '',
@@ -139,7 +141,42 @@ class _ProfileViewState extends State<ProfileView> {
                   if (user.bio != null && user.bio!.isNotEmpty)
                     Padding(
                       padding: const EdgeInsets.only(top: 4),
-                      child: Text(user.bio!),
+                      child: Text(
+                        user.bio!,
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  if (user.location != null && user.location!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            SolarIconsBold.mapPoint,
+                            size: 16,
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            user.location!,
+                            style: Get.textTheme.bodyMedium?.copyWith(
+                              color: Theme.of(context)
+                                  .colorScheme
+                                  .onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  if (user.website != null && user.website!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 16),
+                      child: UrlPreviewComponent(
+                        url: user.website!,
+                        isClickable: true,
+                      ),
                     ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- show user's location below bio on profile
- preview user's website with clickable link

## Testing
- `flutter analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart'; The getter 'foregroundColor' isn't defined for the type 'Feed')*
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_688e2fb0e5108328a45e3258b9a351fe