### PR TITLE
Add feedDeleted translation and update deletion toast

### DIFF
--- a/lib/pages/feed_editor/controllers/feed_editor_controller.dart
+++ b/lib/pages/feed_editor/controllers/feed_editor_controller.dart
@@ -313,7 +313,7 @@ class FeedEditorController extends GetxController {
       _profileController?.feeds.removeWhere((f) => f.id == feed!.id);
       final user = _authService.currentUser;
       user?.feeds?.removeWhere((f) => f.id == feed!.id);
-      ToastService.showSuccess('deleteFeed'.tr);
+      ToastService.showSuccess('feedDeleted'.tr);
       return true;
     } catch (e, s) {
       await ErrorService.reportError(e, stack: s);

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -183,6 +183,7 @@ class AppTranslations extends Translations {
           'deleteFeed': 'Delete Feed',
           'deleteFeedConfirmation':
               'Are you sure you want to delete this feed?',
+          'feedDeleted': 'Feed deleted',
           'explore': 'Explore',
           'topFeeds': 'Top Feeds',
           'mainFeed': 'This is the main feed',
@@ -568,6 +569,7 @@ class AppTranslations extends Translations {
           'deleteFeed': 'Eliminar Feed',
           'deleteFeedConfirmation':
               '¿Estás seguro de que deseas eliminar este feed?',
+          'feedDeleted': 'Feed eliminado',
           'explore': 'Explorar',
           'topFeeds': 'Feeds Populares',
           'mainFeed': 'Este es el feed principal',
@@ -957,6 +959,7 @@ class AppTranslations extends Translations {
           'deleteFeed': 'Eliminar Feed',
           'deleteFeedConfirmation':
               'Tens a certeza de que queres eliminar este feed?',
+          'feedDeleted': 'Feed eliminado',
           'explore': 'Explorar',
           'topFeeds': 'Feeds Populares',
           'mainFeed': 'Este é o feed principal',
@@ -1341,6 +1344,7 @@ class AppTranslations extends Translations {
           'deleteFeed': 'Excluir Feed',
           'deleteFeedConfirmation':
               'Tem certeza de que deseja excluir este feed?',
+          'feedDeleted': 'Feed excluído',
           'explore': 'Explorar',
           'topFeeds': 'Feeds Populares',
           'mainFeed': 'Este é o feed principal',

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -959,7 +959,7 @@ class AppTranslations extends Translations {
           'deleteFeed': 'Eliminar Feed',
           'deleteFeedConfirmation':
               'Tens a certeza de que queres eliminar este feed?',
-          'feedDeleted': 'Feed eliminado',
+          'feedDeleted': 'Feed removido',
           'explore': 'Explorar',
           'topFeeds': 'Feeds Populares',
           'mainFeed': 'Este é o feed principal',


### PR DESCRIPTION
## Summary
- add `feedDeleted` translation for multiple locales
- use new `feedDeleted` toast in feed editor

## Testing
- `flutter test` *(fails: DialogService prompt returns null on cancel)*

------
https://chatgpt.com/codex/tasks/task_e_688fbe7b8b7c8328bdf39932da28c675