### PR TITLE
feat: add mock mode for offline UI

### DIFF
--- a/mock/README.md
+++ b/mock/README.md
@@ -1,0 +1,14 @@
+# Mock mode
+
+This directory contains a lightweight mock setup for running the Hoot UI
+without Firebase or network dependencies. Services are backed by in-memory
+sample data.
+
+## Run
+
+```bash
+flutter run -t mock/main.dart
+```
+
+The app will use the production UI from `lib/` but with static data, making it
+useful for screenshots or UI experiments.

--- a/mock/data/mock_user.dart
+++ b/mock/data/mock_user.dart
@@ -1,0 +1,22 @@
+import 'dart:ui';
+
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/models/user.dart';
+
+/// Sample user used by mock services.
+final Feed mockFeed = Feed(
+  id: 'feed1',
+  userId: 'user1',
+  title: 'General',
+  description: 'Mock feed for testing',
+  color: const Color(0xFF2196F3),
+  subscriberCount: 1,
+);
+
+final U mockUser = U(
+  uid: 'user1',
+  name: 'Mock User',
+  username: 'mockuser',
+  feeds: [mockFeed],
+  subscriptionCount: 1,
+);

--- a/mock/data/sample_posts.json
+++ b/mock/data/sample_posts.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "1",
+    "text": "Hello from mock feed!",
+    "feedId": "feed1",
+    "feed": {
+      "id": "feed1",
+      "userId": "user1",
+      "title": "General",
+      "description": "Mock feed for testing",
+      "color": "4280391411"
+    },
+    "user": {
+      "uid": "user1",
+      "displayName": "Mock User",
+      "username": "mockuser"
+    },
+    "likes": 0
+  }
+]

