### PR TITLE
Add staff-only route and middleware

### DIFF
--- a/lib/middleware/staff_middleware.dart
+++ b/lib/middleware/staff_middleware.dart
@@ -7,11 +7,12 @@ import 'package:hoot/util/routes/app_routes.dart';
 
 /// Middleware that allows access only to staff users.
 class StaffMiddleware extends GetMiddleware {
-  final AuthService _authService = Get.find<AuthService>();
+
 
   @override
   RouteSettings? redirect(String? route) {
-    final user = _authService.currentUser;
+    final authService = Get.find<AuthService>();
+    final user = authService.currentUser;
     if (user == null || user.role != UserRole.staff) {
       return RouteSettings(name: AppRoutes.home);
     }

--- a/lib/middleware/staff_middleware.dart
+++ b/lib/middleware/staff_middleware.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import 'package:hoot/models/user.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/util/routes/app_routes.dart';
+
+/// Middleware that allows access only to staff users.
+class StaffMiddleware extends GetMiddleware {
+  final AuthService _authService = Get.find<AuthService>();
+
+  @override
+  RouteSettings? redirect(String? route) {
+    final user = _authService.currentUser;
+    if (user == null || user.role != UserRole.staff) {
+      return RouteSettings(name: AppRoutes.home);
+    }
+    return null;
+  }
+}

--- a/lib/pages/staff_home/bindings/staff_home_binding.dart
+++ b/lib/pages/staff_home/bindings/staff_home_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+
+/// Binding for the staff home view.
+class StaffHomeBinding extends Bindings {
+  @override
+  void dependencies() {
+    // Add controllers or services for staff home here when needed.
+  }
+}

--- a/lib/pages/staff_home/views/staff_home_view.dart
+++ b/lib/pages/staff_home/views/staff_home_view.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+/// Simple placeholder view for staff users.
+class StaffHomeView extends StatelessWidget {
+  const StaffHomeView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Staff Home'),
+      ),
+    );
+  }
+}

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -9,6 +9,8 @@ import 'package:hoot/pages/username/bindings/username_binding.dart';
 import 'package:hoot/pages/avatar/bindings/avatar_binding.dart';
 import 'package:hoot/pages/home/bindings/home_binding.dart';
 import 'package:hoot/pages/home/views/home_view.dart';
+import 'package:hoot/pages/staff_home/bindings/staff_home_binding.dart';
+import 'package:hoot/pages/staff_home/views/staff_home_view.dart';
 import 'package:hoot/pages/invitation/bindings/invitation_binding.dart';
 import 'package:hoot/pages/invitation/views/invitation_view.dart';
 import 'package:hoot/pages/notifications_permission/bindings/notification_permission_binding.dart';
@@ -50,6 +52,7 @@ import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/routes/args/profile_args.dart';
 import 'package:hoot/util/routes/args/feed_page_args.dart';
 import 'package:hoot/middleware/auth_middleware.dart';
+import 'package:hoot/middleware/staff_middleware.dart';
 
 class AppPages {
   static final List<GetPage> pages = [
@@ -93,6 +96,12 @@ class AppPages {
       page: () => const HomeView(),
       binding: HomeBinding(),
       middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.staff,
+      page: () => const StaffHomeView(),
+      binding: StaffHomeBinding(),
+      middlewares: [AuthMiddleware(), StaffMiddleware()],
     ),
     GetPage(
       name: AppRoutes.createPost,

--- a/lib/util/routes/app_routes.dart
+++ b/lib/util/routes/app_routes.dart
@@ -23,6 +23,7 @@ class AppRoutes {
   static const report = '/report';
   static const aboutUs = '/about_us';
   static const contacts = '/contacts';
+  static const staff = '/staff';
   static const photoViewer = '/photo_view';
   static const appColor = '/app_color';
 }


### PR DESCRIPTION
## Summary
- add Staff route constant
- create middleware restricting access to staff users
- register StaffHomeView guarded by new middleware

## Testing
- `flutter test` *(fails: TimeoutException)*

------
https://chatgpt.com/codex/tasks/task_e_688f895d5b0c83288d06c9a7a882461e