### PR TITLE
feat: localize trending news by topic

### DIFF
--- a/lib/pages/create_post/views/create_post_view.dart
+++ b/lib/pages/create_post/views/create_post_view.dart
@@ -234,20 +234,7 @@ class CreatePostView extends GetView<CreatePostController> {
                                     bottom: 0,
                                   ),
                                   child: Text(
-                                    () {
-                                      final feed =
-                                          controller.selectedFeeds.isNotEmpty
-                                              ? controller.selectedFeeds.last
-                                              : null;
-                                      final type = feed?.type;
-                                      if (type?.rssTopic != null) {
-                                        final translatedType = FeedTypeExtension
-                                            .toTranslatedString(context, type!);
-                                        return 'trendingIn'.trParams(
-                                            {'topic': translatedType});
-                                      }
-                                      return 'trendingNews'.tr;
-                                    }(),
+                                    _getTrendingTitle(context),
                                     style:
                                         Theme.of(context).textTheme.titleMedium,
                                   ),

--- a/lib/pages/create_post/views/create_post_view.dart
+++ b/lib/pages/create_post/views/create_post_view.dart
@@ -13,6 +13,7 @@ import 'package:hoot/components/url_preview_component.dart';
 import 'package:hoot/models/feed.dart';
 import 'package:hoot/pages/home/controllers/home_controller.dart';
 import 'package:hoot/pages/feed/controllers/feed_controller.dart';
+import 'package:hoot/util/enums/feed_types.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class CreatePostView extends GetView<CreatePostController> {
@@ -90,8 +91,8 @@ class CreatePostView extends GetView<CreatePostController> {
                                               const Icon(
                                                   SolarIconsBold.checkSquare)
                                             else
-                                              const Icon(SolarIconsOutline
-                                                  .addSquare),
+                                              const Icon(
+                                                  SolarIconsOutline.addSquare),
                                             const SizedBox(width: 16),
                                             Expanded(
                                               child: Text(
@@ -233,7 +234,20 @@ class CreatePostView extends GetView<CreatePostController> {
                                     bottom: 0,
                                   ),
                                   child: Text(
-                                    'trendingNews'.tr,
+                                    () {
+                                      final feed =
+                                          controller.selectedFeeds.isNotEmpty
+                                              ? controller.selectedFeeds.last
+                                              : null;
+                                      final type = feed?.type;
+                                      if (type?.rssTopic != null) {
+                                        final translatedType = FeedTypeExtension
+                                            .toTranslatedString(context, type!);
+                                        return 'trendingIn'.trParams(
+                                            {'topic': translatedType});
+                                      }
+                                      return 'trendingNews'.tr;
+                                    }(),
                                     style:
                                         Theme.of(context).textTheme.titleMedium,
                                   ),

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -397,6 +397,7 @@ class AppTranslations extends Translations {
           'report': 'Report',
           'reportReasonRequired': 'Report reason required',
           'trendingNews': 'Trending News',
+          'trendingIn': 'Trending in @topic',
         },
         'es': {
           'helloWorld': '¡Hola Mundo!',
@@ -798,6 +799,7 @@ class AppTranslations extends Translations {
           'report': 'Reportar',
           'reportReasonRequired': 'Se requiere un motivo',
           'trendingNews': 'Noticias de Tendencia',
+          'trendingIn': 'Tendencias en @topic',
         },
         'pt_PT': {
           'helloWorld': 'Olá Mundo!',
@@ -1201,6 +1203,7 @@ class AppTranslations extends Translations {
           'report': 'Reportar',
           'reportReasonRequired': 'É necessário fornecer uma razão',
           'trendingNews': 'Notícias em Alta',
+          'trendingIn': 'Em Alta em @topic',
         },
         'pt_BR': {
           'helloWorld': 'Olá Mundo!',
@@ -1600,6 +1603,7 @@ class AppTranslations extends Translations {
           'report': 'Denunciar',
           'reportReasonRequired': 'É necessário fornecer um motivo',
           'trendingNews': 'Notícias em Alta',
+          'trendingIn': 'Em Alta em @topic',
         },
       };
 }

--- a/test/create_post_view_test.dart
+++ b/test/create_post_view_test.dart
@@ -16,6 +16,7 @@ import 'package:hoot/services/storage_service.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/services/news_service.dart';
 import 'package:hoot/util/translations/app_translations.dart';
+import 'package:hoot/util/enums/feed_types.dart';
 
 class FakeAuthService extends GetxService implements AuthService {
   final U _user;
@@ -70,16 +71,18 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   Get.testMode = true;
 
-  testWidgets('renders trending news titles', (tester) async {
+  testWidgets('renders dynamic trending title', (tester) async {
     final firestore = FakeFirebaseFirestore();
     final postService = PostService(firestore: firestore);
     final feed = Feed(
-        id: 'f1',
-        userId: 'u1',
-        title: 't',
-        description: 'd',
-        color: Colors.blue,
-        order: 0);
+      id: 'f1',
+      userId: 'u1',
+      title: 't',
+      description: 'd',
+      color: Colors.blue,
+      order: 0,
+      type: FeedType.technology,
+    );
     final auth = FakeAuthService(U(
         uid: 'u1',
         name: 'Tester',
@@ -94,6 +97,7 @@ void main() {
         newsService: FakeNewsService(
             [NewsItem(title: 'News 1', link: 'https://a.com')]));
     Get.put(controller);
+    controller.selectedFeeds.assignAll([feed]);
     await tester.pumpWidget(Portal(
       child: GetMaterialApp(
         translations: AppTranslations(),
@@ -102,10 +106,9 @@ void main() {
       ),
     ));
     await tester.pump();
-    await tester.pump();
     await tester.pumpAndSettle();
+    expect(find.text('Trending in Technology'), findsOneWidget);
     expect(find.text('News 1'), findsOneWidget);
-    await tester.pumpAndSettle();
     Get.reset();
   }, skip: true);
 }


### PR DESCRIPTION
## Summary
- Show a contextual "Trending in {topic}" header when topic-specific news is available
- Add `trendingIn` translations for English, Spanish, and Portuguese locales
- Expand create post view test to expect the dynamic trending title

## Testing
- `flutter test test/create_post_view_test.dart` *(all tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68905935961083289792334f419c9069