### PR TITLE
Notify staff of new reports

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,8 @@
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
-    "logs": "firebase functions:log"
+    "logs": "firebase functions:log",
+    "test": "npm run build && node --test lib/**/*.test.js"
   },
   "engines": {
     "node": "22"

--- a/functions/src/triggers/onNotificationCreated.ts
+++ b/functions/src/triggers/onNotificationCreated.ts
@@ -25,6 +25,7 @@ export const onNotificationCreated = onDocumentCreated(
       3: "New Subscriber",
       4: "New ReHoot",
       5: "Friend Joined",
+      6: "New Report",
     };
     const title = titles[data.type as number];
     if (!title) return;
@@ -48,6 +49,7 @@ export const onNotificationCreated = onDocumentCreated(
       3: `${username} subscribed to your feed`,
       4: `${username} reFeeded your post`,
       5: `${username} joined Hoot using your invite code`,
+      6: `${username} submitted a report`,
     };
     const body =
       bodyTemplates[data.type as number] ?? "You have a new notification";

--- a/functions/src/triggers/onReportCreated.test.ts
+++ b/functions/src/triggers/onReportCreated.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { notifyStaffOfReport } from './onReportCreated.js';
+
+test('notifyStaffOfReport creates notifications for staff', async () => {
+  const added: any[] = [];
+  const fakeDb: any = {
+    collection: (name: string) => ({
+      doc: (id: string) => ({
+        get: async () =>
+          id === 'user1'
+            ? { data: () => ({ username: 'alice' }) }
+            : { data: () => undefined },
+        collection: () => ({
+          add: async (data: any) => {
+            added.push({ id, data });
+          },
+        }),
+      }),
+      where: () => ({
+        get: async () => ({ docs: [{ id: 'staff1' }, { id: 'staff2' }] }),
+      }),
+    }),
+  };
+
+  await notifyStaffOfReport(fakeDb, 'r1', { userId: 'user1' });
+
+  assert.equal(added.length, 2);
+  assert.ok(
+    added.every(
+      (a) => a.id.startsWith('staff') && a.data.reportId === 'r1' && a.data.type === 6
+    )
+  );
+});

--- a/functions/src/triggers/onReportCreated.ts
+++ b/functions/src/triggers/onReportCreated.ts
@@ -1,0 +1,48 @@
+import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import { FieldValue, Firestore } from "firebase-admin/firestore";
+import { db } from "../config";
+
+export async function notifyStaffOfReport(
+  database: Firestore,
+  reportId: string,
+  report: Record<string, unknown>
+): Promise<void> {
+  const reporterId = report.userId as string | undefined;
+  let reporter: Record<string, unknown> | undefined;
+  if (reporterId) {
+    const reporterSnap = await database.collection("users").doc(reporterId).get();
+    reporter = reporterSnap.data();
+    if (reporter) reporter["uid"] = reporterId;
+  }
+
+  const staffQuery = await database
+    .collection("users")
+    .where("role", "==", "staff")
+    .get();
+
+  await Promise.all(
+    staffQuery.docs.map((doc) =>
+      database
+        .collection("users")
+        .doc(doc.id)
+        .collection("notifications")
+        .add({
+          ...(reporter ? { user: reporter } : {}),
+          reportId,
+          type: 6,
+          read: false,
+          createdAt: FieldValue.serverTimestamp(),
+        })
+    )
+  );
+}
+
+export const onReportCreated = onDocumentCreated(
+  "reports/{reportId}",
+  async (event) => {
+    const { reportId } = event.params;
+    const report = event.data?.data();
+    if (!report) return;
+    await notifyStaffOfReport(db, reportId, report);
+  }
+);

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -71,6 +71,9 @@ class NotificationsView extends GetView<NotificationsController> {
                           text = 'friendJoined'
                               .trParams({'username': user.username ?? ''});
                           break;
+                        case 6:
+                          text = 'newReport'.tr;
+                          break;
                         default:
                           text = '';
                       }
@@ -101,6 +104,9 @@ class NotificationsView extends GetView<NotificationsController> {
                                 AppRoutes.profile,
                                 arguments: ProfileArgs(uid: user.uid),
                               );
+                              break;
+                            case 6:
+                              Get.toNamed(AppRoutes.staffReports);
                               break;
                           }
                         },

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -217,6 +217,7 @@ class AppTranslations extends Translations {
           'newComment': 'New Comment',
           'newReHoot': 'New ReHoot',
           'newMention': 'New Mention',
+          'newReport': 'New Report',
           'reHoot': 'ReHoot',
           'reHootOf': 'ReHoot of',
           'deleteOnRefeededPost':
@@ -588,6 +589,7 @@ class AppTranslations extends Translations {
           'newComment': 'Nuevo Comentario',
           'newReHoot': 'Nuevo ReHoot',
           'newMention': 'Nueva Mención',
+          'newReport': 'Nuevo Reporte',
           'reHoot': 'ReHoot',
           'reHootOf': 'ReHoot de',
           'deleteOnRefeededPost':
@@ -960,6 +962,7 @@ class AppTranslations extends Translations {
           'newComment': 'Novo Comentário',
           'newReHoot': 'Novo ReHoot',
           'newMention': 'Nova Menção',
+          'newReport': 'Novo Relatório',
           'reHoot': 'ReHoot',
           'reHootOf': 'ReHoot de',
           'deleteOnRefeededPost':
@@ -1329,6 +1332,7 @@ class AppTranslations extends Translations {
           'newComment': 'Novo Comentário',
           'newReHoot': 'Novo ReHoot',
           'newMention': 'Nova Menção',
+          'newReport': 'Nova Denúncia',
           'reHoot': 'ReHoot',
           'reHootOf': 'ReHoot de',
           'deleteOnRefeededPost':


### PR DESCRIPTION
## Summary
- send staff notifications when a report is filed
- push "New Report" through notification service and display in app
- cover report-trigger notification logic with unit tests

## Testing
- `npm test`
- `flutter test test/notification_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688f9ca6a95c8328bfe366d87fafe123