### PR TITLE
Persist social sign-in display name

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -172,6 +172,14 @@ class AuthService {
         await _createUserDocumentIfNeeded(firebaseUser);
       }
     }
+
+    final displayName = result.user?.displayName;
+    if (displayName != null && displayName.isNotEmpty) {
+      await _firestore
+          .collection('users')
+          .doc(result.user!.uid)
+          .set({'displayName': displayName}, SetOptions(merge: true));
+    }
     _fetched = false;
     await fetchUser();
     return result;
@@ -196,6 +204,14 @@ class AuthService {
       if (firebaseUser != null) {
         await _createUserDocumentIfNeeded(firebaseUser);
       }
+    }
+
+    final displayName = result.user?.displayName;
+    if (displayName != null && displayName.isNotEmpty) {
+      await _firestore
+          .collection('users')
+          .doc(result.user!.uid)
+          .set({'displayName': displayName}, SetOptions(merge: true));
     }
     _fetched = false;
     await fetchUser();


### PR DESCRIPTION
## Summary
- merge non-empty Google profile name into user document
- merge non-empty Apple profile name into user document
- refresh cached user after saving display name

## Testing
- `flutter test` *(fails: LoginView shows welcome description)*

------
https://chatgpt.com/codex/tasks/task_e_688f34ed6d248328b1a4ea6f4f93d5a8