### PR TITLE
Refactor subscribers list to use ListItem

### DIFF
--- a/lib/components/notification_item.dart
+++ b/lib/components/notification_item.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 
 import 'package:hoot/components/scale_on_press.dart';
@@ -7,10 +6,8 @@ import 'package:hoot/components/avatar_component.dart';
 class ListItem extends StatelessWidget {
   final String avatarUrl;
   final String? avatarHash;
-  final String title;
-  final TextStyle? titleStyle;
-  final String subtitle;
-  final TextStyle? subtitleStyle;
+  final Widget title;
+  final Widget? subtitle;
   final VoidCallback? onTap;
   final VoidCallback? onAvatarTap;
   final Widget? trailing;
@@ -20,9 +17,7 @@ class ListItem extends StatelessWidget {
     required this.avatarUrl,
     this.avatarHash,
     required this.title,
-    required this.subtitle,
-    this.titleStyle,
-    this.subtitleStyle,
+    this.subtitle,
     this.onTap,
     this.onAvatarTap,
     this.trailing,
@@ -55,9 +50,9 @@ class ListItem extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             ProfileAvatarComponent(
-                image: avatarUrl,
-                hash: avatarHash,
-                size: 50,
+              image: avatarUrl,
+              hash: avatarHash,
+              size: 50,
             ),
             const SizedBox(width: 16),
             Expanded(
@@ -65,21 +60,11 @@ class ListItem extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    title,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: titleStyle ?? Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 4),
-                  Text(
-                    subtitle,
-                    maxLines: 3,
-                    overflow: TextOverflow.ellipsis,
-                    style: subtitleStyle ?? Theme.of(context)
-                        .textTheme
-                        .bodySmall,
-                  ),
+                  title,
+                  if (subtitle != null) ...[
+                    const SizedBox(height: 4),
+                    subtitle!,
+                  ],
                 ],
               ),
             ),

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -77,8 +77,18 @@ class NotificationsView extends GetView<NotificationsController> {
                       return ListItem(
                         avatarUrl: user.largeProfilePictureUrl ?? '',
                         avatarHash: user.bigAvatarHash ?? user.smallAvatarHash,
-                        title: text,
-                        subtitle: n.createdAt.timeAgo(),
+                        title: Text(
+                          text,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        subtitle: Text(
+                          n.createdAt.timeAgo(),
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
                         onTap: () {
                           HapticService.lightImpact();
                           switch (n.type) {
@@ -130,7 +140,8 @@ class NotificationsView extends GetView<NotificationsController> {
                       text: 'noNotificationsText'.tr,
                     ),
                     noMoreItemsIndicatorBuilder: (_) => const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 32, horizontal: 16),
+                      padding:
+                          EdgeInsets.symmetric(vertical: 32, horizontal: 16),
                       child: Opacity(
                         opacity: 0.75,
                         child: Center(

--- a/lib/pages/search_by_genre/views/search_by_genre_view.dart
+++ b/lib/pages/search_by_genre/views/search_by_genre_view.dart
@@ -81,9 +81,18 @@ class SearchByGenreView extends GetView<SearchByGenreController> {
                         },
                         avatarUrl: feed.bigAvatar ?? feed.smallAvatar ?? '',
                         avatarHash: feed.bigAvatarHash ?? feed.smallAvatarHash,
-                        title: feed.title,
-                        titleStyle: Theme.of(context).textTheme.titleLarge,
-                        subtitle: content,
+                        title: Text(
+                          feed.title,
+                          style: Theme.of(context).textTheme.titleLarge,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        subtitle: Text(
+                          content,
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
                       ),
                     );
                   },

--- a/lib/pages/subscribers/views/subscribers_view.dart
+++ b/lib/pages/subscribers/views/subscribers_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/pages/subscribers/controllers/subscribers_controller.dart';
-import 'package:hoot/components/avatar_component.dart';
+import 'package:hoot/components/notification_item.dart';
 import 'package:hoot/components/name_component.dart';
 import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/util/routes/app_routes.dart';
@@ -34,16 +34,13 @@ class SubscribersView extends GetView<SubscribersController> {
           itemCount: controller.subscribers.length,
           itemBuilder: (context, index) {
             final user = controller.subscribers[index];
-            return ListTile(
+            return ListItem(
               onTap: () => Get.toNamed(
                 AppRoutes.profile,
                 arguments: ProfileArgs(uid: user.uid),
               ),
-              leading: ProfileAvatarComponent(
-                image: user.smallProfilePictureUrl ?? '',
-                hash: user.smallAvatarHash ?? user.bigAvatarHash,
-                size: 40,
-              ),
+              avatarUrl: user.smallProfilePictureUrl ?? '',
+              avatarHash: user.smallAvatarHash ?? user.bigAvatarHash,
               title: NameComponent(user: user, size: 16),
               trailing: PopupMenuButton<String>(
                 onSelected: (value) async {


### PR DESCRIPTION
## Summary
- allow custom widget titles and optional subtitles in ListItem
- show subscribers with ListItem including avatar and actions
- update other ListItem usages to use widgets for titles/subtitles

## Testing
- `flutter analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_688e3e7330048328a6a707012e5254a4