--- a/mock/main.dart
+++ b/mock/main.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_mentions/flutter_mentions.dart';
+import 'package:flutter_native_splash/flutter_native_splash.dart';
+import 'package:get/get.dart';
+import 'package:hoot/mock/mock_dependency_injector.dart';
+import 'package:hoot/mock/mock_app_pages.dart';
+import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/theme/theme.dart';
+import 'package:hoot/services/theme_service.dart';
+import 'package:hoot/util/translations/app_translations.dart';
+import 'package:toastification/toastification.dart';
+import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
+import 'package:timeago/timeago.dart' as timeago;
+
+void main() {
+  runZonedGuarded(() async {
+    WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+    FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
+
+    await MockDependencyInjector.init();
+
+    TenorGifPicker.init(
+      apiKey: '',
+      locale: Get.locale?.toLanguageTag() ?? 'en',
+      country: Get.deviceLocale?.countryCode ?? 'US',
+    );
+
+    timeago.setLocaleMessages('es', timeago.EsMessages());
+    timeago.setLocaleMessages('pt', timeago.PtBrMessages());
+    timeago.setLocaleMessages('pt-BR', timeago.PtBrMessages());
+    timeago.setLocaleMessages('pt-PT', timeago.PtBrMessages());
+
+    final themeService = Get.find<ThemeService>();
+    runApp(
+      Portal(
+        child: ToastificationWrapper(
+          child: Obx(
+            () => GetMaterialApp(
+              title: 'Hoot',
+              debugShowCheckedModeBanner: false,
+              getPages: MockAppPages.pages,
+              initialRoute: AppRoutes.home,
+              theme: AppTheme.lightTheme(themeService.appColor.value.color),
+              darkTheme: AppTheme.darkTheme(themeService.appColor.value.color),
+              themeMode: themeService.themeMode.value,
+              translations: AppTranslations(),
+              locale: Get.deviceLocale,
+              fallbackLocale: const Locale('en', 'US'),
+              builder: (context, child) => GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    FlutterNativeSplash.remove();
+  }, (error, stack) {});
+}

--- a/mock/mock_app_pages.dart
+++ b/mock/mock_app_pages.dart
@@ -1,0 +1,161 @@
+import 'package:get/get.dart';
+import 'package:hoot/pages/login/bindings/login_binding.dart';
+import 'package:hoot/pages/login/views/login_view.dart';
+import 'package:hoot/pages/photo_view/bindings/photo_view_binding.dart';
+import 'package:hoot/pages/photo_view/views/photo_view.dart';
+import 'package:hoot/pages/welcome/bindings/welcome_binding.dart';
+import 'package:hoot/pages/welcome/views/welcome_view.dart';
+import 'package:hoot/pages/username/bindings/username_binding.dart';
+import 'package:hoot/pages/avatar/bindings/avatar_binding.dart';
+import 'package:hoot/pages/home/bindings/home_binding.dart';
+import 'package:hoot/pages/home/views/home_view.dart';
+import 'package:hoot/pages/invitation/bindings/invitation_binding.dart';
+import 'package:hoot/pages/invitation/views/invitation_view.dart';
+import 'package:hoot/pages/notifications_permission/bindings/notification_permission_binding.dart';
+import 'package:hoot/pages/notifications_permission/views/notification_permission_view.dart';
+import 'package:hoot/pages/create_post/bindings/create_post_binding.dart';
+import 'package:hoot/pages/create_post/views/create_post_view.dart';
+import 'package:hoot/pages/profile/bindings/profile_binding.dart';
+import 'package:hoot/pages/profile/views/profile_view.dart';
+import 'package:hoot/pages/settings/bindings/settings_binding.dart';
+import 'package:hoot/pages/settings/views/settings_view.dart';
+import 'package:hoot/pages/app_color/bindings/app_color_binding.dart';
+import 'package:hoot/pages/app_color/views/app_color_view.dart';
+import 'package:hoot/pages/edit_profile/bindings/edit_profile_binding.dart';
+import 'package:hoot/pages/edit_profile/views/edit_profile_view.dart';
+import 'package:hoot/pages/search/bindings/search_binding.dart';
+import 'package:hoot/pages/search/views/search_view.dart';
+import 'package:hoot/pages/search_by_genre/bindings/search_by_genre_binding.dart';
+import 'package:hoot/pages/search_by_genre/views/search_by_genre_view.dart';
+import 'package:hoot/pages/feed_editor/bindings/feed_editor_binding.dart';
+import 'package:hoot/pages/feed_editor/views/feed_editor_view.dart';
+import 'package:hoot/pages/feed_requests/bindings/feed_requests_binding.dart';
+import 'package:hoot/pages/feed_requests/views/feed_requests_view.dart';
+import 'package:hoot/pages/subscriptions/bindings/subscriptions_binding.dart';
+import 'package:hoot/pages/subscriptions/views/subscriptions_view.dart';
+import 'package:hoot/pages/subscribers/bindings/subscribers_binding.dart';
+import 'package:hoot/pages/subscribers/views/subscribers_view.dart';
+import 'package:hoot/pages/feed_page/bindings/feed_page_binding.dart';
+import 'package:hoot/pages/feed_page/views/feed_page_view.dart';
+import 'package:hoot/pages/post/bindings/post_binding.dart';
+import 'package:hoot/pages/post/views/post_view.dart';
+import 'package:hoot/pages/report/bindings/report_binding.dart';
+import 'package:hoot/pages/report/views/report_view.dart';
+import 'package:hoot/pages/contacts/bindings/contacts_binding.dart';
+import 'package:hoot/pages/contacts/views/contacts_view.dart';
+import 'package:hoot/pages/terms.dart';
+import 'package:hoot/pages/about_us.dart';
+import 'package:hoot/util/constants.dart';
+import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/util/routes/args/profile_args.dart';
+import 'package:hoot/util/routes/args/feed_page_args.dart';
+
+class AppPages {
+  static final List<GetPage> pages = [
+    GetPage(
+      name: AppRoutes.login,
+      page: () => LoginView(),
+      binding: LoginBinding(),
+    ),
+    GetPage(
+        name: AppRoutes.welcome,
+        page: () => const WelcomeView(),
+        binding: WelcomeBinding()),
+    GetPage(
+        name: AppRoutes.username,
+        page: () => const WelcomeView(initialIndex: kWelcomeUsernameStep),
+        binding: UsernameBinding()),
+    GetPage(
+        name: AppRoutes.avatar,
+        page: () => const WelcomeView(initialIndex: kWelcomeAvatarStep),
+        binding: AvatarBinding()),
+    GetPage(
+        name: AppRoutes.invitation,
+        page: () => const InvitationView(),
+        binding: InvitationBinding()),
+    GetPage(
+        name: AppRoutes.notificationsPermission,
+        page: () => const NotificationPermissionView(),
+        binding: NotificationPermissionBinding()),
+    GetPage(
+        name: AppRoutes.home,
+        page: () => const HomeView(),
+        binding: HomeBinding()),
+    GetPage(
+        name: AppRoutes.createPost,
+        page: () => const CreatePostView(),
+        binding: CreatePostBinding()),
+    GetPage(
+        name: AppRoutes.settings,
+        page: () => const SettingsView(),
+        binding: SettingsBinding()),
+    GetPage(
+        name: AppRoutes.appColor,
+        page: () => const AppColorView(),
+        binding: AppColorBinding()),
+    GetPage<ProfileArgs>(
+        name: AppRoutes.profile,
+        page: () => const ProfileView(),
+        binding: ProfileBinding()),
+    GetPage(
+        name: AppRoutes.editProfile,
+        page: () => const EditProfileView(),
+        binding: EditProfileBinding()),
+    GetPage(
+        name: AppRoutes.search,
+        page: () => const SearchView(),
+        binding: SearchBinding()),
+    GetPage(
+        name: AppRoutes.searchByGenre,
+        page: () => const SearchByGenreView(),
+        binding: SearchByGenreBinding()),
+    GetPage(
+        name: AppRoutes.createFeed,
+        page: () => const FeedEditorView(),
+        binding: FeedEditorBinding()),
+    GetPage(
+        name: AppRoutes.editFeed,
+        page: () => const FeedEditorView(),
+        binding: FeedEditorBinding()),
+    GetPage(
+        name: AppRoutes.feedRequests,
+        page: () => const FeedRequestsView(),
+        binding: FeedRequestsBinding()),
+    GetPage(
+        name: AppRoutes.subscriptions,
+        page: () => const SubscriptionsView(),
+        binding: SubscriptionsBinding()),
+    GetPage(
+        name: AppRoutes.subscribers,
+        page: () => const SubscribersView(),
+        binding: SubscribersBinding()),
+    GetPage<FeedPageArgs>(
+        name: AppRoutes.feed,
+        page: () => const FeedPageView(),
+        binding: FeedPageBinding()),
+    GetPage(
+        name: AppRoutes.post,
+        page: () => const PostView(),
+        binding: PostBinding()),
+    GetPage(
+        name: AppRoutes.report,
+        page: () => const ReportView(),
+        binding: ReportBinding()),
+    GetPage(
+      name: AppRoutes.terms,
+      page: () => const TermsOfService(),
+    ),
+    GetPage(
+      name: AppRoutes.aboutUs,
+      page: () => const AboutUsPage(),
+    ),
+    GetPage(
+        name: AppRoutes.contacts,
+        page: () => const ContactsView(),
+        binding: ContactsBinding()),
+    GetPage(
+        name: AppRoutes.photoViewer,
+        page: () => const PhotoZoomView(),
+        binding: PhotoViewBinding()),
+  ];
+}

--- a/mock/mock_dependency_injector.dart
+++ b/mock/mock_dependency_injector.dart
@@ -1,0 +1,25 @@
+import 'package:get/get.dart';
+import 'package:hoot/services/theme_service.dart';
+import 'package:hoot/services/feed_service.dart';
+import 'package:hoot/services/post_service.dart';
+import 'services/mock_auth_service.dart';
+import 'services/mock_feed_service.dart';
+import 'services/mock_post_service.dart';
+import 'package:hoot/services/auth_service.dart';
+
+/// Registers mock dependencies for running the app without backend services.
+class MockDependencyInjector {
+  MockDependencyInjector._();
+
+  /// Initializes mock services and theme settings.
+  static Future<void> init() async {
+    final auth = Get.put<AuthService>(MockAuthService(), permanent: true);
+    final postService = MockPostService();
+    await postService.load();
+    Get.put<BasePostService>(postService, permanent: true);
+    Get.put<BaseFeedService>(MockFeedService(postService: postService),
+        permanent: true);
+    final theme = Get.put(ThemeService(), permanent: true);
+    await theme.loadThemeSettings();
+  }
+}

--- a/mock/services/mock_auth_service.dart
+++ b/mock/services/mock_auth_service.dart
@@ -1,0 +1,40 @@
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/services/auth_service.dart' as real;
+import 'package:hoot/mock/data/mock_user.dart';
+
+/// Mock implementation of [AuthService] providing in-memory user data.
+class MockAuthService extends real.AuthService {
+  MockAuthService()
+      : super(auth: MockFirebaseAuth(), firestore: FakeFirebaseFirestore());
+
+  @override
+  Future<U?> fetchUser() async {
+    currentUserRx.value = mockUser;
+    return currentUserRx.value;
+  }
+
+  @override
+  Future<U?> fetchUserById(String uid) async {
+    return uid == mockUser.uid ? mockUser : null;
+  }
+
+  @override
+  Future<U?> fetchUserByUsername(String username) async {
+    return username == mockUser.username ? mockUser : null;
+  }
+
+  @override
+  Future<List<U>> searchUsers(String query, {int limit = 5}) async {
+    if (mockUser.username != null && mockUser.username!.startsWith(query)) {
+      return [mockUser];
+    }
+    return [];
+  }
+
+  @override
+  Future<void> signOut() async {
+    currentUserRx.value = null;
+  }
+}

--- a/mock/services/mock_feed_service.dart
+++ b/mock/services/mock_feed_service.dart
@@ -1,0 +1,26 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/services/feed_service.dart';
+import 'mock_post_service.dart';
+
+/// Mock implementation of [BaseFeedService] returning posts from memory.
+class MockFeedService implements BaseFeedService {
+  MockFeedService({required this.postService});
+
+  final MockPostService postService;
+
+  @override
+  Future<PostPage> fetchSubscribedPosts(
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
+    final posts = postService.posts.take(limit).toList();
+    return PostPage(posts: posts, hasMore: postService.posts.length > limit);
+  }
+
+  @override
+  Future<PostPage> fetchFeedPosts(String feedId,
+      {DocumentSnapshot? startAfter, int limit = 10}) async {
+    final posts =
+        postService.posts.where((p) => p.feedId == feedId).take(limit).toList();
+    return PostPage(posts: posts, hasMore: false);
+  }
+}

--- a/mock/services/mock_post_service.dart
+++ b/mock/services/mock_post_service.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/services/post_service.dart';
+import 'package:hoot/mock/data/mock_user.dart';
+
+/// Mock implementation of [BasePostService] storing posts in memory.
+class MockPostService implements BasePostService {
+  final List<Post> _posts = [];
+
+  /// Loads posts from bundled JSON sample data.
+  Future<void> load() async {
+    final raw = await rootBundle.loadString('mock/data/sample_posts.json');
+    final data = jsonDecode(raw) as List<dynamic>;
+    _posts.addAll(data.map((e) => Post.fromJson(e as Map<String, dynamic>)));
+  }
+
+  List<Post> get posts => _posts;
+
+  @override
+  String newPostId() => (_posts.length + 1).toString();
+
+  @override
+  Future<void> createPost(Map<String, dynamic> data, {String? id}) async {
+    final post = Post.fromJson({
+      'id': id ?? newPostId(),
+      ...data,
+      'user': mockUser.toJson(),
+    });
+    _posts.insert(0, post);
+  }
+
+  @override
+  Future<void> toggleLike(String postId, String userId, bool like) async {
+    final post =
+        _posts.firstWhere((p) => p.id == postId, orElse: () => Post.empty());
+    if (post.id == '0') return;
+    post.liked = like;
+    post.likes = (post.likes ?? 0) + (like ? 1 : -1);
+  }
+
+  @override
+  Future<Post?> fetchPost(String id) async {
+    try {
+      return _posts.firstWhere((p) => p.id == id);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  @override
+  Future<String> reFeed(
+      {required Post original,
+      required Feed targetFeed,
+      required U user}) async {
+    final newId = newPostId();
+    final clone = Post(
+      id: newId,
+      text: original.text,
+      feedId: targetFeed.id,
+      feed: targetFeed,
+      user: user,
+      reFeeded: true,
+      reFeededFrom: original,
+      createdAt: DateTime.now(),
+    );
+    _posts.insert(0, clone);
+    return newId;
+  }
+
+  @override
+  Future<void> deletePost(String id) async {
+    _posts.removeWhere((p) => p.id == id);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -120,6 +120,7 @@ flutter:
   assets:
     - assets/
     - assets/videos/
+    - mock/data/
     - assets/images/
     - assets/terms/
     - assets/fonts/


### PR DESCRIPTION
## Summary
- add mock dependency injector and services backed by in-memory data
- create mock routing and entry point for running UI without Firebase
- include sample data and docs for launching mock mode

## Testing
- `flutter test` *(fails: unhandled error during finalization of test)*

------
https://chatgpt.com/codex/tasks/task_e_688e87ea061483289321b3729f7d17a5