### PR TITLE
Scale post font size based on text length

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -187,12 +187,13 @@ class _PostComponentState extends State<PostComponent> {
     Get.toNamed(AppRoutes.post, arguments: _post);
   }
 
-  double _calculateFontSize(String text, double base) {
+  double _calculateFontSize(String? text, double base) {
     const double minFontSize = 16;
     const int threshold = 100;
     const int maxLength = 280;
-    if (text.length <= threshold) return base;
-    final ratio = ((text.length - threshold) / (maxLength - threshold))
+    final length = text?.length ?? 0;
+    if (length <= threshold) return base;
+    final ratio = ((length - threshold) / (maxLength - threshold))
         .clamp(0.0, 1.0);
     return base - (base - minFontSize) * ratio;
   }

--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -187,6 +187,16 @@ class _PostComponentState extends State<PostComponent> {
     Get.toNamed(AppRoutes.post, arguments: _post);
   }
 
+  double _calculateFontSize(String text, double base) {
+    const double minFontSize = 16;
+    const int threshold = 100;
+    const int maxLength = 280;
+    if (text.length <= threshold) return base;
+    final ratio = ((text.length - threshold) / (maxLength - threshold))
+        .clamp(0.0, 1.0);
+    return base - (base - minFontSize) * ratio;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(
@@ -364,7 +374,19 @@ class _PostComponentState extends State<PostComponent> {
                     const SizedBox(height: 16),
                     RichText(
                       text: TextSpan(
-                        style: Theme.of(context).textTheme.headlineSmall,
+                        style: Theme.of(context)
+                            .textTheme
+                            .headlineSmall
+                            ?.copyWith(
+                              fontSize: _calculateFontSize(
+                                _post.text!,
+                                Theme.of(context)
+                                        .textTheme
+                                        .headlineSmall
+                                        ?.fontSize ??
+                                    20,
+                              ),
+                            ),
                         children: parseMentions(_post.text!),
                       ),
                     ),


### PR DESCRIPTION
## Summary
- reduce post text font size as content grows
- add helper to compute dynamic size and apply it in post component

## Testing
- `flutter format lib/components/post_component.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fde812c54832889d055b2b21cfdb3