### PR TITLE
Add feed creation translation

### DIFF
--- a/lib/pages/feed_editor/controllers/feed_editor_controller.dart
+++ b/lib/pages/feed_editor/controllers/feed_editor_controller.dart
@@ -211,7 +211,7 @@ class FeedEditorController extends GetxController {
       user.feeds = (user.feeds ?? [])..add(newFeed);
     }
     _profileController?.feeds.add(newFeed);
-    ToastService.showSuccess('createFeed'.tr);
+    ToastService.showSuccess('feedCreated'.tr);
     titleController.clear();
     descriptionController.clear();
     selectedType.value = null;

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -115,6 +115,7 @@ class AppTranslations extends Translations {
           'newUnfollower': '@username unfollowed you',
           'friendJoined': '@username joined Hoot using your invite code',
           'createFeed': 'Create a new Feed',
+          'feedCreated': 'Feed created',
           'title': 'Title',
           'description': 'Description',
           'color': 'Color',
@@ -501,6 +502,7 @@ class AppTranslations extends Translations {
           'friendJoined':
               '@username se unió a Hoot usando tu código de invitación',
           'createFeed': 'Crear un nuevo Feed',
+          'feedCreated': 'Feed creado',
           'title': 'Título',
           'description': 'Descripción',
           'color': 'Color',
@@ -891,6 +893,7 @@ class AppTranslations extends Translations {
           'friendJoined':
               '@username juntou-se ao Hoot usando o teu código de convite',
           'createFeed': 'Criar um novo Feed',
+          'feedCreated': 'Feed criado',
           'title': 'Título',
           'description': 'Descrição',
           'color': 'Cor',
@@ -1276,6 +1279,7 @@ class AppTranslations extends Translations {
           'friendJoined':
               '@username entrou no Hoot usando seu código de convite',
           'createFeed': 'Criar um novo Feed',
+          'feedCreated': 'Feed criado',
           'title': 'Título',
           'description': 'Descrição',
           'color': 'Cor',


### PR DESCRIPTION
## Summary
- add `feedCreated` translations for English, Spanish, Portuguese (Portugal/Brazil)
- show success toast using new translation key

## Testing
- `flutter analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_688fbe78c9c883288d63ba0a31f292a2