### PR TITLE
Add LanguageService for locale management

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -8,6 +8,7 @@ import 'package:hoot/services/feed_request_service.dart';
 import 'package:hoot/services/subscription_manager.dart';
 import 'package:hoot/services/quick_actions_service.dart';
 import 'package:hoot/services/onesignal_service.dart';
+import 'package:hoot/services/language_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -26,6 +27,8 @@ class DependencyInjector {
     Get.put(OneSignalService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeSettings();
+    final language = Get.put(LanguageService(), permanent: true);
+    await language.loadLocale();
     await Get.find<OneSignalService>().init();
     await Get.find<QuickActionsService>().init();
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:toastification/toastification.dart';
 import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
 import 'package:timeago/timeago.dart' as timeago;
 import 'package:hoot/services/theme_service.dart';
+import 'package:hoot/services/language_service.dart';
 import 'package:hoot/firebase_options.dart';
 
 void main() {
@@ -37,10 +38,11 @@ void main() {
     await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
     FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
 
+    final languageService = Get.find<LanguageService>();
     TenorGifPicker.init(
       apiKey: dotenv.env['TENOR_API_KEY'] ?? '',
-      locale: Get.locale?.toLanguageTag() ?? 'en',
-      country: Get.deviceLocale?.countryCode ?? 'US',
+      locale: languageService.locale.value.toLanguageTag(),
+      country: languageService.locale.value.countryCode ?? 'US',
     );
 
     timeago.setLocaleMessages('es', timeago.EsMessages());
@@ -62,7 +64,7 @@ void main() {
               darkTheme: AppTheme.darkTheme(themeService.appColor.value.color),
               themeMode: themeService.themeMode.value,
               translations: AppTranslations(),
-              locale: Get.deviceLocale,
+              locale: languageService.locale.value,
               fallbackLocale: const Locale('en', 'US'),
               builder: (context, child) => GestureDetector(
                 behavior: HitTestBehavior.opaque,

--- a/lib/services/language_service.dart
+++ b/lib/services/language_service.dart
@@ -15,8 +15,18 @@ class LanguageService extends GetxService {
     final code = prefs.getString(_prefKeyLocale);
     if (code != null) {
       final parts = code.split('-');
-      locale.value = Locale(parts[0], parts.length > 1 ? parts[1] : null);
-    } else {
+      // Validate language code (must be non-empty and match [a-zA-Z]{2,3})
+      final languageCode = parts.isNotEmpty ? parts[0] : '';
+      final countryCode = parts.length > 1 ? parts[1] : null;
+      final isValidLanguage = RegExp(r'^[a-zA-Z]{2,3}$').hasMatch(languageCode);
+      if (isValidLanguage) {
+        locale.value = Locale.fromSubtags(
+          languageCode: languageCode,
+          countryCode: countryCode,
+        );
+      } else {
+        locale.value = const Locale('en', 'US');
+      }
       locale.value = Get.deviceLocale ?? const Locale('en', 'US');
     }
     Get.updateLocale(locale.value);

--- a/lib/services/language_service.dart
+++ b/lib/services/language_service.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Service responsible for managing and persisting the app's locale.
+class LanguageService extends GetxService {
+  static const _prefKeyLocale = 'locale';
+
+  /// Currently selected locale.
+  final locale = const Locale('en', 'US').obs;
+
+  /// Loads the saved locale or defaults to [Get.deviceLocale].
+  Future<void> loadLocale() async {
+    final prefs = await SharedPreferences.getInstance();
+    final code = prefs.getString(_prefKeyLocale);
+    if (code != null) {
+      final parts = code.split('-');
+      locale.value = Locale(parts[0], parts.length > 1 ? parts[1] : null);
+    } else {
+      locale.value = Get.deviceLocale ?? const Locale('en', 'US');
+    }
+    Get.updateLocale(locale.value);
+  }
+
+  /// Persists and applies the selected [newLocale].
+  Future<void> updateLocale(Locale newLocale) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefKeyLocale, newLocale.toLanguageTag());
+    locale.value = newLocale;
+    Get.updateLocale(newLocale);
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce `LanguageService` to persist and update app locale
- Register `LanguageService` during dependency injection startup
- Use `LanguageService` locale in `main.dart` for Tenor GIFs and `GetMaterialApp`

## Testing
- `flutter analyze` (fails: 22 issues found across repo)
- `flutter test` (fails: No file or variants found for asset: assets/.env)


------
https://chatgpt.com/codex/tasks/task_e_688fc4bcaccc8328a44952043f859847