### PR TITLE
refactor: use list item for feed requests

### DIFF
--- a/lib/components/notification_item.dart
+++ b/lib/components/notification_item.dart
@@ -1,4 +1,3 @@
-
 import 'package:flutter/material.dart';
 
 import 'package:hoot/components/scale_on_press.dart';
@@ -7,9 +6,9 @@ import 'package:hoot/components/avatar_component.dart';
 class ListItem extends StatelessWidget {
   final String avatarUrl;
   final String? avatarHash;
-  final String title;
+  final Widget title;
   final TextStyle? titleStyle;
-  final String subtitle;
+  final Widget subtitle;
   final TextStyle? subtitleStyle;
   final VoidCallback? onTap;
   final VoidCallback? onAvatarTap;
@@ -55,9 +54,9 @@ class ListItem extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             ProfileAvatarComponent(
-                image: avatarUrl,
-                hash: avatarHash,
-                size: 50,
+              image: avatarUrl,
+              hash: avatarHash,
+              size: 50,
             ),
             const SizedBox(width: 16),
             Expanded(
@@ -65,20 +64,20 @@ class ListItem extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.center,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    title,
+                  DefaultTextStyle(
+                    style:
+                        titleStyle ?? Theme.of(context).textTheme.titleMedium!,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
-                    style: titleStyle ?? Theme.of(context).textTheme.titleMedium,
+                    child: title,
                   ),
                   const SizedBox(height: 4),
-                  Text(
-                    subtitle,
+                  DefaultTextStyle(
+                    style:
+                        subtitleStyle ?? Theme.of(context).textTheme.bodySmall!,
                     maxLines: 3,
                     overflow: TextOverflow.ellipsis,
-                    style: subtitleStyle ?? Theme.of(context)
-                        .textTheme
-                        .bodySmall,
+                    child: subtitle,
                   ),
                 ],
               ),

--- a/lib/pages/feed_requests/views/feed_requests_view.dart
+++ b/lib/pages/feed_requests/views/feed_requests_view.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/pages/feed_requests/controllers/feed_requests_controller.dart';
-import 'package:hoot/components/avatar_component.dart';
-import 'package:hoot/components/name_component.dart';
 import 'package:hoot/components/empty_message.dart';
+import 'package:hoot/components/name_component.dart';
+import 'package:hoot/components/notification_item.dart';
 
 class FeedRequestsView extends GetView<FeedRequestsController> {
   const FeedRequestsView({super.key});
@@ -34,13 +34,10 @@ class FeedRequestsView extends GetView<FeedRequestsController> {
             final user = request.user;
             final title =
                 controller.feedTitles[request.feedId] ?? request.feedId;
-            return ListTile(
+            return ListItem(
               onTap: () => controller.openProfile(user.uid),
-              leading: ProfileAvatarComponent(
-                image: user.smallProfilePictureUrl ?? '',
-                hash: user.smallAvatarHash ?? user.bigAvatarHash,
-                size: 40,
-              ),
+              avatarUrl: user.smallProfilePictureUrl ?? '',
+              avatarHash: user.smallAvatarHash ?? user.bigAvatarHash,
               title: NameComponent(user: user, size: 16),
               subtitle: Text(title),
               trailing: Row(

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -77,8 +77,8 @@ class NotificationsView extends GetView<NotificationsController> {
                       return ListItem(
                         avatarUrl: user.largeProfilePictureUrl ?? '',
                         avatarHash: user.bigAvatarHash ?? user.smallAvatarHash,
-                        title: text,
-                        subtitle: n.createdAt.timeAgo(),
+                        title: Text(text),
+                        subtitle: Text(n.createdAt.timeAgo()),
                         onTap: () {
                           HapticService.lightImpact();
                           switch (n.type) {
@@ -130,7 +130,8 @@ class NotificationsView extends GetView<NotificationsController> {
                       text: 'noNotificationsText'.tr,
                     ),
                     noMoreItemsIndicatorBuilder: (_) => const Padding(
-                      padding: EdgeInsets.symmetric(vertical: 32, horizontal: 16),
+                      padding:
+                          EdgeInsets.symmetric(vertical: 32, horizontal: 16),
                       child: Opacity(
                         opacity: 0.75,
                         child: Center(

--- a/lib/pages/search_by_genre/views/search_by_genre_view.dart
+++ b/lib/pages/search_by_genre/views/search_by_genre_view.dart
@@ -81,9 +81,11 @@ class SearchByGenreView extends GetView<SearchByGenreController> {
                         },
                         avatarUrl: feed.bigAvatar ?? feed.smallAvatar ?? '',
                         avatarHash: feed.bigAvatarHash ?? feed.smallAvatarHash,
-                        title: feed.title,
-                        titleStyle: Theme.of(context).textTheme.titleLarge,
-                        subtitle: content,
+                        title: Text(
+                          feed.title,
+                          style: Theme.of(context).textTheme.titleLarge,
+                        ),
+                        subtitle: Text(content),
                       ),
                     );
                   },


### PR DESCRIPTION
## Summary
- render feed request rows with ListItem and action buttons
- allow ListItem widget to accept widget-based title and subtitle
- adjust search and notifications views to use widget titles

## Testing
- `flutter analyze`
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_688e3e75f41c8328a85181dc79ebe8c3