### PR TITLE
feat: add feedback submission endpoint

### DIFF
--- a/functions/src/feedback.ts
+++ b/functions/src/feedback.ts
@@ -1,0 +1,15 @@
+import { onCall } from "firebase-functions/v2/https";
+import { FieldValue } from "firebase-admin/firestore";
+import { db } from "./config";
+
+export const submitFeedback = onCall(async (request) => {
+  const screenshot = request.data.screenshot as string | undefined;
+  const message = request.data.message as string | undefined;
+  await db.collection("feedback").add({
+    screenshot,
+    message,
+    userId: request.auth?.uid ?? null,
+    createdAt: FieldValue.serverTimestamp(),
+  });
+  return { success: true };
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,3 +9,4 @@ export * from "./triggers/onUserUpdated";
 export * from "./triggers/onFeedUpdated";
 export * from "./triggers/onInvitationUsed";
 export * from "./triggers/onReportCreated";
+export * from "./feedback";

--- a/lib/pages/settings/controllers/settings_controller.dart
+++ b/lib/pages/settings/controllers/settings_controller.dart
@@ -12,6 +12,7 @@ import 'package:hoot/services/error_service.dart';
 import 'package:hoot/services/toast_service.dart';
 import 'package:hoot/services/theme_service.dart';
 import 'package:hoot/services/language_service.dart';
+import 'package:hoot/services/feedback_service.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 
 class SettingsController extends GetxController {
@@ -80,7 +81,16 @@ class SettingsController extends GetxController {
   }
 
   void sendFeedback(BuildContext ctx) {
-    BetterFeedback.of(ctx).show((UserFeedback feedback) {});
+    BetterFeedback.of(ctx).show((UserFeedback feedback) async {
+      try {
+        await FeedbackService.submitFeedback(
+          screenshot: feedback.screenshot,
+          message: feedback.feedback,
+        );
+      } catch (e, s) {
+        await ErrorService.reportError(e, stack: s);
+      }
+    });
   }
 
   Future<void> deleteAccount(BuildContext context) async {

--- a/lib/services/feedback_service.dart
+++ b/lib/services/feedback_service.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cloud_functions/cloud_functions.dart';
+
+/// Service to submit user feedback such as screenshots and comments.
+class FeedbackService {
+  FeedbackService._();
+
+  static final _functions = FirebaseFunctions.instance;
+
+  /// Sends [screenshot] and [message] to the backend Cloud Function.
+  static Future<void> submitFeedback({
+    required Uint8List screenshot,
+    required String message,
+  }) async {
+    final callable = _functions.httpsCallable('submitFeedback');
+    await callable.call(<String, dynamic>{
+      'screenshot': base64Encode(screenshot),
+      'message': message,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add feedback service to send screenshots and messages to Cloud Functions
- wire settings feedback action to new service
- expose Cloud Function endpoint to store feedback

## Testing
- `npm test` *(fails: Could not find '/workspace/Hoot/functions/lib/**/*.test.js')*
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*


------
https://chatgpt.com/codex/tasks/task_e_68909278d77c8328bf08b2c42bb11c57