### PR TITLE
Add feedback option in settings

### DIFF
--- a/lib/pages/settings/controllers/settings_controller.dart
+++ b/lib/pages/settings/controllers/settings_controller.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:flutter_contacts/flutter_contacts.dart';
+import 'package:feedback/feedback.dart';
 
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/services/dialog_service.dart';
@@ -76,6 +77,10 @@ class SettingsController extends GetxController {
       return;
     }
     Get.toNamed(AppRoutes.contacts);
+  }
+
+  void sendFeedback(BuildContext ctx) {
+    BetterFeedback.of(ctx).show((UserFeedback feedback) {});
   }
 
   Future<void> deleteAccount(BuildContext context) async {

--- a/lib/pages/settings/views/settings_view.dart
+++ b/lib/pages/settings/views/settings_view.dart
@@ -172,6 +172,12 @@ class SettingsView extends GetView<SettingsController> {
                         ),
                       ],
                     ),
+                    ListTile(
+                      leading: const Icon(SolarIconsOutline.bug),
+                      title: Text('sendFeedback'.tr),
+                      trailing: const Icon(SolarIconsOutline.arrowRight),
+                      onTap: () => controller.sendFeedback(context),
+                    ),
                     Obx(
                       () => ListTile(
                         leading: const Icon(SolarIconsOutline.infoSquare),

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -329,6 +329,7 @@ class AppTranslations extends Translations {
           'portugueseBrazil': 'Portuguese (Brazil)',
           'appColor': 'App Color',
           'resetColor': 'Revert to default color',
+          'sendFeedback': 'Send Feedback',
           'version': 'Version',
           'deleteAccount': 'Delete Account',
           'deleteAccountDescription':
@@ -731,6 +732,7 @@ class AppTranslations extends Translations {
           'portugueseBrazil': 'Portugués (Brasil)',
           'appColor': 'Color de la App',
           'resetColor': 'Restablecer color por defecto',
+          'sendFeedback': 'Enviar comentarios',
           'version': 'Versión',
           'deleteAccount': 'Eliminar Cuenta',
           'deleteAccountDescription':
@@ -1134,6 +1136,7 @@ class AppTranslations extends Translations {
           'portugueseBrazil': 'Português (Brasil)',
           'appColor': 'Cor da App',
           'resetColor': 'Repor cor padrão',
+          'sendFeedback': 'Enviar feedback',
           'version': 'Versão',
           'deleteAccount': 'Eliminar Conta',
           'deleteAccountDescription':
@@ -1534,6 +1537,7 @@ class AppTranslations extends Translations {
           'portugueseBrazil': 'Português (Brasil)',
           'appColor': 'Cor do App',
           'resetColor': 'Restaurar cor padrão',
+          'sendFeedback': 'Enviar feedback',
           'version': 'Versão',
           'deleteAccount': 'Excluir Conta',
           'deleteAccountDescription':


### PR DESCRIPTION
## Summary
- add `sendFeedback` method to launch BetterFeedback UI
- expose a "Send Feedback" tile in Settings
- localize new feedback label

## Testing
- `flutter analyze` *(fails: asset file 'assets/.env' doesn't exist)*
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_68908701696c8328b542c231bd8971ad