### PR TITLE
feat: restrict adult content for new accounts

### DIFF
--- a/lib/pages/explore/bindings/explore_binding.dart
+++ b/lib/pages/explore/bindings/explore_binding.dart
@@ -1,9 +1,10 @@
 import 'package:get/get.dart';
 import 'package:hoot/pages/explore/controllers/explore_controller.dart';
+import 'package:hoot/services/auth_service.dart';
 
 class ExploreBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut(() => ExploreController());
+    Get.lazyPut(() => ExploreController(authService: Get.find<AuthService>()));
   }
 }

--- a/lib/pages/home/bindings/home_binding.dart
+++ b/lib/pages/home/bindings/home_binding.dart
@@ -5,13 +5,14 @@ import 'package:hoot/pages/explore/controllers/explore_controller.dart';
 import 'package:hoot/pages/create_post/controllers/create_post_controller.dart';
 import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
 import 'package:hoot/pages/profile/controllers/profile_controller.dart';
+import 'package:hoot/services/auth_service.dart';
 
 class HomeBinding extends Bindings {
   @override
   void dependencies() {
     Get.lazyPut(() => HomeController());
     Get.lazyPut(() => FeedController());
-    Get.lazyPut(() => ExploreController());
+    Get.lazyPut(() => ExploreController(authService: Get.find<AuthService>()));
     Get.lazyPut(() => CreatePostController());
     Get.lazyPut(() => NotificationsController());
     Get.lazyPut(() => ProfileController(), tag: 'current');

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -1,6 +1,9 @@
 const kDefaultFetchLimit = 10;
 const kUserChunkSize = 10;
 
+/// Minimum account age required to view adult content.
+const int kAdultContentAccountAgeDays = 30;
+
 const kInvitationFadeDuration = Duration(milliseconds: 500);
 const kInvitationExtendedFadeDuration = Duration(milliseconds: 1000);
 const kInvitationCrossFadeDuration = Duration(milliseconds: 300);

--- a/test/explore_view_test.dart
+++ b/test/explore_view_test.dart
@@ -2,11 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 
 import 'package:hoot/pages/explore/controllers/explore_controller.dart';
 import 'package:hoot/pages/explore/views/explore_view.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/translations/app_translations.dart';
+import 'package:hoot/services/auth_service.dart';
 
 void main() {
   testWidgets('ExploreView shows search suggestions', (tester) async {
@@ -28,7 +30,9 @@ void main() {
       'createdAt': DateTime.now(),
     });
 
-    Get.put(ExploreController(firestore: firestore));
+    final auth = AuthService(auth: MockFirebaseAuth(), firestore: firestore);
+    Get.put<AuthService>(auth);
+    Get.put(ExploreController(firestore: firestore, authService: auth));
 
     await tester.pumpWidget(
       GetMaterialApp(
@@ -64,7 +68,9 @@ void main() {
       'usernameLowercase': 'tester',
     });
 
-    Get.put(ExploreController(firestore: firestore));
+    final auth = AuthService(auth: MockFirebaseAuth(), firestore: firestore);
+    Get.put<AuthService>(auth);
+    Get.put(ExploreController(firestore: firestore, authService: auth));
 
     await tester.pumpWidget(
       GetMaterialApp(


### PR DESCRIPTION
## Summary
- add kAdultContentAccountAgeDays constant for adult content gating
- inject AuthService into ExploreController and filter adult feeds/posts for new users
- update bindings and tests to supply AuthService

## Testing
- `flutter test` *(fails: No Firebase App '[DEFAULT]' has been created)*

------
https://chatgpt.com/codex/tasks/task_e_688f7a0a476c8328a916483d1fd9a287