### PR TITLE
Prefill display name on welcome

### DIFF
--- a/lib/pages/welcome/controllers/welcome_controller.dart
+++ b/lib/pages/welcome/controllers/welcome_controller.dart
@@ -18,6 +18,16 @@ class WelcomeController extends GetxController {
   WelcomeController({BaseUserService? userService})
       : _userService = userService ?? UserService();
 
+  @override
+  void onInit() {
+    final initialName =
+        _auth.currentUser?.name ?? FirebaseAuth.instance.currentUser?.displayName;
+    if (initialName != null) {
+      displayNameController.text = initialName;
+    }
+    super.onInit();
+  }
+
   /// Validates and saves the display name to Firestore.
   Future<bool> saveDisplayName() async {
     final name = displayNameController.text.trim();


### PR DESCRIPTION
## Summary
- prefill welcome display name field using existing user name on controller init

## Testing
- `flutter test` *(fails: LoginView shows welcome description)*

------
https://chatgpt.com/codex/tasks/task_e_688f41251d588328a93d55775d8254e9