### PR TITLE
Ensure PostComponent updates when post data changes

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -75,6 +75,16 @@ class _PostComponentState extends State<PostComponent> {
     }
   }
 
+  @override
+  void didUpdateWidget(covariant PostComponent oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.post != oldWidget.post) {
+      setState(() {
+        _post = widget.post;
+      });
+    }
+  }
+
   Future<void> _toggleLike() async {
     final user = _authService.currentUser;
     if (user == null) return;


### PR DESCRIPTION
## Summary
- Override `didUpdateWidget` in `PostComponent` to refresh internal state when `post` changes
- Keeps displayed post data in sync after async reloads

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_688e3cf867e08328826edcb978769287