### PR TITLE
refactor: centralize fetch limits

### DIFF
--- a/lib/services/comment_service.dart
+++ b/lib/services/comment_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hoot/models/comment.dart';
+import 'package:hoot/util/constants.dart';
 
 class CommentPage {
   CommentPage({required this.comments, this.lastDoc, this.hasMore = false});
@@ -13,7 +14,7 @@ abstract class BaseCommentService {
   Future<CommentPage> fetchComments(
     String postId, {
     DocumentSnapshot? startAfter,
-    int limit = 10,
+    int limit = kDefaultFetchLimit,
   });
 
   String newCommentId(String postId);
@@ -32,7 +33,7 @@ class CommentService implements BaseCommentService {
   Future<CommentPage> fetchComments(
     String postId, {
     DocumentSnapshot? startAfter,
-    int limit = 10,
+    int limit = kDefaultFetchLimit,
   }) async {
     var query = _firestore
         .collection('posts')

--- a/lib/services/feed_request_service.dart
+++ b/lib/services/feed_request_service.dart
@@ -6,6 +6,7 @@ import 'package:hoot/models/user.dart';
 import 'package:hoot/models/feed_join_request.dart';
 import 'dart:math' as math;
 import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/util/constants.dart';
 
 class FeedRequestService {
   final FirebaseFirestore _firestore;
@@ -91,7 +92,7 @@ class FeedRequestService {
     final ids = snapshot.docs.map((d) => d.id).toList();
     if (ids.isEmpty) return [];
 
-    const chunkSize = 10;
+    const chunkSize = kUserChunkSize;
     final Map<String, U> users = {};
     for (var i = 0; i < ids.length; i += chunkSize) {
       final chunk = ids.sublist(i, math.min(i + chunkSize, ids.length));

--- a/lib/services/feed_service.dart
+++ b/lib/services/feed_service.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 
 import 'package:hoot/models/post.dart';
 import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/util/constants.dart';
 
 /// Page of posts along with pagination data.
 class PostPage {
@@ -17,13 +18,13 @@ class PostPage {
 abstract class BaseFeedService {
   Future<PostPage> fetchSubscribedPosts({
     DocumentSnapshot? startAfter,
-    int limit = 10,
+    int limit = kDefaultFetchLimit,
   });
 
   Future<PostPage> fetchFeedPosts(
     String feedId, {
     DocumentSnapshot? startAfter,
-    int limit = 10,
+    int limit = kDefaultFetchLimit,
   });
 }
 
@@ -40,7 +41,7 @@ class FeedService implements BaseFeedService {
   @override
   Future<PostPage> fetchSubscribedPosts({
     DocumentSnapshot? startAfter,
-    int limit = 10,
+    int limit = kDefaultFetchLimit,
   }) async {
     final user = _authService.currentUser;
     if (user == null) return PostPage(posts: [], hasMore: false);
@@ -97,7 +98,7 @@ class FeedService implements BaseFeedService {
   Future<PostPage> fetchFeedPosts(
     String feedId, {
     DocumentSnapshot? startAfter,
-    int limit = 10,
+    int limit = kDefaultFetchLimit,
   }) async {
     final user = _authService.currentUser;
     if (user == null) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'package:hoot/models/hoot_notification.dart';
+import 'package:hoot/util/constants.dart';
 
 class NotificationPage {
   NotificationPage({
@@ -18,7 +19,7 @@ abstract class BaseNotificationService {
   Future<NotificationPage> fetchNotifications(
     String userId, {
     DocumentSnapshot? startAfter,
-    int limit = 10,
+    int limit = kDefaultFetchLimit,
   });
   Future<void> createNotification(String userId, Map<String, dynamic> data);
   Future<void> markAsRead(String userId, String notificationId);
@@ -36,7 +37,7 @@ class NotificationService implements BaseNotificationService {
   Future<NotificationPage> fetchNotifications(
     String userId, {
     DocumentSnapshot? startAfter,
-    int limit = 10,
+    int limit = kDefaultFetchLimit,
   }) async {
     var query = _firestore
         .collection('users')

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/models/user.dart';
+import 'package:hoot/util/constants.dart';
 
 class SubscriptionService {
   final FirebaseFirestore _firestore;
@@ -87,7 +88,7 @@ class SubscriptionService {
     final ids = snapshot.docs.map((d) => d.id).toList();
     if (ids.isEmpty) return [];
 
-    const chunkSize = 10;
+    const chunkSize = kUserChunkSize;
     final List<U> users = [];
     for (var i = 0; i < ids.length; i += chunkSize) {
       final chunk = ids.sublist(

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -1,3 +1,6 @@
+const kDefaultFetchLimit = 10;
+const kUserChunkSize = 10;
+
 const kInvitationFadeDuration = Duration(milliseconds: 500);
 const kInvitationExtendedFadeDuration = Duration(milliseconds: 1000);
 const kInvitationCrossFadeDuration = Duration(milliseconds: 300);


### PR DESCRIPTION
## Summary
- add shared constants for default fetch limit and user chunk size
- use shared constants across services

## Testing
- `flutter test` *(fails: No Firebase App '[DEFAULT]' has been created)*

------
https://chatgpt.com/codex/tasks/task_e_688e80cbb0c88328af102556c29f85d3