### PR TITLE
Fix location suggestions layout in edit profile

### DIFF
--- a/lib/pages/edit_profile/views/edit_profile_view.dart
+++ b/lib/pages/edit_profile/views/edit_profile_view.dart
@@ -165,6 +165,7 @@ class EditProfileView extends GetView<EditProfileController> {
                     TypeAheadField<String>(
                       controller: controller.locationController,
                       suggestionsCallback: controller.searchCities,
+                      direction: VerticalDirection.up,
                       builder: (context, textController, focusNode) {
                         return TextField(
                           controller: textController,


### PR DESCRIPTION
## Summary
- ensure location suggestions drop down above the keyboard in edit profile

## Testing
- `flutter analyze`
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_688e383e9b108328a8e2794ddcd7b2de