### PR TITLE
Add comment-deleted translation and update toast message

### DIFF
--- a/lib/pages/post/controllers/post_controller.dart
+++ b/lib/pages/post/controllers/post_controller.dart
@@ -205,7 +205,7 @@ class PostController extends GetxController {
       }
       post.value.comments = (post.value.comments ?? 0) - 1;
       post.refresh();
-      ToastService.showSuccess('deleteComment'.tr);
+      ToastService.showSuccess('commentDeleted'.tr);
     } catch (e) {
       ToastService.showError('somethingWentWrong'.tr);
     }

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -230,6 +230,7 @@ class AppTranslations extends Translations {
           'deleteComment': 'Delete Comment',
           'deleteCommentConfirmation':
               'Are you sure you want to delete this comment?',
+          'commentDeleted': 'Comment deleted',
           'reportPost': 'Report Post',
           'reportPostInfo': 'Why are you reporting this post?',
           'reportComment': 'Report Comment',
@@ -617,6 +618,7 @@ class AppTranslations extends Translations {
           'deleteComment': 'Eliminar Comentario',
           'deleteCommentConfirmation':
               '¿Estás seguro de que deseas eliminar este comentario?',
+          'commentDeleted': 'Comentario eliminado',
           'reportPost': 'Reportar Hoot',
           'reportPostInfo': '¿Por qué estás reportando este hoot?',
           'reportComment': 'Reportar Comentario',
@@ -1005,6 +1007,7 @@ class AppTranslations extends Translations {
           'deleteComment': 'Eliminar Comentário',
           'deleteCommentConfirmation':
               'Tens a certeza de que queres eliminar este comentário?',
+          'commentDeleted': 'Comentário eliminado',
           'reportPost': 'Reportar Hoot',
           'reportPostInfo': 'Por que estás denunciando este hoot?',
           'reportComment': 'Reportar Comentário',
@@ -1390,6 +1393,7 @@ class AppTranslations extends Translations {
           'deleteComment': 'Excluir Comentário',
           'deleteCommentConfirmation':
               'Tem certeza de que deseja excluir este comentário?',
+          'commentDeleted': 'Comentário excluído',
           'reportPost': 'Denunciar Hoot',
           'reportPostInfo': 'Por que você está denunciando este hoot?',
           'reportComment': 'Denunciar Comentário',


### PR DESCRIPTION
## Summary
- Add `commentDeleted` translation for English, Spanish, Portuguese (Portugal) and Portuguese (Brazil)
- Use `commentDeleted` key when showing success toast after removing a comment

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*


------
https://chatgpt.com/codex/tasks/task_e_688fbe6a0850832888f6cc6426362bf9