### PR TITLE
Add createdAt to user model and fetching

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -15,6 +15,7 @@ class U {
   String? bio;
   String? location;
   String? website;
+  DateTime? createdAt;
 
   String? invitationCode;
   String? invitedBy;
@@ -44,6 +45,7 @@ class U {
     this.bio,
     this.location,
     this.website,
+    this.createdAt,
     this.invitationCode,
     this.invitedBy,
     this.invitationUses,
@@ -86,6 +88,18 @@ class U {
       bio: json['bio'],
       location: json['location'],
       website: json['website'],
+      createdAt: json['createdAt'] != null
+          ? json['createdAt'] is Timestamp
+              ? (json['createdAt'] as Timestamp).toDate()
+              : json['createdAt'] is Map<String, dynamic> &&
+                      json['createdAt']['_seconds'] != null
+                  ? DateTime.fromMillisecondsSinceEpoch(
+                      json['createdAt']['_seconds'] * 1000)
+                  : json['createdAt'] is String
+                      ? DateTime.fromMillisecondsSinceEpoch(
+                          int.parse(json['createdAt']))
+                      : json['createdAt']
+          : null,
       invitationCode: json['invitationCode'],
       invitedBy: json['invitedBy'],
       invitationUses: json['invitationUses'],
@@ -119,6 +133,7 @@ class U {
       'bio': bio,
       'location': location,
       'website': website,
+      'createdAt': createdAt,
       'invitationCode': invitationCode,
       'invitationUses': invitationUses,
       'invitationLastReset': invitationLastReset,
@@ -142,6 +157,9 @@ class U {
         'bio': bio,
         'location': location,
         'website': website,
+        'createdAt': createdAt != null
+            ? createdAt!.millisecondsSinceEpoch.toString()
+            : null,
         'invitationCode': invitationCode,
         'invitationUses': invitationUses,
         'invitationLastReset': invitationLastReset,
@@ -155,4 +173,39 @@ class U {
         'popularityScore': popularityScore,
         'feeds': feeds?.map((e) => e.toCache()).toList(),
       };
+
+  factory U.fromCache(Map<String, dynamic> json) {
+    return U(
+      uid: json['uid'],
+      name: json['displayName'],
+      username: json['username'],
+      smallProfilePictureUrl: json['smallAvatar'],
+      largeProfilePictureUrl: json['bigAvatar'],
+      smallAvatarHash: json['smallAvatarHash'],
+      bigAvatarHash: json['bigAvatarHash'],
+      bannerPictureUrl: json['banner'],
+      bannerHash: json['bannerHash'],
+      musicUrl: json['music'],
+      bio: json['bio'],
+      location: json['location'],
+      website: json['website'],
+      createdAt: json['createdAt'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(int.parse(json['createdAt']))
+          : null,
+      invitationCode: json['invitationCode'],
+      invitedBy: json['invitedBy'],
+      invitationUses: json['invitationUses'],
+      invitationLastReset: json['invitationLastReset'],
+      phoneNumber: json['phoneNumber'],
+      verified: json['verified'],
+      tester: json['tester'],
+      birthday: json['birthday'],
+      subscriptionCount: json['subscriptionCount'],
+      activityScore: json['activityScore'],
+      popularityScore: json['popularityScore'],
+      feeds: json['feeds'] != null
+          ? List<Feed>.from(json['feeds'].map((x) => Feed.fromJson(x)))
+          : [],
+    );
+  }
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -41,7 +41,9 @@ class AuthService {
     final doc =
         await _firestore.collection('users').doc(firebaseUser.uid).get();
     if (doc.exists) {
-      _currentUser.value = U.fromJson(doc.data()!);
+      final data = doc.data()!;
+      _currentUser.value =
+          U.fromJson({...data, 'createdAt': data['createdAt']});
       final subs = await _firestore
           .collection('users')
           .doc(firebaseUser.uid)
@@ -67,7 +69,8 @@ class AuthService {
   Future<U?> fetchUserById(String uid) async {
     final doc = await _firestore.collection('users').doc(uid).get();
     if (!doc.exists) return null;
-    final user = U.fromJson(doc.data()!);
+    final data = doc.data()!;
+    final user = U.fromJson({...data, 'createdAt': data['createdAt']});
     final subs = await _firestore
         .collection('users')
         .doc(uid)
@@ -94,7 +97,8 @@ class AuthService {
         .get();
     if (query.docs.isEmpty) return null;
     final doc = query.docs.first;
-    final user = U.fromJson(doc.data());
+    final data = doc.data();
+    final user = U.fromJson({...data, 'createdAt': data['createdAt']});
     final subs = await _firestore
         .collection('users')
         .doc(doc.id)

--- a/mock/data/mock_user.dart
+++ b/mock/data/mock_user.dart
@@ -17,6 +17,7 @@ final U mockUser = U(
   uid: 'user1',
   name: 'Mock User',
   username: 'mockuser',
+  createdAt: DateTime(2020, 1, 1),
   feeds: [mockFeed],
   subscriptionCount: 1,
 );

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -38,6 +38,7 @@ void main() {
         'bio': 'bio',
         'location': 'loc',
         'website': 'w',
+        'createdAt': DateTime(2020, 1, 1),
         'invitationCode': 'ABCDEF',
         'invitationUses': 1,
         'invitationLastReset': DateTime(2020, 1, 1),
@@ -63,6 +64,7 @@ void main() {
       expect(user.invitationUses, 1);
       expect(user.activityScore, 5);
       expect(user.popularityScore, 10);
+      expect(user.createdAt, isNotNull);
 
       final json = user.toJson();
       expect(json['displayName'], 'John');
@@ -77,6 +79,7 @@ void main() {
       expect(cache['popularityScore'], 10);
       expect(cache['smallAvatarHash'], 'uhash');
       expect(cache['bigAvatarHash'], 'ubhash');
+      expect(cache['createdAt'], isNotNull);
     });
   });
 


### PR DESCRIPTION
## Summary
- add createdAt to user model with cache and json serialization
- include createdAt when fetching users and in mock data
- test user model serialization with createdAt

## Testing
- `flutter test` *(fails: UnimplementedError in auth_service_test and assertion in login_view_test)*
- `flutter test test/models_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688f76d265508328ac6882155e0c0290