### PR TITLE
feat: add login background video

### DIFF
--- a/lib/pages/login/views/login_view.dart
+++ b/lib/pages/login/views/login_view.dart
@@ -1,11 +1,42 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_signin_button/flutter_signin_button.dart' as buttons;
 import 'package:get/get.dart';
+import 'package:video_player/video_player.dart';
 
 import 'package:hoot/pages/login/controllers/login_controller.dart';
 
-class LoginView extends GetView<LoginController> {
-  const LoginView({super.key});
+class LoginView extends StatefulWidget {
+  const LoginView({super.key, this.playBackgroundVideo = true});
+
+  final bool playBackgroundVideo;
+
+  @override
+  State<LoginView> createState() => _LoginViewState();
+}
+
+class _LoginViewState extends State<LoginView> {
+  final LoginController controller = Get.find();
+  VideoPlayerController? _videoController;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.playBackgroundVideo) {
+      _videoController =
+          VideoPlayerController.asset('assets/videos/login_video.mp4')
+            ..setLooping(false)
+            ..initialize().then((_) {
+              setState(() {});
+              _videoController?.play();
+            });
+    }
+  }
+
+  @override
+  void dispose() {
+    _videoController?.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -13,12 +44,15 @@ class LoginView extends GetView<LoginController> {
       body: Stack(
         fit: StackFit.expand,
         children: [
-          Positioned.fill(
-            child: Image.asset(
-              'assets/images/bg.jpg',
+          if (_videoController != null && _videoController!.value.isInitialized)
+            FittedBox(
               fit: BoxFit.cover,
+              child: SizedBox(
+                width: _videoController!.value.size.width,
+                height: _videoController!.value.size.height,
+                child: VideoPlayer(_videoController!),
+              ),
             ),
-          ),
           Positioned(
             bottom: 16,
             left: 16,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1773,6 +1773,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  video_player:
+    dependency: "direct main"
+    description:
+      name: video_player
+      sha256: "0d55b1f1a31e5ad4c4967bfaa8ade0240b07d20ee4af1dfef5f531056512961a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.10.0"
+  video_player_android:
+    dependency: transitive
+    description:
+      name: video_player_android
+      sha256: "0fabf59eea728a6a887f29f2818eafbefb4b37c727dbb62dccef56c9287a692f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.10"
+  video_player_avfoundation:
+    dependency: transitive
+    description:
+      name: video_player_avfoundation
+      sha256: "509ef9cfe7a3379783ccf306d45f5b5fc9db747401f956ce31c963417019e48e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.2"
+  video_player_platform_interface:
+    dependency: transitive
+    description:
+      name: video_player_platform_interface
+      sha256: cf2a1d29a284db648fd66cbd18aacc157f9862d77d2cc790f6f9678a46c1db5a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.0"
+  video_player_web:
+    dependency: transitive
+    description:
+      name: video_player_web
+      sha256: "9f3c00be2ef9b76a95d94ac5119fb843dca6f2c69e6c9968f6f2b6c9e7afbdeb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,6 +86,7 @@ dependencies:
   onesignal_flutter: ^5.3.4
   geocoding: ^2.1.0
   flutter_typeahead: ^5.2.0
+  video_player: ^2.7.0
 
   meta: any
 dev_dependencies:

--- a/test/login_view_test.dart
+++ b/test/login_view_test.dart
@@ -71,7 +71,7 @@ void main() {
         translations: AppTranslations(),
         locale: const Locale('en'),
         theme: AppTheme.lightTheme(AppColor.blue.color),
-        home: const LoginView(),
+        home: const LoginView(playBackgroundVideo: false),
       ),
     );
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- play login video once and stop on last frame
- add video_player dependency and test flag

## Testing
- `flutter test` *(fails: home_view_test.dart swiping left opens create post page - did not complete)*
- `flutter test test/login_view_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688f1824d2488328bed65494e071349d