### PR TITLE
Use topic-based Google News RSS path

### DIFF
--- a/lib/services/news_service.dart
+++ b/lib/services/news_service.dart
@@ -40,10 +40,8 @@ class NewsService implements BaseNewsService {
       if (topic == null) {
         uri = Uri.https('news.google.com', '/rss', queryParameters);
       } else {
-        uri = Uri.https('news.google.com', '/rss/search', {
-          ...queryParameters,
-          'q': topic,
-        });
+        uri = Uri.https('news.google.com',
+            '/rss/headlines/section/topic/$topic', queryParameters);
       }
       final response = await _client.get(uri);
       if (response.statusCode != 200) {
@@ -51,9 +49,10 @@ class NewsService implements BaseNewsService {
       }
       final feed = RssFeed.parse(response.body);
       return feed.items
-              .where((i) => i.title != null && i.link != null)
-              .map((i) => NewsItem(title: i.title!.split(' - ').first, link: i.link!))
-              .toList();
+          .where((i) => i.title != null && i.link != null)
+          .map((i) =>
+              NewsItem(title: i.title!.split(' - ').first, link: i.link!))
+          .toList();
     } catch (_) {
       return [];
     }

--- a/test/news_service_test.dart
+++ b/test/news_service_test.dart
@@ -19,8 +19,26 @@ void main() {
     language.locale.value = const Locale('en', 'US');
     final service = NewsService(client: client, languageService: language);
     await service.fetchTrendingNews();
-    expect(requested.toString(),
-        'https://news.google.com/rss?hl=en-US&gl=US&ceid=US:en');
+    expect(
+        requested,
+        Uri.https('news.google.com', '/rss',
+            {'hl': 'en-US', 'gl': 'US', 'ceid': 'US:en'}));
+  });
+
+  test('uses topic path when topic is provided', () async {
+    Uri? requested;
+    final client = MockClient((request) async {
+      requested = request.url;
+      return http.Response('<rss><channel></channel></rss>', 200);
+    });
+    final language = LanguageService();
+    language.locale.value = const Locale('en', 'US');
+    final service = NewsService(client: client, languageService: language);
+    await service.fetchTrendingNews(topic: 'TECHNOLOGY');
+    expect(
+        requested,
+        Uri.https('news.google.com', '/rss/headlines/section/topic/TECHNOLOGY',
+            {'hl': 'en-US', 'gl': 'US', 'ceid': 'US:en'}));
   });
 
   test('parses feed items', () async {


### PR DESCRIPTION
## Summary
- Fetch topic-specific Google News RSS headlines when a topic is provided
- Add unit tests verifying constructed Google News URLs

## Testing
- `flutter test --no-test-assets test/news_service_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68905539779c83288316ccce53d38f4e