### PR TITLE
Handle account deletion requiring recent login

### DIFF
--- a/lib/pages/settings/controllers/settings_controller.dart
+++ b/lib/pages/settings/controllers/settings_controller.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
@@ -90,8 +91,14 @@ class SettingsController extends GetxController {
       ToastService.showSuccess('deleteAccountSuccess'.tr);
       Get.offAllNamed(AppRoutes.login);
     } catch (e, s) {
-      await ErrorService.reportError(e,
-          message: 'deleteAccountFailed'.tr, stack: s);
+      if (e is FirebaseAuthException && e.code == 'requires-recent-login') {
+        await _auth.signOut();
+        ToastService.showError('deleteAccountRequiresRecentLogin'.tr);
+        Get.offAllNamed(AppRoutes.login);
+      } else {
+        await ErrorService.reportError(e,
+            message: 'deleteAccountFailed'.tr, stack: s);
+      }
     }
   }
 }

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -315,6 +315,8 @@ class AppTranslations extends Translations {
           'deleteAccountVerify': "Type 'delete' to confirm.",
           'deleteAccountFailed': 'Failed to delete account',
           'deleteAccountSuccess': 'Account deleted successfully',
+          'deleteAccountRequiresRecentLogin':
+              'Please log in again before deleting your account',
           'blockUser': 'Block @username',
           'unblockUser': 'Unblock @username',
           'blockUserDescription':
@@ -679,6 +681,8 @@ class AppTranslations extends Translations {
           'deleteAccountVerify': "Escribe 'delete' para confirmar.",
           'deleteAccountFailed': 'No se pudo eliminar la cuenta',
           'deleteAccountSuccess': 'Cuenta eliminada exitosamente',
+          'deleteAccountRequiresRecentLogin':
+              'Inicia sesión de nuevo antes de eliminar tu cuenta',
           'blockUser': 'Bloquear a @username',
           'unblockUser': 'Desbloquear a @username',
           'blockUserDescription':
@@ -1044,6 +1048,8 @@ class AppTranslations extends Translations {
           'deleteAccountVerify': "Escreve 'delete' para confirmar.",
           'deleteAccountFailed': 'Não foi possível eliminar a conta',
           'deleteAccountSuccess': 'Conta eliminada com sucesso',
+          'deleteAccountRequiresRecentLogin':
+              'Inicia sessão novamente antes de eliminares a tua conta',
           'blockUser': 'Bloquear @username',
           'unblockUser': 'Desbloquear @username',
           'blockUserDescription':
@@ -1406,6 +1412,8 @@ class AppTranslations extends Translations {
           'deleteAccountVerify': "Digite 'delete' para confirmar.",
           'deleteAccountFailed': 'Não foi possível excluir a conta',
           'deleteAccountSuccess': 'Conta excluída com sucesso',
+          'deleteAccountRequiresRecentLogin':
+              'Faça login novamente antes de excluir sua conta',
           'blockUser': 'Bloquear @username',
           'unblockUser': 'Desbloquear @username',
           'blockUserDescription':


### PR DESCRIPTION
## Summary
- sign user out and show toast if account deletion fails due to `firebase_auth/requires-recent-login`
- add translations for the new error message in all supported languages

## Testing
- `flutter test` *(fails: PathNotFoundException, did not complete)*
- `flutter analyze` *(fails: 21 issues including missing firebase_options.dart)*

------
https://chatgpt.com/codex/tasks/task_e_688e8a0aa1b883288ad6c2c9c4f4368d