### PR TITLE
feat: allow feed ordering

### DIFF
--- a/lib/models/feed.dart
+++ b/lib/models/feed.dart
@@ -18,6 +18,7 @@ class Feed {
   bool? nsfw;
   bool? verified;
   FeedType? type;
+  int order;
   final int? subscriberCount;
   List<Post>? posts;
 
@@ -36,6 +37,7 @@ class Feed {
       this.nsfw,
       this.verified,
       this.type,
+      this.order = 0,
       this.subscriberCount,
       this.posts});
 
@@ -58,6 +60,9 @@ class Feed {
       private: json['private'],
       nsfw: json['nsfw'],
       verified: json['verified'],
+      order: (json['order'] is int)
+          ? json['order']
+          : (json['order'] != null ? int.parse(json['order'].toString()) : 0),
       subscriberCount: json['subscriberCount'],
       posts: json['posts'] != null
           ? (json['posts'] as List).map((i) => Post.fromJson(i)).toList()
@@ -77,6 +82,7 @@ class Feed {
         'type': type.toString().split('.').last,
         'private': private,
         'nsfw': nsfw,
+        'order': order,
       };
 
   Map<String, dynamic> toCache() => {
@@ -94,6 +100,7 @@ class Feed {
         'private': private,
         'nsfw': nsfw,
         'verified': verified,
-        'subscriberCount': subscriberCount
+        'subscriberCount': subscriberCount,
+        'order': order
       };
 }

--- a/lib/models/feed.dart
+++ b/lib/models/feed.dart
@@ -60,9 +60,7 @@ class Feed {
       private: json['private'],
       nsfw: json['nsfw'],
       verified: json['verified'],
-      order: (json['order'] is int)
-          ? json['order']
-          : (json['order'] != null ? int.parse(json['order'].toString()) : 0),
+      order: json['order'] ?? 0,
       subscriberCount: json['subscriberCount'],
       posts: json['posts'] != null
           ? (json['posts'] as List).map((i) => Post.fromJson(i)).toList()

--- a/lib/pages/feed_editor/controllers/feed_editor_controller.dart
+++ b/lib/pages/feed_editor/controllers/feed_editor_controller.dart
@@ -162,6 +162,10 @@ class FeedEditorController extends GetxController {
       bigAvatarUrl = _authService.currentUser?.largeProfilePictureUrl;
     }
 
+    final order = _profileController?.feeds.length ??
+        _authService.currentUser?.feeds?.length ??
+        0;
+
     await docRef.set({
       'title': title,
       'description': description,
@@ -170,6 +174,7 @@ class FeedEditorController extends GetxController {
       'private': isPrivate.value,
       'nsfw': isNsfw.value,
       'userId': _userId,
+      'order': order,
       if (smallAvatarUrl != null) 'smallAvatar': smallAvatarUrl,
       if (bigAvatarUrl != null) 'bigAvatar': bigAvatarUrl,
       if (smallAvatarHash != null) 'smallAvatarHash': smallAvatarHash,
@@ -198,6 +203,7 @@ class FeedEditorController extends GetxController {
       type: type,
       private: isPrivate.value,
       nsfw: isNsfw.value,
+      order: order,
       subscriberCount: 0,
     );
     final user = _authService.currentUser;

--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -136,6 +136,19 @@ class ProfileController extends GetxController {
     await loadFeedPosts(feedId);
   }
 
+  /// Reorders feeds locally and persists the new order.
+  Future<void> reorderFeeds(int oldIndex, int newIndex) async {
+    if (!isCurrentUser) return;
+    if (oldIndex < newIndex) newIndex -= 1;
+    final feed = feeds.removeAt(oldIndex);
+    feeds.insert(newIndex, feed);
+    for (var i = 0; i < feeds.length; i++) {
+      feeds[i].order = i;
+    }
+    user.value?.feeds = feeds.toList();
+    await _feedService.updateFeedOrder(feeds);
+  }
+
   /// Toggles subscription state for [feedId].
   Future<void> toggleSubscription(String feedId,
       [BuildContext? context]) async {

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -325,9 +325,11 @@ class _ProfileViewState extends State<ProfileView> {
             childAspectRatio: 1,
             children: children,
             onReorder: (oldIndex, newIndex) {
+              // Prevent any reorder involving the add tile
               if (oldIndex == feeds.length || newIndex == feeds.length) return;
               controller.reorderFeeds(oldIndex, newIndex);
             },
+            canReorder: (index) => index != feeds.length,
           ),
         );
       } else {

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -7,6 +7,7 @@ import 'package:hoot/util/extensions/feed_extension.dart';
 import 'package:liquid_glass_renderer/liquid_glass_renderer.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:hoot/models/user.dart';
+import 'package:hoot/models/feed.dart';
 import 'package:hoot/components/image_component.dart';
 import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/util/routes/app_routes.dart';
@@ -17,6 +18,7 @@ import 'package:hoot/services/report_service.dart';
 import 'package:hoot/services/toast_service.dart';
 import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:hoot/services/haptic_service.dart';
+import 'package:reorderable_grid_view/reorderable_grid_view.dart';
 
 class ProfileView extends StatefulWidget {
   const ProfileView({super.key});
@@ -175,159 +177,179 @@ class _ProfileViewState extends State<ProfileView> {
     return uri;
   }
 
-  Widget buildFeedGrid(BuildContext context) {
-    return Obx(() {
-      final feeds = controller.feeds;
-      final itemCount =
-          controller.isCurrentUser ? feeds.length + 1 : feeds.length;
-      return SliverPadding(
-        padding: EdgeInsets.symmetric(horizontal: 16).copyWith(
-          bottom: MediaQuery.of(context).padding.bottom + 16,
+  Widget _buildAddTile(BuildContext context) {
+    return GestureDetector(
+      key: const ValueKey('add'),
+      onTap: () {
+        HapticService.lightImpact();
+        Get.toNamed(AppRoutes.createFeed);
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          border: Border.all(
+            color: Theme.of(context).colorScheme.outline.withAlpha(50),
+            width: 1,
+          ),
+          color: Theme.of(context).colorScheme.surfaceContainer,
         ),
-        sliver: SliverGrid(
-          delegate: SliverChildBuilderDelegate(
-            (context, index) {
-              if (controller.isCurrentUser && index == 0) {
-                return GestureDetector(
-                  onTap: () {
-                    HapticService.lightImpact();
-                    Get.toNamed(AppRoutes.createFeed);
-                  },
-                  child: Container(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(16),
-                      border: Border.all(
-                        color:
-                            Theme.of(context).colorScheme.outline.withAlpha(50),
-                        width: 1,
-                      ),
-                      color: Theme.of(context).colorScheme.surfaceContainer,
-                    ),
-                    clipBehavior: Clip.hardEdge,
-                    child: Stack(
-                      fit: StackFit.expand,
-                      children: [
-                        HashCachedImage(
-                          imageUrl:
-                              controller.user.value?.smallProfilePictureUrl ??
-                                  '',
-                          hash: controller.user.value?.smallAvatarHash,
-                          width: double.infinity,
-                          height: double.infinity,
-                          fit: BoxFit.cover,
-                        ).blurred(
-                          blur: 16,
-                          blurColor: Theme.of(context).colorScheme.surface,
-                          colorOpacity: 0.25,
-                        ),
-                        Center(
-                          child: Icon(
-                            SolarIconsBold.addSquare,
-                            size: 64,
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onSurface
-                                .withAlpha(125),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              }
-              final feed = feeds[controller.isCurrentUser ? index - 1 : index];
-              final color = feed.color ?? Theme.of(context).colorScheme.primary;
-              final textColor = feed.foregroundColor;
-              return ClipRRect(
+        clipBehavior: Clip.hardEdge,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            HashCachedImage(
+              imageUrl: controller.user.value?.smallProfilePictureUrl ?? '',
+              hash: controller.user.value?.smallAvatarHash,
+              width: double.infinity,
+              height: double.infinity,
+              fit: BoxFit.cover,
+            ).blurred(
+              blur: 16,
+              blurColor: Theme.of(context).colorScheme.surface,
+              colorOpacity: 0.25,
+            ),
+            Center(
+              child: Icon(
+                SolarIconsBold.addSquare,
+                size: 64,
+                color: Theme.of(context).colorScheme.onSurface.withAlpha(125),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFeedTile(BuildContext context, Feed feed) {
+    final color = feed.color ?? Theme.of(context).colorScheme.primary;
+    final textColor = feed.foregroundColor;
+    return ClipRRect(
+      key: ValueKey(feed.id),
+      borderRadius: BorderRadius.circular(16),
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          Positioned.fill(
+            child: HashCachedImage(
+              imageUrl: feed.smallAvatar ??
+                  controller.user.value?.smallProfilePictureUrl ??
+                  '',
+              hash: feed.bigAvatarHash ?? controller.user.value?.bigAvatarHash,
+              width: double.infinity,
+              height: double.infinity,
+              fit: BoxFit.cover,
+            ).blurred(
+              blur: 16,
+              blurColor: color,
+              colorOpacity: 0.5,
+            ),
+          ),
+          Positioned.fill(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: InkWell(
+                onTap: () {
+                  HapticService.lightImpact();
+                  Get.toNamed(
+                    AppRoutes.feed,
+                    arguments: FeedPageArgs(feedId: feed.id),
+                  );
+                },
+                splashColor: Colors.white.withAlpha(50),
+                highlightColor: Colors.white.withAlpha(50),
                 borderRadius: BorderRadius.circular(16),
-                child: Stack(
-                  fit: StackFit.expand,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.center,
                   children: [
-                    Positioned.fill(
-                      child: HashCachedImage(
-                        imageUrl: feed.smallAvatar ??
-                            controller.user.value?.smallProfilePictureUrl ??
-                            '',
-                        hash: feed.bigAvatarHash ??
-                            controller.user.value?.bigAvatarHash,
-                        width: double.infinity,
-                        height: double.infinity,
-                        fit: BoxFit.cover,
-                      ).blurred(
-                        blur: 16,
-                        blurColor: color,
-                        colorOpacity: 0.5,
+                    const SizedBox(height: 16),
+                    Text(
+                      feed.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Get.textTheme.titleLarge?.copyWith(
+                        color: textColor,
+                        fontWeight: FontWeight.bold,
                       ),
+                      textAlign: TextAlign.center,
                     ),
-                    Positioned.fill(
-                      child: Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: InkWell(
-                          onTap: () {
-                            HapticService.lightImpact();
-                            Get.toNamed(
-                              AppRoutes.feed,
-                              arguments: FeedPageArgs(feedId: feed.id),
-                            );
-                          },
-                          splashColor: Colors.white.withAlpha(50),
-                          highlightColor: Colors.white.withAlpha(50),
-                          borderRadius: BorderRadius.circular(16),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.center,
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              const SizedBox(height: 16),
-                              Text(
-                                feed.title,
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                                style: Get.textTheme.titleLarge?.copyWith(
-                                  color: textColor,
-                                  fontWeight: FontWeight.bold,
-                                ),
-                                textAlign: TextAlign.center,
-                              ),
-                              if (feed.description != null &&
-                                  feed.description!.isNotEmpty) ...[
-                                const SizedBox(height: 8),
-                                Text(
-                                  feed.description!,
-                                  maxLines: 2,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: Get.textTheme.bodyMedium?.copyWith(
-                                    color: textColor,
-                                  ),
-                                  textAlign: TextAlign.center,
-                                ),
-                              ],
-                              const SizedBox(height: 8),
-                              Text(
-                                '${feed.subscriberCount ?? 0} ${'followers'.tr}',
-                                style: Get.textTheme.bodySmall?.copyWith(
-                                  color: textColor,
-                                ),
-                                textAlign: TextAlign.center,
-                              ),
-                            ],
-                          ),
+                    if (feed.description != null &&
+                        feed.description!.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Text(
+                        feed.description!,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: Get.textTheme.bodyMedium?.copyWith(
+                          color: textColor,
                         ),
+                        textAlign: TextAlign.center,
                       ),
+                    ],
+                    const SizedBox(height: 8),
+                    Text(
+                      '${feed.subscriberCount ?? 0} ${'followers'.tr}',
+                      style: Get.textTheme.bodySmall?.copyWith(
+                        color: textColor,
+                      ),
+                      textAlign: TextAlign.center,
                     ),
                   ],
                 ),
-              );
-            },
-            childCount: itemCount,
+              ),
+            ),
           ),
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 2,
-            crossAxisSpacing: 8,
-            mainAxisSpacing: 8,
-            childAspectRatio: 1,
-          ),
-        ),
+        ],
+      ),
+    );
+  }
+
+  Widget buildFeedGrid(BuildContext context) {
+    return Obx(() {
+      final feeds = controller.feeds;
+      final padding = EdgeInsets.symmetric(horizontal: 16).copyWith(
+        bottom: MediaQuery.of(context).padding.bottom + 16,
       );
+      if (controller.isCurrentUser) {
+        final children = [
+          for (final feed in feeds) _buildFeedTile(context, feed),
+          _buildAddTile(context),
+        ];
+        return SliverPadding(
+          padding: padding,
+          sliver: ReorderableSliverGridView.count(
+            crossAxisCount: 2,
+            mainAxisSpacing: 8,
+            crossAxisSpacing: 8,
+            childAspectRatio: 1,
+            children: children,
+            onReorder: (oldIndex, newIndex) {
+              if (oldIndex == feeds.length || newIndex == feeds.length) return;
+              controller.reorderFeeds(oldIndex, newIndex);
+            },
+          ),
+        );
+      } else {
+        return SliverPadding(
+          padding: padding,
+          sliver: SliverGrid(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                final feed = feeds[index];
+                return _buildFeedTile(context, feed);
+              },
+              childCount: feeds.length,
+            ),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              crossAxisSpacing: 8,
+              mainAxisSpacing: 8,
+              childAspectRatio: 1,
+            ),
+          ),
+        );
+      }
     });
   }
 
@@ -391,7 +413,8 @@ class _ProfileViewState extends State<ProfileView> {
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: Get.textTheme.bodySmall?.copyWith(
-                            color: Theme.of(context).colorScheme.onSurfaceVariant,
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
                           ),
                         ),
                       ],

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -52,6 +52,7 @@ class AuthService {
       final feedsSnapshot = await _firestore
           .collection('feeds')
           .where('userId', isEqualTo: firebaseUser.uid)
+          .orderBy('order')
           .get();
       _currentUser.value!.feeds = feedsSnapshot.docs
           .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
@@ -76,6 +77,7 @@ class AuthService {
     final feedsSnapshot = await _firestore
         .collection('feeds')
         .where('userId', isEqualTo: uid)
+        .orderBy('order')
         .get();
     user.feeds = feedsSnapshot.docs
         .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))
@@ -102,6 +104,7 @@ class AuthService {
     final feedsSnapshot = await _firestore
         .collection('feeds')
         .where('userId', isEqualTo: doc.id)
+        .orderBy('order')
         .get();
     user.feeds = feedsSnapshot.docs
         .map((d) => Feed.fromJson({'id': d.id, ...d.data()}))

--- a/lib/services/feed_service.dart
+++ b/lib/services/feed_service.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get/get.dart';
 
 import 'package:hoot/models/post.dart';
+import 'package:hoot/models/feed.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/util/constants.dart';
 
@@ -26,6 +27,8 @@ abstract class BaseFeedService {
     DocumentSnapshot? startAfter,
     int limit = kDefaultFetchLimit,
   });
+
+  Future<void> updateFeedOrder(List<Feed> feeds);
 }
 
 /// Default implementation retrieving posts from feeds the current user is subscribed to.
@@ -160,5 +163,15 @@ class FeedService implements BaseFeedService {
       lastDoc: snapshot.docs.isNotEmpty ? snapshot.docs.last : null,
       hasMore: snapshot.docs.length == limit,
     );
+  }
+
+  @override
+  Future<void> updateFeedOrder(List<Feed> feeds) async {
+    final batch = _firestore.batch();
+    for (var i = 0; i < feeds.length; i++) {
+      final feed = feeds[i];
+      batch.update(_firestore.collection('feeds').doc(feed.id), {'order': i});
+    }
+    await batch.commit();
   }
 }

--- a/mock/services/mock_feed_service.dart
+++ b/mock/services/mock_feed_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hoot/services/feed_service.dart';
+import 'package:hoot/models/feed.dart';
 import 'mock_post_service.dart';
 
 /// Mock implementation of [BaseFeedService] returning posts from memory.
@@ -22,4 +23,7 @@ class MockFeedService implements BaseFeedService {
         postService.posts.where((p) => p.feedId == feedId).take(limit).toList();
     return PostPage(posts: posts, hasMore: false);
   }
+
+  @override
+  Future<void> updateFeedOrder(List<Feed> feeds) async {}
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1400,6 +1400,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.2"
+  reorderable_grid_view:
+    dependency: "direct main"
+    description:
+      name: reorderable_grid_view
+      sha256: e36c6229a97105a10c79e15ab4b9b14ee9f6c488574ff2be9e858c82af47cda6
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.8"
   rx:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,6 +87,7 @@ dependencies:
   geocoding: ^2.1.0
   flutter_typeahead: ^5.2.0
   video_player: ^2.7.0
+  reorderable_grid_view: ^2.2.8
 
   meta: any
 dev_dependencies:

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -100,7 +100,8 @@ void main() {
                 userId: 'u1',
                 title: 't',
                 description: 'd',
-                color: Colors.blue)
+                color: Colors.blue,
+                order: 0)
           ]));
       final storage = FakeStorageService();
       final controller = CreatePostController(
@@ -133,7 +134,8 @@ void main() {
                 userId: 'u1',
                 title: 't',
                 description: 'd',
-                color: Colors.blue)
+                color: Colors.blue,
+                order: 0)
           ]));
       final storage = FakeStorageService();
       final controller = CreatePostController(
@@ -147,7 +149,8 @@ void main() {
           userId: 't',
           title: 't',
           description: 'd',
-          color: Colors.blue);
+          color: Colors.blue,
+          order: 0);
       expect(await controller.publish(), isNull);
       await tester.pump(const Duration(seconds: 4));
       await tester.pumpAndSettle();
@@ -172,7 +175,8 @@ void main() {
                 userId: 'u1',
                 title: 't',
                 description: 'd',
-                color: Colors.blue)
+                color: Colors.blue,
+                order: 0)
           ]));
       final storage = FakeStorageService();
       final controller = CreatePostController(
@@ -185,7 +189,8 @@ void main() {
           userId: 't',
           title: 't',
           description: 'd',
-          color: Colors.blue);
+          color: Colors.blue,
+          order: 0);
       controller.textController.text = 'Hi';
       final result = await controller.publish();
       await tester.pump(const Duration(seconds: 4));
@@ -220,7 +225,8 @@ void main() {
                 userId: 'u1',
                 title: 't',
                 description: 'd',
-                color: Colors.blue)
+                color: Colors.blue,
+                order: 0)
           ]));
       final storage = FakeStorageService();
       final controller = CreatePostController(
@@ -234,7 +240,8 @@ void main() {
           userId: 't',
           title: 't',
           description: 'd',
-          color: Colors.blue);
+          color: Colors.blue,
+          order: 0);
       final file = File('${Directory.systemTemp.path}/img.jpg')
         ..writeAsBytesSync([0]);
       addTearDown(() => file.deleteSync());
