### PR TITLE
Move add tile to start of profile feed grid

### DIFF
--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -313,8 +313,8 @@ class _ProfileViewState extends State<ProfileView> {
       );
       if (controller.isCurrentUser) {
         final children = [
-          for (final feed in feeds) _buildFeedTile(context, feed),
           _buildAddTile(context),
+          for (final feed in feeds) _buildFeedTile(context, feed),
         ];
         return SliverPadding(
           padding: padding,
@@ -325,9 +325,9 @@ class _ProfileViewState extends State<ProfileView> {
             childAspectRatio: 1,
             children: children,
             onReorder: (oldIndex, newIndex) {
-              // Prevent any reorder involving the add tile
-              if (oldIndex == feeds.length || newIndex == feeds.length) return;
-              controller.reorderFeeds(oldIndex, newIndex);
+              // Prevent reordering of the add tile
+              if (oldIndex == 0 || newIndex == 0) return;
+              controller.reorderFeeds(oldIndex - 1, newIndex - 1);
             },
           ),
         );


### PR DESCRIPTION
## Summary
- Put the add-feed tile first in the profile grid
- Skip reordering when the add tile is involved and offset indices for feed reorder

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_688f760d535c8328b3a2fc8a3f8ec6c3