### PR TITLE
Implement staff report management

### DIFF
--- a/lib/models/report.dart
+++ b/lib/models/report.dart
@@ -1,0 +1,32 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Report {
+  final String id;
+  final String type;
+  final String targetId;
+  final String userId;
+  final String reason;
+  final DateTime? createdAt;
+
+  Report({
+    required this.id,
+    required this.type,
+    required this.targetId,
+    required this.userId,
+    required this.reason,
+    required this.createdAt,
+  });
+
+  factory Report.fromJson(String id, Map<String, dynamic> json) {
+    return Report(
+      id: id,
+      type: json['type'] ?? '',
+      targetId: json['targetId'] ?? '',
+      userId: json['userId'] ?? '',
+      reason: json['reason'] ?? '',
+      createdAt: json['createdAt'] is Timestamp
+          ? (json['createdAt'] as Timestamp).toDate()
+          : null,
+    );
+  }
+}

--- a/lib/pages/staff_home/views/staff_home_view.dart
+++ b/lib/pages/staff_home/views/staff_home_view.dart
@@ -1,14 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/util/routes/app_routes.dart';
 
-/// Simple placeholder view for staff users.
+/// Simple dashboard for staff users.
 class StaffHomeView extends StatelessWidget {
   const StaffHomeView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('Staff Home'),
+    return Scaffold(
+      appBar: AppBarComponent(
+        title: 'staff'.tr,
+      ),
+      body: ListView(
+        children: [
+          ListTile(
+            leading: const Icon(Icons.report),
+            title: Text('reports'.tr),
+            trailing: const Icon(Icons.arrow_forward),
+            onTap: () => Get.toNamed(AppRoutes.staffReports),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/staff_reports/bindings/staff_reports_binding.dart
+++ b/lib/pages/staff_reports/bindings/staff_reports_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import 'package:hoot/pages/staff_reports/controllers/staff_reports_controller.dart';
+
+class StaffReportsBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => StaffReportsController());
+  }
+}

--- a/lib/pages/staff_reports/controllers/staff_reports_controller.dart
+++ b/lib/pages/staff_reports/controllers/staff_reports_controller.dart
@@ -1,0 +1,55 @@
+import 'package:get/get.dart';
+import 'package:hoot/models/report.dart';
+import 'package:hoot/services/post_service.dart';
+import 'package:hoot/services/report_service.dart';
+
+class StaffReportsController extends GetxController {
+  final BaseReportService _service;
+  final BasePostService _postService;
+
+  StaffReportsController(
+      {BaseReportService? service, BasePostService? postService})
+      : _service = service ??
+            (Get.isRegistered<BaseReportService>()
+                ? Get.find<BaseReportService>()
+                : ReportService()),
+        _postService = postService ??
+            (Get.isRegistered<BasePostService>()
+                ? Get.find<BasePostService>()
+                : PostService());
+
+  final RxList<Report> reports = <Report>[].obs;
+  final RxBool loading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    loadReports();
+  }
+
+  Future<void> loadReports() async {
+    loading.value = true;
+    try {
+      final result = await _service.fetchReports();
+      reports.assignAll(result);
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  Future<void> dismiss(String reportId) async {
+    await _service.resolveReport(reportId, action: 'dismiss');
+    reports.removeWhere((r) => r.id == reportId);
+  }
+
+  Future<void> removePost(Report report) async {
+    await _postService.deletePost(report.targetId);
+    await _service.resolveReport(report.id, action: 'remove_post');
+    reports.removeWhere((r) => r.id == report.id);
+  }
+
+  Future<void> warnUser(Report report) async {
+    await _service.resolveReport(report.id, action: 'warn_user');
+    reports.removeWhere((r) => r.id == report.id);
+  }
+}

--- a/lib/pages/staff_reports/views/staff_reports_view.dart
+++ b/lib/pages/staff_reports/views/staff_reports_view.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/components/empty_message.dart';
+import 'package:hoot/pages/staff_reports/controllers/staff_reports_controller.dart';
+
+class StaffReportsView extends GetView<StaffReportsController> {
+  const StaffReportsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBarComponent(
+        title: 'reports'.tr,
+      ),
+      body: Obx(() {
+        if (controller.loading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.reports.isEmpty) {
+          return Center(
+            child: NothingToShowComponent(
+              icon: const Icon(Icons.report_gmailerrorred_outlined),
+              text: 'noReports'.tr,
+            ),
+          );
+        }
+        return ListView.builder(
+          itemCount: controller.reports.length,
+          itemBuilder: (context, index) {
+            final report = controller.reports[index];
+            return ListTile(
+              title: Text(report.type),
+              subtitle: Text(report.reason),
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.check),
+                    tooltip: 'dismiss'.tr,
+                    onPressed: () => controller.dismiss(report.id),
+                  ),
+                  if (report.type == 'post')
+                    IconButton(
+                      icon: const Icon(Icons.delete),
+                      tooltip: 'removePost'.tr,
+                      onPressed: () => controller.removePost(report),
+                    ),
+                  IconButton(
+                    icon: const Icon(Icons.warning),
+                    tooltip: 'warnUser'.tr,
+                    onPressed: () => controller.warnUser(report),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/services/report_service.dart
+++ b/lib/services/report_service.dart
@@ -2,11 +2,14 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:get/get.dart';
 
 import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/models/report.dart';
 
 /// Provides helpers to submit user and post reports.
 abstract class BaseReportService {
   Future<void> reportPost({required String postId, required String reason});
   Future<void> reportUser({required String userId, required String reason});
+  Future<List<Report>> fetchReports();
+  Future<void> resolveReport(String id, {required String action});
 }
 
 class ReportService implements BaseReportService {
@@ -28,6 +31,7 @@ class ReportService implements BaseReportService {
       'userId': user.uid,
       'reason': reason,
       'createdAt': FieldValue.serverTimestamp(),
+      'resolved': false,
     });
   }
 
@@ -42,6 +46,26 @@ class ReportService implements BaseReportService {
       'userId': user.uid,
       'reason': reason,
       'createdAt': FieldValue.serverTimestamp(),
+      'resolved': false,
+    });
+  }
+
+  @override
+  Future<List<Report>> fetchReports() async {
+    final snapshot = await _firestore
+        .collection('reports')
+        .where('resolved', isEqualTo: false)
+        .orderBy('createdAt', descending: true)
+        .get();
+    return snapshot.docs.map((d) => Report.fromJson(d.id, d.data())).toList();
+  }
+
+  @override
+  Future<void> resolveReport(String id, {required String action}) async {
+    await _firestore.collection('reports').doc(id).update({
+      'resolved': true,
+      'action': action,
+      'resolvedAt': FieldValue.serverTimestamp(),
     });
   }
 }

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -11,6 +11,8 @@ import 'package:hoot/pages/home/bindings/home_binding.dart';
 import 'package:hoot/pages/home/views/home_view.dart';
 import 'package:hoot/pages/staff_home/bindings/staff_home_binding.dart';
 import 'package:hoot/pages/staff_home/views/staff_home_view.dart';
+import 'package:hoot/pages/staff_reports/bindings/staff_reports_binding.dart';
+import 'package:hoot/pages/staff_reports/views/staff_reports_view.dart';
 import 'package:hoot/pages/invitation/bindings/invitation_binding.dart';
 import 'package:hoot/pages/invitation/views/invitation_view.dart';
 import 'package:hoot/pages/notifications_permission/bindings/notification_permission_binding.dart';
@@ -101,6 +103,12 @@ class AppPages {
       name: AppRoutes.staff,
       page: () => const StaffHomeView(),
       binding: StaffHomeBinding(),
+      middlewares: [AuthMiddleware(), StaffMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.staffReports,
+      page: () => const StaffReportsView(),
+      binding: StaffReportsBinding(),
       middlewares: [AuthMiddleware(), StaffMiddleware()],
     ),
     GetPage(

--- a/lib/util/routes/app_routes.dart
+++ b/lib/util/routes/app_routes.dart
@@ -24,6 +24,7 @@ class AppRoutes {
   static const aboutUs = '/about_us';
   static const contacts = '/contacts';
   static const staff = '/staff';
+  static const staffReports = '/staff_reports';
   static const photoViewer = '/photo_view';
   static const appColor = '/app_color';
 }


### PR DESCRIPTION
## Summary
- extend `ReportService` with fetching and resolving reports
- add staff reports module with UI to review and act on pending reports
- link staff dashboard to report list

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_688f91b4366483288d09f25e930efb44