### PR TITLE
Add user roles and staff promotion docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ flutter run
 flutter test
 ```
 
+## User roles
+
+Every document in the `users` collection contains a `role` field indicating whether the account is a regular `user` or a member of `staff`. New accounts default to the `user` role. To promote someone to staff, set their document's `role` to `staff` in Firestore. To demote them, change the value back to `user`.
+
 ## Contributing
 
 Read the [contributing guidelines](CONTRIBUTING.md) for information on preferred patterns and example usage of services.

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -1,6 +1,9 @@
 import 'package:hoot/models/feed.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+/// Defines the role of a user.
+enum UserRole { user, staff }
+
 class U {
   final String uid;
   String? name;
@@ -30,6 +33,7 @@ class U {
   int? activityScore;
   int? popularityScore;
   List<Feed>? feeds;
+  UserRole role;
 
   U({
     required this.uid,
@@ -58,6 +62,7 @@ class U {
     this.activityScore = 0,
     this.popularityScore = 0,
     this.feeds,
+    this.role = UserRole.user,
   });
 
   bool get isNewUser => username == null || username!.isEmpty;
@@ -116,6 +121,7 @@ class U {
       feeds: json['feeds'] != null
           ? List<Feed>.from(json['feeds'].map((x) => Feed.fromJson(x)))
           : [],
+      role: json['role'] == 'staff' ? UserRole.staff : UserRole.user,
     );
   }
 
@@ -140,6 +146,7 @@ class U {
       'invitedBy': invitedBy,
       'phoneNumber': phoneNumber,
       'birthday': birthday,
+      'role': role.name,
     };
   }
 
@@ -172,6 +179,7 @@ class U {
         'activityScore': activityScore,
         'popularityScore': popularityScore,
         'feeds': feeds?.map((e) => e.toCache()).toList(),
+        'role': role.name,
       };
 
   factory U.fromCache(Map<String, dynamic> json) {
@@ -206,6 +214,7 @@ class U {
       feeds: json['feeds'] != null
           ? List<Feed>.from(json['feeds'].map((x) => Feed.fromJson(x)))
           : [],
+      role: json['role'] == 'staff' ? UserRole.staff : UserRole.user,
     );
   }
 }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -139,6 +139,7 @@ class AuthService {
     await docRef.set({
       'uid': user.uid,
       'displayName': user.displayName,
+      'role': 'user',
       'invitationCode': const Uuid().v4().substring(0, 8).toUpperCase(),
       'invitationUses': 0,
       'invitationLastReset': FieldValue.serverTimestamp(),

--- a/mock/data/mock_user.dart
+++ b/mock/data/mock_user.dart
@@ -22,6 +22,7 @@ U createMockUser({DateTime? createdAt}) {
     createdAt: createdAt ?? DateTime(2020, 1, 1),
     feeds: [mockFeed],
     subscriptionCount: 1,
+    role: UserRole.user,
   );
 }
 

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
 
 import 'package:hoot/services/auth_service.dart';
@@ -17,11 +18,13 @@ void main() {
     final doc = await firestore.collection('users').doc('u1').get();
     expect(doc.get('activityScore'), 0);
     expect(doc.get('popularityScore'), 0);
+    expect(doc.get('role'), 'user');
   });
 
   test('signInWithGoogle writes displayName into Firestore', () async {
     final firestore = FakeFirebaseFirestore();
-    final auth = MockFirebaseAuth(mockUser: MockUser(uid: 'u1', displayName: 'John'));
+    final auth =
+        StubFirebaseAuth(mockUser: MockUser(uid: 'u1', displayName: 'John'));
     final service = AuthService(auth: auth, firestore: firestore);
 
     final originalPlatform = GoogleSignInPlatform.instance;
@@ -74,7 +77,8 @@ class FakeGoogleSignInPlatform extends GoogleSignInPlatform {
   Future<GoogleSignInTokenData> getTokens({
     required String email,
     bool? shouldRecoverAuth,
-  }) async => tokens;
+  }) async =>
+      tokens;
 
   @override
   Future<void> signOut() async {}
@@ -92,5 +96,37 @@ class FakeGoogleSignInPlatform extends GoogleSignInPlatform {
   Future<bool> requestScopes(List<String> scopes) async => true;
 
   @override
-  Future<bool> canAccessScopes(List<String> scopes, {String? accessToken}) async => true;
+  Future<bool> canAccessScopes(List<String> scopes,
+          {String? accessToken}) async =>
+      true;
+}
+
+class FakeUserCredential implements UserCredential {
+  FakeUserCredential(this._user);
+
+  final MockUser _user;
+
+  @override
+  User get user => _user;
+
+  @override
+  AdditionalUserInfo? get additionalUserInfo =>
+      AdditionalUserInfo(isNewUser: true);
+
+  @override
+  AuthCredential? get credential => null;
+}
+
+class StubFirebaseAuth extends MockFirebaseAuth {
+  StubFirebaseAuth({required MockUser mockUser})
+      : _user = mockUser,
+        super(mockUser: mockUser);
+
+  final MockUser _user;
+
+  @override
+  Future<UserCredential> signInWithCredential(
+      AuthCredential? credential) async {
+    return FakeUserCredential(_user);
+  }
 }

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -50,7 +50,8 @@ void main() {
         'subscriptionCount': 2,
         'activityScore': 5,
         'popularityScore': 10,
-        'feeds': [feedJson]
+        'feeds': [feedJson],
+        'role': 'staff'
       };
 
       final user = U.fromJson(userJson);
@@ -65,6 +66,7 @@ void main() {
       expect(user.activityScore, 5);
       expect(user.popularityScore, 10);
       expect(user.createdAt, isNotNull);
+      expect(user.role, UserRole.staff);
 
       final json = user.toJson();
       expect(json['displayName'], 'John');
@@ -73,6 +75,7 @@ void main() {
       expect(json['invitationCode'], 'ABCDEF');
       expect(json['smallAvatarHash'], 'uhash');
       expect(json['bigAvatarHash'], 'ubhash');
+      expect(json['role'], 'staff');
 
       final cache = user.toCache();
       expect(cache['activityScore'], 5);
@@ -80,6 +83,7 @@ void main() {
       expect(cache['smallAvatarHash'], 'uhash');
       expect(cache['bigAvatarHash'], 'ubhash');
       expect(cache['createdAt'], isNotNull);
+      expect(cache['role'], 'staff');
     });
   });
 


### PR DESCRIPTION
## Summary
- extend user model with `UserRole` enum and role field
- persist and fetch roles in AuthService
- document promoting/demoting staff accounts in Firestore

## Testing
- `flutter test test/models_test.dart test/auth_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688f84aa2844832888e007ee320b847d