### PR TITLE
feat: allow publishing to multiple feeds

### DIFF
--- a/lib/pages/create_post/views/create_post_view.dart
+++ b/lib/pages/create_post/views/create_post_view.dart
@@ -63,11 +63,71 @@ class CreatePostView extends GetView<CreatePostController> {
                 children: [
                   DropdownButtonHideUnderline(
                     child: Obx(() {
+                      final selected = controller.selectedFeeds;
                       return DropdownButton2<Feed>(
-                        value: controller.selectedFeed.value,
-                        hint: Text('selectFeed'.tr),
-                        onChanged: (f) => controller.selectedFeed.value = f,
                         isExpanded: true,
+                        hint: Text('selectFeed'.tr),
+                        items: controller.availableFeeds
+                            .map((feed) => DropdownMenuItem<Feed>(
+                                  value: feed,
+                                  enabled: false,
+                                  child: StatefulBuilder(
+                                    builder: (context, menuSetState) {
+                                      final isSelected =
+                                          selected.contains(feed);
+                                      return InkWell(
+                                        onTap: () {
+                                          isSelected
+                                              ? selected.remove(feed)
+                                              : selected.add(feed);
+                                          selected.refresh();
+                                          menuSetState(() {});
+                                        },
+                                        child: Container(
+                                          height: double.infinity,
+                                          padding: const EdgeInsets.symmetric(
+                                              horizontal: 16.0),
+                                          child: Row(
+                                            children: [
+                                              if (isSelected)
+                                                const Icon(
+                                                    Icons.check_box_outlined)
+                                              else
+                                                const Icon(Icons
+                                                    .check_box_outline_blank),
+                                              const SizedBox(width: 16),
+                                              Expanded(
+                                                child: Text(
+                                                  feed.title,
+                                                  style: const TextStyle(
+                                                    fontSize: 14,
+                                                  ),
+                                                ),
+                                              ),
+                                            ],
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  ),
+                                ))
+                            .toList(),
+                        value: selected.isEmpty ? null : selected.last,
+                        onChanged: (_) {},
+                        selectedItemBuilder: (context) {
+                          return controller.availableFeeds.map((feed) {
+                            return Container(
+                              alignment: AlignmentDirectional.center,
+                              child: Text(
+                                selected.map((f) => f.title).join(', '),
+                                style: const TextStyle(
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                                maxLines: 1,
+                              ),
+                            );
+                          }).toList();
+                        },
                         dropdownStyleData: DropdownStyleData(
                           padding: const EdgeInsets.symmetric(vertical: 8),
                           decoration: BoxDecoration(
@@ -86,12 +146,6 @@ class CreatePostView extends GetView<CreatePostController> {
                             borderRadius: BorderRadius.circular(16),
                           ),
                         ),
-                        items: controller.availableFeeds
-                            .map((feed) => DropdownMenuItem(
-                                  value: feed,
-                                  child: Text(feed.title),
-                                ))
-                            .toList(),
                       );
                     }),
                   ),

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -142,12 +142,12 @@ void main() {
           userId: 'u1',
           storageService: storage);
       controller.textController.text = 'a' * 281;
-      controller.selectedFeed.value = Feed(
+      controller.selectedFeeds.add(Feed(
           id: 'f1',
           userId: 't',
           title: 't',
           description: 'd',
-          color: Colors.blue);
+          color: Colors.blue));
       expect(await controller.publish(), isNull);
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
@@ -180,12 +180,12 @@ void main() {
           authService: auth,
           userId: 'u1',
           storageService: storage);
-      controller.selectedFeed.value = Feed(
+      controller.selectedFeeds.add(Feed(
           id: 'f1',
           userId: 't',
           title: 't',
           description: 'd',
-          color: Colors.blue);
+          color: Colors.blue));
       controller.textController.text = 'Hi';
       final result = await controller.publish();
       await tester.pump(const Duration(seconds: 4));
@@ -199,6 +199,52 @@ void main() {
       expect(data['user']['username'], 'tester');
       expect(data['user']['smallAvatar'], 'a.png');
       expect(data['feed']['title'], 't');
+    });
+
+    testWidgets('publish creates a post for each selected feed',
+        (tester) async {
+      await tester.pumpWidget(const ToastificationWrapper(
+        child: MaterialApp(home: Scaffold(body: SizedBox())),
+      ));
+      final firestore = FakeFirebaseFirestore();
+      final postService = PostService(
+        firestore: firestore,
+      );
+      final feeds = [
+        Feed(
+            id: 'f1',
+            userId: 'u1',
+            title: 't1',
+            description: 'd1',
+            color: Colors.blue),
+        Feed(
+            id: 'f2',
+            userId: 'u1',
+            title: 't2',
+            description: 'd2',
+            color: Colors.red),
+      ];
+      final auth = FakeAuthService(U(
+          uid: 'u1',
+          name: 'Tester',
+          username: 'tester',
+          smallProfilePictureUrl: 'a.png',
+          feeds: feeds));
+      final storage = FakeStorageService();
+      final controller = CreatePostController(
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage);
+      controller.selectedFeeds.assignAll(feeds);
+      controller.textController.text = 'Hi';
+      await controller.publish();
+      await tester.pump(const Duration(seconds: 4));
+      await tester.pumpAndSettle();
+      final posts = await firestore.collection('posts').get();
+      expect(posts.docs.length, 2);
+      final feedIds = posts.docs.map((e) => e.data()['feedId']).toSet();
+      expect(feedIds, {'f1', 'f2'});
     });
 
     testWidgets('images are uploaded and urls stored', (tester) async {
@@ -229,12 +275,12 @@ void main() {
           userId: 'u1',
           storageService: storage);
 
-      controller.selectedFeed.value = Feed(
+      controller.selectedFeeds.add(Feed(
           id: 'f1',
           userId: 't',
           title: 't',
           description: 'd',
-          color: Colors.blue);
+          color: Colors.blue));
       final file = File('${Directory.systemTemp.path}/img.jpg')
         ..writeAsBytesSync([0]);
       addTearDown(() => file.deleteSync());


### PR DESCRIPTION
## Summary
- support selecting multiple feeds when creating a post
- validate at least one feed is chosen and publish to each selected feed
- add tests for multi-feed publishing and validation

## Testing
- `flutter test test/create_post_controller_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688f6ce85b0c83288d062034c534987b