### PR TITLE
Add staff dashboard with statistics

### DIFF
--- a/lib/pages/staff_dashboard/bindings/staff_dashboard_binding.dart
+++ b/lib/pages/staff_dashboard/bindings/staff_dashboard_binding.dart
@@ -1,0 +1,9 @@
+import 'package:get/get.dart';
+import 'package:hoot/pages/staff_dashboard/controllers/staff_dashboard_controller.dart';
+
+class StaffDashboardBinding extends Bindings {
+  @override
+  void dependencies() {
+    Get.lazyPut(() => StaffDashboardController());
+  }
+}

--- a/lib/pages/staff_dashboard/controllers/staff_dashboard_controller.dart
+++ b/lib/pages/staff_dashboard/controllers/staff_dashboard_controller.dart
@@ -1,0 +1,30 @@
+import 'package:get/get.dart';
+import 'package:hoot/services/stats_service.dart';
+
+class StaffDashboardController extends GetxController {
+  final BaseStatsService _service;
+
+  StaffDashboardController({BaseStatsService? service})
+      : _service = service ??
+            (Get.isRegistered<BaseStatsService>()
+                ? Get.find<BaseStatsService>()
+                : StatsService());
+
+  final Rx<Stats?> stats = Rx<Stats?>(null);
+  final RxBool loading = false.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    loadStats();
+  }
+
+  Future<void> loadStats() async {
+    loading.value = true;
+    try {
+      stats.value = await _service.fetchStats();
+    } finally {
+      loading.value = false;
+    }
+  }
+}

--- a/lib/pages/staff_dashboard/views/staff_dashboard_view.dart
+++ b/lib/pages/staff_dashboard/views/staff_dashboard_view.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/pages/staff_dashboard/controllers/staff_dashboard_controller.dart';
+
+class StaffDashboardView extends GetView<StaffDashboardController> {
+  const StaffDashboardView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBarComponent(
+        title: 'dashboard'.tr,
+      ),
+      body: Obx(() {
+        if (controller.loading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final stats = controller.stats.value;
+        if (stats == null) {
+          return Center(child: Text('noData'.tr));
+        }
+        return ListView(
+          children: [
+            ListTile(
+              leading: const Icon(Icons.people),
+              title: Text('totalUsers'.tr),
+              trailing: Text('${stats.totalUsers}'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.person_outline),
+              title: Text('activeUsers'.tr),
+              trailing: Text('${stats.activeUsers}'),
+            ),
+            ListTile(
+              leading: const Icon(Icons.report),
+              title: Text('reports'.tr),
+              trailing: Text('${stats.reportsCount}'),
+            ),
+          ],
+        );
+      }),
+    );
+  }
+}

--- a/lib/pages/staff_home/views/staff_home_view.dart
+++ b/lib/pages/staff_home/views/staff_home_view.dart
@@ -16,6 +16,12 @@ class StaffHomeView extends StatelessWidget {
       body: ListView(
         children: [
           ListTile(
+            leading: const Icon(Icons.dashboard),
+            title: Text('dashboard'.tr),
+            trailing: const Icon(Icons.arrow_forward),
+            onTap: () => Get.toNamed(AppRoutes.staffDashboard),
+          ),
+          ListTile(
             leading: const Icon(Icons.report),
             title: Text('reports'.tr),
             trailing: const Icon(Icons.arrow_forward),

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -1,0 +1,48 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Represents aggregated statistics for the application.
+class Stats {
+  final int totalUsers;
+  final int activeUsers;
+  final int reportsCount;
+
+  Stats({
+    required this.totalUsers,
+    required this.activeUsers,
+    required this.reportsCount,
+  });
+}
+
+/// Contract for fetching aggregate statistics.
+abstract class BaseStatsService {
+  Future<Stats> fetchStats();
+}
+
+/// Default implementation that aggregates data from Firestore.
+class StatsService implements BaseStatsService {
+  final FirebaseFirestore _firestore;
+
+  StatsService({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  @override
+  Future<Stats> fetchStats() async {
+    final results = await Future.wait([
+      _firestore.collection('users').get(),
+      _firestore
+          .collection('users')
+          .where('activityScore', isGreaterThan: 0)
+          .get(),
+      _firestore
+          .collection('reports')
+          .where('resolved', isEqualTo: false)
+          .get(),
+    ]);
+
+    return Stats(
+      totalUsers: results[0].size,
+      activeUsers: results[1].size,
+      reportsCount: results[2].size,
+    );
+  }
+}

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -13,6 +13,8 @@ import 'package:hoot/pages/staff_home/bindings/staff_home_binding.dart';
 import 'package:hoot/pages/staff_home/views/staff_home_view.dart';
 import 'package:hoot/pages/staff_reports/bindings/staff_reports_binding.dart';
 import 'package:hoot/pages/staff_reports/views/staff_reports_view.dart';
+import 'package:hoot/pages/staff_dashboard/bindings/staff_dashboard_binding.dart';
+import 'package:hoot/pages/staff_dashboard/views/staff_dashboard_view.dart';
 import 'package:hoot/pages/invitation/bindings/invitation_binding.dart';
 import 'package:hoot/pages/invitation/views/invitation_view.dart';
 import 'package:hoot/pages/notifications_permission/bindings/notification_permission_binding.dart';
@@ -103,6 +105,12 @@ class AppPages {
       name: AppRoutes.staff,
       page: () => const StaffHomeView(),
       binding: StaffHomeBinding(),
+      middlewares: [AuthMiddleware(), StaffMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.staffDashboard,
+      page: () => const StaffDashboardView(),
+      binding: StaffDashboardBinding(),
       middlewares: [AuthMiddleware(), StaffMiddleware()],
     ),
     GetPage(

--- a/lib/util/routes/app_routes.dart
+++ b/lib/util/routes/app_routes.dart
@@ -24,6 +24,7 @@ class AppRoutes {
   static const aboutUs = '/about_us';
   static const contacts = '/contacts';
   static const staff = '/staff';
+  static const staffDashboard = '/staff_dashboard';
   static const staffReports = '/staff_reports';
   static const photoViewer = '/photo_view';
   static const appColor = '/app_color';


### PR DESCRIPTION
## Summary
- add StatsService to gather user and report counts
- introduce StaffDashboard page displaying metrics with GetX
- link dashboard from StaffHome and register new route

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_688f94ee2ebc83289ca449ab271794d4