### PR TITLE
test: verify news topic locale and feed refresh

### DIFF
--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -506,7 +506,6 @@ void main() {
       controller.selectedFeeds[0] = scienceFeed;
       controller.selectedFeeds.refresh();
       await tester.pump();
-      expect(news.calls[1], 'TECHNOLOGY');
       expect(news.calls.last, 'SCIENCE');
       expect(controller.trendingNews.first.title, 'Science');
     });

--- a/test/create_post_controller_test.dart
+++ b/test/create_post_controller_test.dart
@@ -449,6 +449,68 @@ void main() {
       expect(controller.trendingNews.first.title, 'General');
     });
 
+    testWidgets('switching selected feed refreshes headlines', (tester) async {
+      final firestore = FakeFirebaseFirestore();
+      final postService = PostService(
+        firestore: firestore,
+      );
+      final techFeed = Feed(
+          id: 'f1',
+          userId: 'u1',
+          title: 'tech',
+          description: 'd',
+          color: Colors.blue,
+          order: 0,
+          type: FeedType.technology);
+      final scienceFeed = Feed(
+          id: 'f2',
+          userId: 'u1',
+          title: 'science',
+          description: 'd',
+          color: Colors.red,
+          order: 0,
+          type: FeedType.science);
+      final auth = FakeAuthService(U(
+          uid: 'u1',
+          name: 'Tester',
+          username: 'tester',
+          smallProfilePictureUrl: 'a.png',
+          feeds: [techFeed, scienceFeed]));
+      final storage = FakeStorageService();
+      final generalNews =
+          [NewsItem(title: 'General', link: 'https://example.com')];
+      final techNews = [NewsItem(title: 'Tech', link: 'https://tech.com')];
+      final scienceNews =
+          [NewsItem(title: 'Science', link: 'https://science.com')];
+      final news = FakeNewsService(topicItems: {
+        null: generalNews,
+        'TECHNOLOGY': techNews,
+        'SCIENCE': scienceNews,
+      });
+      final controller = CreatePostController(
+          postService: postService,
+          authService: auth,
+          userId: 'u1',
+          storageService: storage,
+          newsService: news);
+      controller.onInit();
+      await tester.pump();
+      expect(news.calls, [null]);
+      expect(controller.trendingNews.first.title, 'General');
+
+      controller.selectedFeeds.add(techFeed);
+      await tester.pump();
+      expect(news.calls, [null, 'TECHNOLOGY']);
+      expect(controller.trendingNews.first.title, 'Tech');
+
+      controller.selectedFeeds[0] = scienceFeed;
+      controller.selectedFeeds.refresh();
+      await tester.pump();
+      expect(news.calls[1], 'TECHNOLOGY');
+      expect(news.calls.last, 'SCIENCE');
+      expect(controller.trendingNews.first.title, 'Science');
+    });
+
     testWidgets('falls back to general news when topic returns empty',
         (tester) async {
       final firestore = FakeFirebaseFirestore();

--- a/test/news_service_test.dart
+++ b/test/news_service_test.dart
@@ -41,6 +41,22 @@ void main() {
             {'hl': 'en-US', 'gl': 'US', 'ceid': 'US:en'}));
   });
 
+  test('adds locale parameters for topic requests', () async {
+    Uri? requested;
+    final client = MockClient((request) async {
+      requested = request.url;
+      return http.Response('<rss><channel></channel></rss>', 200);
+    });
+    final language = LanguageService();
+    language.locale.value = const Locale('es', 'MX');
+    final service = NewsService(client: client, languageService: language);
+    await service.fetchTrendingNews(topic: 'WORLD');
+    expect(
+        requested,
+        Uri.https('news.google.com', '/rss/headlines/section/topic/WORLD',
+            {'hl': 'es-MX', 'gl': 'MX', 'ceid': 'MX:es'}));
+  });
+
   test('parses feed items', () async {
     const rss =
         '<rss version="2.0"><channel><item><title>Title 1</title><link>https://example.com/1</link></item></channel></rss>';


### PR DESCRIPTION
## Summary
- add coverage for locale parameters on topic news requests
- ensure CreatePostController refreshes headlines when switching feeds

## Testing
- `flutter test test/news_service_test.dart test/create_post_controller_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_68905cfa33fc8328986d6adb87b02b31