### PR TITLE
test: add ExploreController adult content filter tests

### DIFF
--- a/mock/data/mock_user.dart
+++ b/mock/data/mock_user.dart
@@ -3,7 +3,7 @@ import 'dart:ui';
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/models/user.dart';
 
-/// Sample user used by mock services.
+/// Sample feed used by mock services.
 final Feed mockFeed = Feed(
   id: 'feed1',
   userId: 'user1',
@@ -13,11 +13,17 @@ final Feed mockFeed = Feed(
   subscriberCount: 1,
 );
 
-final U mockUser = U(
-  uid: 'user1',
-  name: 'Mock User',
-  username: 'mockuser',
-  createdAt: DateTime(2020, 1, 1),
-  feeds: [mockFeed],
-  subscriptionCount: 1,
-);
+/// Generates a sample user for mock services.
+U createMockUser({DateTime? createdAt}) {
+  return U(
+    uid: 'user1',
+    name: 'Mock User',
+    username: 'mockuser',
+    createdAt: createdAt ?? DateTime(2020, 1, 1),
+    feeds: [mockFeed],
+    subscriptionCount: 1,
+  );
+}
+
+/// Default mock user instance.
+final U mockUser = createMockUser();

--- a/mock/services/mock_auth_service.dart
+++ b/mock/services/mock_auth_service.dart
@@ -7,29 +7,31 @@ import '../data/mock_user.dart';
 
 /// Mock implementation of [AuthService] providing in-memory user data.
 class MockAuthService extends real.AuthService {
-  MockAuthService()
-      : super(auth: MockFirebaseAuth(), firestore: FakeFirebaseFirestore());
+  final U user;
+  MockAuthService({DateTime? createdAt})
+      : user = createMockUser(createdAt: createdAt),
+        super(auth: MockFirebaseAuth(), firestore: FakeFirebaseFirestore());
 
   @override
   Future<U?> fetchUser() async {
-    currentUserRx.value = mockUser;
+    currentUserRx.value = user;
     return currentUserRx.value;
   }
 
   @override
   Future<U?> fetchUserById(String uid) async {
-    return uid == mockUser.uid ? mockUser : null;
+    return uid == user.uid ? user : null;
   }
 
   @override
   Future<U?> fetchUserByUsername(String username) async {
-    return username == mockUser.username ? mockUser : null;
+    return username == user.username ? user : null;
   }
 
   @override
   Future<List<U>> searchUsers(String query, {int limit = 5}) async {
-    if (mockUser.username != null && mockUser.username!.startsWith(query)) {
-      return [mockUser];
+    if (user.username != null && user.username!.startsWith(query)) {
+      return [user];
     }
     return [];
   }

--- a/test/explore_controller_adult_filter_test.dart
+++ b/test/explore_controller_adult_filter_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/pages/explore/controllers/explore_controller.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/util/constants.dart';
+import 'package:hoot/util/enums/feed_types.dart';
+
+void main() {
+  group('ExploreController adult content filtering', () {
+    test('excludes adult content for young accounts', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('feeds').doc('f1').set({
+        'title': 'Adult Feed',
+        'titleLowercase': 'adult feed',
+        'description': 'desc',
+        'color': '0',
+        'type': 'adultContent',
+        'userId': 'u1',
+        'subscriberCount': 1,
+        'createdAt': DateTime.now(),
+        'nsfw': true,
+      });
+      await firestore.collection('posts').doc('p1').set({
+        'text': 'adult post',
+        'likes': 0,
+        'createdAt': DateTime.now(),
+        'feedId': 'f1',
+        'feed': {
+          'id': 'f1',
+          'title': 'Adult Feed',
+          'titleLowercase': 'adult feed',
+          'description': 'desc',
+          'color': '0',
+          'type': 'adultContent',
+          'userId': 'u1',
+          'subscriberCount': 1,
+          'createdAt': DateTime.now(),
+          'nsfw': true,
+          'private': false,
+        },
+      });
+
+      final auth = AuthService(auth: MockFirebaseAuth(), firestore: firestore);
+      final youngDate = DateTime.now().subtract(
+        const Duration(days: kAdultContentAccountAgeDays - 1),
+      );
+      auth.currentUserRx.value = U(uid: 'u1', createdAt: youngDate);
+
+      final controller = ExploreController(
+        firestore: firestore,
+        authService: auth,
+      );
+      await controller.loadTopFeeds();
+      await controller.loadTopPosts();
+      await controller.loadNewFeeds();
+      await controller.loadGenres();
+
+      expect(controller.topFeeds, isEmpty);
+      expect(controller.topPosts, isEmpty);
+      expect(controller.newFeeds, isEmpty);
+      expect(controller.genres, isEmpty);
+    });
+
+    test('includes adult content for old accounts', () async {
+      final firestore = FakeFirebaseFirestore();
+      await firestore.collection('feeds').doc('f1').set({
+        'title': 'Adult Feed',
+        'titleLowercase': 'adult feed',
+        'description': 'desc',
+        'color': '0',
+        'type': 'adultContent',
+        'userId': 'u1',
+        'subscriberCount': 1,
+        'createdAt': DateTime.now(),
+        'nsfw': true,
+      });
+      await firestore.collection('posts').doc('p1').set({
+        'text': 'adult post',
+        'likes': 0,
+        'createdAt': DateTime.now(),
+        'feedId': 'f1',
+        'feed': {
+          'id': 'f1',
+          'title': 'Adult Feed',
+          'titleLowercase': 'adult feed',
+          'description': 'desc',
+          'color': '0',
+          'type': 'adultContent',
+          'userId': 'u1',
+          'subscriberCount': 1,
+          'createdAt': DateTime.now(),
+          'nsfw': true,
+          'private': false,
+        },
+      });
+
+      final auth = AuthService(auth: MockFirebaseAuth(), firestore: firestore);
+      final oldDate = DateTime.now().subtract(
+        const Duration(days: kAdultContentAccountAgeDays + 1),
+      );
+      auth.currentUserRx.value = U(uid: 'u1', createdAt: oldDate);
+
+      final controller = ExploreController(
+        firestore: firestore,
+        authService: auth,
+      );
+      await controller.loadTopFeeds();
+      await controller.loadTopPosts();
+      await controller.loadNewFeeds();
+      await controller.loadGenres();
+
+      expect(controller.topFeeds.length, 1);
+      expect(controller.topFeeds.first.type, FeedType.adultContent);
+      expect(controller.topPosts.length, 1);
+      expect(controller.topPosts.first.feed?.type, FeedType.adultContent);
+      expect(controller.newFeeds.length, 1);
+      expect(controller.genres.length, 1);
+      expect(controller.genres.first, FeedType.adultContent);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow configuring mock users' createdAt for tests
- add tests verifying ExploreController hides or shows adult content based on account age

## Testing
- `flutter test test/explore_controller_adult_filter_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688f7c7b2f448328a4afef613ada9d94