### PR TITLE
Add feedback stats to staff dashboard

### DIFF
--- a/lib/pages/staff_dashboard/controllers/staff_dashboard_controller.dart
+++ b/lib/pages/staff_dashboard/controllers/staff_dashboard_controller.dart
@@ -10,6 +10,7 @@ class StaffDashboardController extends GetxController {
                 ? Get.find<BaseStatsService>()
                 : StatsService());
 
+  /// Aggregated statistics including feedback counts.
   final Rx<Stats?> stats = Rx<Stats?>(null);
   final RxBool loading = false.obs;
 

--- a/lib/pages/staff_dashboard/views/staff_dashboard_view.dart
+++ b/lib/pages/staff_dashboard/views/staff_dashboard_view.dart
@@ -42,6 +42,11 @@ class StaffDashboardView extends GetView<StaffDashboardController> {
               title: Text('reports'.tr),
               trailing: Text('${stats.reportsCount}'),
             ),
+            ListTile(
+              leading: const Icon(Icons.feedback),
+              title: Text('feedbacks'.tr),
+              trailing: Text('${stats.feedbackCount}'),
+            ),
           ],
         );
       }),

--- a/lib/services/stats_service.dart
+++ b/lib/services/stats_service.dart
@@ -6,12 +6,14 @@ class Stats {
   final int activeUsers;
   final int uninvitedUsers;
   final int reportsCount;
+  final int feedbackCount;
 
   Stats({
     required this.totalUsers,
     required this.activeUsers,
     required this.uninvitedUsers,
     required this.reportsCount,
+    required this.feedbackCount,
   });
 }
 
@@ -40,13 +42,20 @@ class StatsService implements BaseStatsService {
           .where('resolved', isEqualTo: false)
           .get(),
       // Uninvited users: invitationCode is null
-      _firestore.collection('users').where('invitationCode', isNull: true).get(),
+      _firestore
+          .collection('users')
+          .where('invitationCode', isNull: true)
+          .get(),
       // Uninvited users: invitationCode is empty string
-      _firestore.collection('users').where('invitationCode', isEqualTo: '').get(),
+      _firestore
+          .collection('users')
+          .where('invitationCode', isEqualTo: '')
+          .get(),
       // Uninvited users: invitedBy is null
       _firestore.collection('users').where('invitedBy', isNull: true).get(),
       // Uninvited users: invitedBy is empty string
       _firestore.collection('users').where('invitedBy', isEqualTo: '').get(),
+      _firestore.collection('feedback').get(),
     ]);
 
     final usersSnapshot = results[0];
@@ -65,6 +74,7 @@ class StatsService implements BaseStatsService {
       activeUsers: results[1].size,
       reportsCount: results[2].size,
       uninvitedUsers: uninvitedUsers,
+      feedbackCount: results[7].size,
     );
   }
 }


### PR DESCRIPTION
## Summary
- include feedback count in aggregated stats
- surface feedback totals on staff dashboard
- document controller stats to mention feedback counts

## Testing
- `flutter test` *(fails: A test overrode FlutterError.onError but did not restore it; swiping left opens create post page)*

------
https://chatgpt.com/codex/tasks/task_e_6890a2be024c8328bc97c50d80056c42