### PR TITLE
feat: add RSS topic mapping for feed types

### DIFF
--- a/lib/util/enums/feed_types.dart
+++ b/lib/util/enums/feed_types.dart
@@ -81,6 +81,29 @@ extension FeedTypeExtension on FeedType {
     return firstLetter.codeUnitAt(0);
   }
 
+  String? get rssTopic {
+    switch (this) {
+      case FeedType.general:
+        return 'WORLD';
+      case FeedType.news:
+        return 'NATION';
+      case FeedType.business:
+        return 'BUSINESS';
+      case FeedType.technology:
+        return 'TECHNOLOGY';
+      case FeedType.entertainment:
+        return 'ENTERTAINMENT';
+      case FeedType.science:
+        return 'SCIENCE';
+      case FeedType.sports:
+        return 'SPORTS';
+      case FeedType.health:
+        return 'HEALTH';
+      default:
+        return null;
+    }
+  }
+
   static String toTranslatedString(BuildContext context, FeedType type) {
     switch (type) {
       case FeedType.activism:


### PR DESCRIPTION
## Summary
- add `rssTopic` getter to `FeedTypeExtension`
- map supported feed types to Google News RSS topic codes

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*
- `dart test` *(fails: Could not find package `test` or file `test:test`)*
- `dart analyze lib/util/enums/feed_types.dart`


------
https://chatgpt.com/codex/tasks/task_e_688fe3989ae08328a78b2595eb961674