### PR TITLE
refactor: centralize image compression sizes

### DIFF
--- a/lib/pages/avatar/controllers/avatar_controller.dart
+++ b/lib/pages/avatar/controllers/avatar_controller.dart
@@ -13,6 +13,7 @@ import 'package:image/image.dart' as img;
 import 'package:hoot/services/error_service.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/util/constants.dart';
 
 class AvatarController extends GetxController {
   final _auth = Get.find<AuthService>();
@@ -57,17 +58,21 @@ class AvatarController extends GetxController {
         final bytes = await file.readAsBytes();
         final decoded = img.decodeImage(bytes);
         if (decoded != null) {
-          final small = img.copyResizeCropSquare(decoded, size: 48);
-          final big = img.copyResizeCropSquare(decoded, size: 512);
-          final banner = img.copyResize(decoded, height: 1024);
+          final small =
+              img.copyResizeCropSquare(decoded, size: kSmallAvatarSize);
+          final big = img.copyResizeCropSquare(decoded, size: kBigAvatarSize);
+          final banner = img.copyResize(decoded, height: kBannerHeight);
 
           final smallData = Uint8List.fromList(img.encodeJpg(small));
           final bigData = Uint8List.fromList(img.encodeJpg(big));
           final bannerData = Uint8List.fromList(img.encodeJpg(banner));
 
-          final smallHash = await BlurHash.encode(smallData, 4, 3);
-          final bigHash = await BlurHash.encode(bigData, 4, 3);
-          final bannerHash = await BlurHash.encode(bannerData, 4, 3);
+          final smallHash =
+              await BlurHash.encode(smallData, kBlurHashX, kBlurHashY);
+          final bigHash =
+              await BlurHash.encode(bigData, kBlurHashX, kBlurHashY);
+          final bannerHash =
+              await BlurHash.encode(bannerData, kBlurHashX, kBlurHashY);
 
           final avatarRef =
               FirebaseStorage.instance.ref().child('avatars').child(uid);

--- a/lib/pages/edit_profile/controllers/edit_profile_controller.dart
+++ b/lib/pages/edit_profile/controllers/edit_profile_controller.dart
@@ -14,6 +14,7 @@ import 'package:hoot/services/error_service.dart';
 import 'package:hoot/services/toast_service.dart';
 import 'package:hoot/services/user_service.dart';
 import 'package:hoot/models/user.dart';
+import 'package:hoot/util/constants.dart';
 
 class EditProfileController extends GetxController {
   final AuthService _authService;
@@ -89,15 +90,19 @@ class EditProfileController extends GetxController {
         final bytes = await file.readAsBytes();
         final decoded = img.decodeImage(bytes);
         if (decoded != null) {
-          final small = img.copyResizeCropSquare(decoded, size: 48);
-          final big = img.copyResizeCropSquare(decoded, size: 512);
-          final banner = img.copyResize(decoded, height: 1024);
+          final small =
+              img.copyResizeCropSquare(decoded, size: kSmallAvatarSize);
+          final big = img.copyResizeCropSquare(decoded, size: kBigAvatarSize);
+          final banner = img.copyResize(decoded, height: kBannerHeight);
           final smallData = Uint8List.fromList(img.encodeJpg(small));
           final bigData = Uint8List.fromList(img.encodeJpg(big));
           final bannerData = Uint8List.fromList(img.encodeJpg(banner));
-          bannerHash = await BlurHash.encode(bannerData, 4, 3);
-          smallAvatarHash = await BlurHash.encode(smallData, 4, 3);
-          bigAvatarHash = await BlurHash.encode(bigData, 4, 3);
+          bannerHash =
+              await BlurHash.encode(bannerData, kBlurHashX, kBlurHashY);
+          smallAvatarHash =
+              await BlurHash.encode(smallData, kBlurHashX, kBlurHashY);
+          bigAvatarHash =
+              await BlurHash.encode(bigData, kBlurHashX, kBlurHashY);
           final storageRef =
               FirebaseStorage.instance.ref().child('avatars').child(uid);
           final smallRef = storageRef.child('small_avatar.jpg');

--- a/lib/pages/feed_editor/controllers/feed_editor_controller.dart
+++ b/lib/pages/feed_editor/controllers/feed_editor_controller.dart
@@ -17,6 +17,7 @@ import 'package:hoot/services/dialog_service.dart';
 import 'package:hoot/services/error_service.dart';
 import 'package:hoot/services/toast_service.dart';
 import 'package:hoot/util/enums/feed_types.dart';
+import 'package:hoot/util/constants.dart';
 
 /// Controller for creating and editing feeds.
 class FeedEditorController extends GetxController {
@@ -135,12 +136,14 @@ class FeedEditorController extends GetxController {
       final bytes = await file.readAsBytes();
       final decoded = img.decodeImage(bytes);
       if (decoded != null) {
-        final small = img.copyResizeCropSquare(decoded, size: 48);
-        final big = img.copyResizeCropSquare(decoded, size: 1024);
+        final small = img.copyResizeCropSquare(decoded, size: kSmallAvatarSize);
+        final big =
+            img.copyResizeCropSquare(decoded, size: kLargeImageDimension);
         final smallData = Uint8List.fromList(img.encodeJpg(small));
         final bigData = Uint8List.fromList(img.encodeJpg(big));
-        smallAvatarHash = await BlurHash.encode(smallData, 4, 3);
-        bigAvatarHash = await BlurHash.encode(bigData, 4, 3);
+        smallAvatarHash =
+            await BlurHash.encode(smallData, kBlurHashX, kBlurHashY);
+        bigAvatarHash = await BlurHash.encode(bigData, kBlurHashX, kBlurHashY);
         final storageRef = FirebaseStorage.instance
             .ref()
             .child('feed_avatars')
@@ -222,12 +225,14 @@ class FeedEditorController extends GetxController {
       final bytes = await file.readAsBytes();
       final decoded = img.decodeImage(bytes);
       if (decoded != null) {
-        final small = img.copyResizeCropSquare(decoded, size: 48);
-        final big = img.copyResizeCropSquare(decoded, size: 1024);
+        final small = img.copyResizeCropSquare(decoded, size: kSmallAvatarSize);
+        final big =
+            img.copyResizeCropSquare(decoded, size: kLargeImageDimension);
         final smallData = Uint8List.fromList(img.encodeJpg(small));
         final bigData = Uint8List.fromList(img.encodeJpg(big));
-        smallAvatarHash = await BlurHash.encode(smallData, 4, 3);
-        bigAvatarHash = await BlurHash.encode(bigData, 4, 3);
+        smallAvatarHash =
+            await BlurHash.encode(smallData, kBlurHashX, kBlurHashY);
+        bigAvatarHash = await BlurHash.encode(bigData, kBlurHashX, kBlurHashY);
         final storageRef = FirebaseStorage.instance
             .ref()
             .child('feed_avatars')

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -13,6 +13,10 @@ const kMaxImageDimension = 1080;
 const kJpegQuality = 85;
 const kBlurHashX = 4;
 const kBlurHashY = 3;
+const kSmallAvatarSize = 48;
+const kBigAvatarSize = 512;
+const kLargeImageDimension = 1024;
+const kBannerHeight = kLargeImageDimension;
 const kWelcomeUsernameStep = 1;
 const kWelcomeAvatarStep = 2;
 // Search by genre constants


### PR DESCRIPTION
## Summary
- centralize image compression sizes for avatars and banners via constants
- use new constants across avatar, profile, and feed editors

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*
- `flutter analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*


------
https://chatgpt.com/codex/tasks/task_e_688e87371a9c8328ba8759ae6bd817b6