### PR TITLE
Use DialogService for comment dialogs

### DIFF
--- a/lib/pages/post/views/post_view.dart
+++ b/lib/pages/post/views/post_view.dart
@@ -1,4 +1,3 @@
-import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -10,6 +9,7 @@ import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/components/mention_text_field.dart';
 import 'package:hoot/components/post_component.dart';
 import 'package:hoot/pages/post/controllers/post_controller.dart';
+import 'package:hoot/services/dialog_service.dart';
 
 class PostView extends GetView<PostController> {
   const PostView({super.key});
@@ -62,49 +62,32 @@ class PostView extends GetView<PostController> {
                             ),
                             confirmDismiss: (_) async {
                               if (isOwner) {
-                                final confirmed = await showDialog<bool>(
+                                return await DialogService.confirm(
                                   context: context,
-                                  builder: (context) => AlertDialog(
-                                    title: Text('deleteComment'.tr),
-                                    content:
-                                        Text('deleteCommentConfirmation'.tr),
-                                    actions: [
-                                      TextButton(
-                                        onPressed: () =>
-                                            Navigator.of(context).pop(false),
-                                        child: Text('cancel'.tr),
-                                      ),
-                                      TextButton(
-                                        onPressed: () =>
-                                            Navigator.of(context).pop(true),
-                                        child: Text('delete'.tr),
-                                      ),
-                                    ],
-                                  ),
+                                  title: 'deleteComment'.tr,
+                                  message: 'deleteCommentConfirmation'.tr,
+                                  okLabel: 'delete'.tr,
+                                  cancelLabel: 'cancel'.tr,
                                 );
-                                // If the dialog is dismissed without a result, treat as not confirmed (return false).
-                                return confirmed ?? false;
                               } else {
-                                final reasons = await showTextInputDialog(
+                                final reason = await DialogService.prompt(
                                   context: context,
                                   title: 'reportComment'.tr,
-                                  textFields: [
-                                    DialogTextField(
-                                      hintText: 'reportCommentInfo'.tr,
-                                      minLines: 3,
-                                      maxLines: 5,
-                                      maxLength: 500,
-                                      keyboardType: TextInputType.multiline,
-                                      textCapitalization:
-                                          TextCapitalization.sentences,
-                                    ),
-                                  ],
+                                  hintText: 'reportCommentInfo'.tr,
+                                  maxLength: 500,
+                                  minLines: 3,
+                                  maxLines: 5,
+                                  keyboardType: TextInputType.multiline,
+                                  textCapitalization:
+                                      TextCapitalization.sentences,
+                                  okLabel: 'report'.tr,
+                                  cancelLabel: 'cancel'.tr,
                                 );
-                                final reason = reasons?.first;
                                 if (reason?.trim().isEmpty ?? true) {
                                   return false;
                                 }
-                                await controller.reportComment(item, reason!);
+                                await controller.reportComment(
+                                    item, reason!.trim());
                                 return false;
                               }
                             },

--- a/lib/services/dialog_service.dart
+++ b/lib/services/dialog_service.dart
@@ -46,6 +46,39 @@ class DialogService {
     return input == expectedWord.toLowerCase();
   }
 
+  /// Prompts the user for text input and returns the entered value.
+  /// Returns null if the dialog is cancelled.
+  static Future<String?> prompt({
+    required BuildContext context,
+    required String title,
+    required String hintText,
+    int? maxLength,
+    int minLines = 1,
+    int maxLines = 1,
+    TextInputType keyboardType = TextInputType.text,
+    TextCapitalization textCapitalization = TextCapitalization.none,
+    String? okLabel,
+    String? cancelLabel,
+  }) async {
+    final result = await showTextInputDialog(
+      context: context,
+      title: title,
+      textFields: [
+        DialogTextField(
+          hintText: hintText,
+          maxLength: maxLength,
+          minLines: minLines,
+          maxLines: maxLines,
+          keyboardType: keyboardType,
+          textCapitalization: textCapitalization,
+        ),
+      ],
+      okLabel: okLabel,
+      cancelLabel: cancelLabel,
+    );
+    return result?.first;
+  }
+
   /// Shows a modal action sheet with the provided [actions].
   /// Returns the value associated with the selected action.
   static Future<T?> showActionSheet<T>({

--- a/test/services_test.dart
+++ b/test/services_test.dart
@@ -108,4 +108,55 @@ void main() {
 
     expect(await future, isFalse);
   });
+
+  testWidgets('DialogService prompt returns entered text', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SizedBox()),
+      ),
+    );
+
+    final context = tester.element(find.byType(Scaffold));
+
+    final future = DialogService.prompt(
+      context: context,
+      title: 'Title',
+      hintText: 'Hint',
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'reason');
+    await tester.tap(find.text('OK'));
+    await tester.pumpAndSettle();
+
+    expect(await future, 'reason');
+  });
+
+  testWidgets('DialogService prompt returns null on cancel', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: SizedBox()),
+      ),
+    );
+
+    final context = tester.element(find.byType(Scaffold));
+
+    final future = DialogService.prompt(
+      context: context,
+      title: 'Title',
+      hintText: 'Hint',
+      okLabel: 'OK',
+      cancelLabel: 'Cancel',
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(await future, isNull);
+  });
 }


### PR DESCRIPTION
## Summary
- use DialogService for comment delete confirmation and reporting
- add DialogService.prompt for text input dialogs
- test DialogService prompt flow

## Testing
- `flutter test` *(fails: tests hang at loading)*

------
https://chatgpt.com/codex/tasks/task_e_688fb592bddc8328b9ef63dcd7c4ad0b