@@ -261,7 +268,8 @@ void main() {
           userId: 'u1',
           title: 't',
           description: 'd',
-          color: Colors.blue);
+          color: Colors.blue,
+          order: 0);
       final auth = FakeAuthService(U(
           uid: 'u1',
           name: 'Tester',

--- a/test/feed_editor_controller_test.dart
+++ b/test/feed_editor_controller_test.dart
@@ -78,6 +78,9 @@ class FakeFeedService implements BaseFeedService {
       {DocumentSnapshot? startAfter, int limit = 10}) async {
     return PostPage(posts: []);
   }
+
+  @override
+  Future<void> updateFeedOrder(List<Feed> feeds) async {}
 }
 
 void main() {
@@ -253,6 +256,7 @@ void main() {
       private: false,
       nsfw: false,
       subscriberCount: 0,
+      order: 0,
     );
     final user = U(uid: 'u1', feeds: [feed]);
     final auth = FakeAuthService(user);

--- a/test/post_service_test.dart
+++ b/test/post_service_test.dart
@@ -133,7 +133,8 @@ void main() {
           userId: 'u1',
           title: 'feed',
           description: 'd',
-          color: Colors.blue);
+          color: Colors.blue,
+          order: 0);
       final user = U(uid: 'u1');
 
       final newId = await service.reFeed(
@@ -158,13 +159,18 @@ void main() {
           .set({'text': 'Hello', 'reFeeds': 0});
       final original = Post(id: 'orig', text: 'Hello');
       final feed = Feed(
-          id: 'f1', userId: 'u1', title: 'feed', description: 'd', color: Colors.blue);
+          id: 'f1',
+          userId: 'u1',
+          title: 'feed',
+          description: 'd',
+          color: Colors.blue,
+          order: 0);
       final user = U(uid: 'u1');
 
-      final firstId =
-          await service.reFeed(original: original, targetFeed: feed, user: user);
-      final secondId =
-          await service.reFeed(original: original, targetFeed: feed, user: user);
+      final firstId = await service.reFeed(
+          original: original, targetFeed: feed, user: user);
+      final secondId = await service.reFeed(
+          original: original, targetFeed: feed, user: user);
 
       expect(firstId, secondId);
       expect((await firestore.collection('posts').get()).docs.length, 2);

--- a/test/profile_controller_test.dart
+++ b/test/profile_controller_test.dart
@@ -134,6 +134,9 @@ class FakeFeedService implements BaseFeedService {
       {DocumentSnapshot? startAfter, int limit = 10}) async {
     return PostPage(posts: []);
   }
+
+  @override
+  Future<void> updateFeedOrder(List<Feed> feeds) async {}
 }
 
 void main() {
@@ -150,7 +153,8 @@ void main() {
             userId: 'u2',
             title: 'f',
             description: 'd',
-            private: false)
+            private: false,
+            order: 0)
       ]);
       final auth = FakeAuthService(user);
       final manager = FakeSubscriptionManager(SubscriptionResult.subscribed);
@@ -183,7 +187,12 @@ void main() {
       ));
       final user = U(uid: 'u1', feeds: [
         Feed(
-            id: 'f1', userId: 'u2', title: 'f', description: 'd', private: true)
+            id: 'f1',
+            userId: 'u2',
+            title: 'f',
+            description: 'd',
+            private: true,
+            order: 0)
       ]);
       final auth = FakeAuthService(user);
       final manager = FakeSubscriptionManager(SubscriptionResult.requested);


### PR DESCRIPTION
## Summary
- add `order` field for feeds and persist throughout auth and feed services
- allow reordering owned feeds via a reorderable grid
- batch update feed order in Firestore

## Testing
- `flutter test test/models_test.dart`
- `flutter test` *(fails: No Firebase App '[DEFAULT]' has been created, ReorderableSliverGrid undefined, login view test assertion)*

------
https://chatgpt.com/codex/tasks/task_e_688f6d72c0b88328929ca71b6161ac11