### PR TITLE
feat: add pull to refresh on post page

### DIFF
--- a/lib/pages/post/controllers/post_controller.dart
+++ b/lib/pages/post/controllers/post_controller.dart
@@ -100,6 +100,23 @@ class PostController extends GetxController {
     }
   }
 
+  @override
+  void refresh() {
+    _postService.fetchPost(post.value.id).then((fetched) {
+      if (fetched != null) {
+        post.value = fetched;
+      }
+    }).catchError((e) {
+      FirebaseCrashlytics.instance.recordError(
+        e,
+        null,
+        reason: 'Failed to refresh post',
+      );
+    });
+    commentsState.value = commentsState.value.reset();
+    fetchNextComments();
+  }
+
   /// Searches users for mentions in comments.
   Future<void> searchUsers(String query) async {
     _userService ??= UserService();

--- a/lib/pages/post/views/post_view.dart
+++ b/lib/pages/post/views/post_view.dart
@@ -23,47 +23,50 @@ class PostView extends GetView<PostController> {
       body: Stack(
         children: [
           Positioned.fill(
-            child: CustomScrollView(
-              slivers: [
-                Obx(() {
-                  final post = controller.post.value;
-                  return SliverToBoxAdapter(
-                    child: PostComponent(
-                      post: post,
-                      margin: const EdgeInsets.all(16),
-                    ),
-                  );
-                }),
-                Obx(() {
-                  final state = controller.commentsState.value;
-                  return PagedSliverList<DocumentSnapshot?, Comment>(
-                    state: state,
-                    fetchNextPage: controller.fetchNextComments,
-                    builderDelegate: PagedChildBuilderDelegate<Comment>(
-                      itemBuilder: (context, item, index) =>
-                          CommentComponent(comment: item),
-                      firstPageProgressIndicatorBuilder: (_) => const Padding(
-                        padding: EdgeInsets.all(16),
-                        child: Center(child: CircularProgressIndicator()),
+            child: RefreshIndicator(
+              onRefresh: () => Future.sync(() => controller.refresh()),
+              child: CustomScrollView(
+                slivers: [
+                  Obx(() {
+                    final post = controller.post.value;
+                    return SliverToBoxAdapter(
+                      child: PostComponent(
+                        post: post,
+                        margin: const EdgeInsets.all(16),
                       ),
-                      newPageProgressIndicatorBuilder: (_) => const Padding(
-                        padding: EdgeInsets.all(16),
-                        child: Center(child: CircularProgressIndicator()),
+                    );
+                  }),
+                  Obx(() {
+                    final state = controller.commentsState.value;
+                    return PagedSliverList<DocumentSnapshot?, Comment>(
+                      state: state,
+                      fetchNextPage: controller.fetchNextComments,
+                      builderDelegate: PagedChildBuilderDelegate<Comment>(
+                        itemBuilder: (context, item, index) =>
+                            CommentComponent(comment: item),
+                        firstPageProgressIndicatorBuilder: (_) => const Padding(
+                          padding: EdgeInsets.all(16),
+                          child: Center(child: CircularProgressIndicator()),
+                        ),
+                        newPageProgressIndicatorBuilder: (_) => const Padding(
+                          padding: EdgeInsets.all(16),
+                          child: Center(child: CircularProgressIndicator()),
+                        ),
+                        firstPageErrorIndicatorBuilder: (_) =>
+                            NothingToShowComponent(
+                          icon: const Icon(Icons.error_outline),
+                          text: 'somethingWentWrong'.tr,
+                        ),
+                        noItemsFoundIndicatorBuilder: (_) =>
+                            const SizedBox.shrink(),
                       ),
-                      firstPageErrorIndicatorBuilder: (_) =>
-                          NothingToShowComponent(
-                        icon: const Icon(Icons.error_outline),
-                        text: 'somethingWentWrong'.tr,
-                      ),
-                      noItemsFoundIndicatorBuilder: (_) =>
-                          const SizedBox.shrink(),
-                    ),
-                  );
-                }),
-                SliverToBoxAdapter(
-                  child: SafeArea(child: const SizedBox(height: 32)),
-                ),
-              ],
+                    );
+                  }),
+                  SliverToBoxAdapter(
+                    child: SafeArea(child: const SizedBox(height: 32)),
+                  ),
+                ],
+              ),
             ),
           ),
           Positioned(


### PR DESCRIPTION
## Summary
- allow users to pull to refresh the post page
- implement controller logic to reload the post and reset comments

## Testing
- `flutter analyze`
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_688e4bf383588328acbdab80fdbfbc72