### PR TITLE
Allow public feed access without subscription

### DIFF
--- a/lib/services/feed_service.dart
+++ b/lib/services/feed_service.dart
@@ -113,7 +113,7 @@ class FeedService implements BaseFeedService {
       return PostPage(posts: [], hasMore: false);
     }
     final ownerId = feedDoc.get('userId');
-    final isPrivate = feedDoc.data()?['private'] == true;
+    final isPrivate = feedDoc.data()?['private'] as bool? ?? false;
     if (isPrivate && ownerId != user.uid) {
       final subDoc = await _firestore
           .collection('users')

--- a/lib/services/feed_service.dart
+++ b/lib/services/feed_service.dart
@@ -113,7 +113,8 @@ class FeedService implements BaseFeedService {
       return PostPage(posts: [], hasMore: false);
     }
     final ownerId = feedDoc.get('userId');
-    if (ownerId != user.uid) {
+    final isPrivate = feedDoc.data()?['private'] == true;
+    if (isPrivate && ownerId != user.uid) {
       final subDoc = await _firestore
           .collection('users')
           .doc(user.uid)


### PR DESCRIPTION
## Summary
- Handle `private` flag when fetching feed posts so public feeds are accessible without subscriptions
- Test that public feeds are viewable without subscription and private feeds remain restricted

## Testing
- `flutter test` *(fails: `[core/no-app] No Firebase App '[DEFAULT]' has been created - call Firebase.initializeApp()`)*
- `flutter test test/feed_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_688fdb61459c8328a6a348427c122444