### PR TITLE
refactor: extract feed order constants

### DIFF
--- a/lib/util/enums/feed_types.dart
+++ b/lib/util/enums/feed_types.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:solar_icons/solar_icons.dart';
 
+// Feed order constants to control the relative position of special feeds.
+const kGeneralFeedOrder = 0; // Ensures the general feed appears first.
+const kOtherFeedOrder = 1000; // Places the miscellaneous feed at the end.
+
 enum FeedType {
   general,
   activism,
@@ -68,8 +72,10 @@ enum FeedType {
 
 extension FeedTypeExtension on FeedType {
   int get order {
-    if (this == FeedType.general) return 0;
-    if (this == FeedType.other) return 1000;
+    if (this == FeedType.general)
+      return kGeneralFeedOrder; // General feed comes first.
+    if (this == FeedType.other)
+      return kOtherFeedOrder; // Other feed is sorted last.
 
     final firstLetter = toString().substring(0, 1).toLowerCase();
     return firstLetter.codeUnitAt(0);


### PR DESCRIPTION
## Summary
- define constants to name feed ordering of general and other categories
- use constants in feed type order getter with clarifying comments

## Testing
- `flutter test` *(fails: unhandled error; process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_688e80cdde4883288d8a3b32aaf3bc66