### PR TITLE
fix: preserve saved locale

### DIFF
--- a/lib/services/language_service.dart
+++ b/lib/services/language_service.dart
@@ -27,6 +27,7 @@ class LanguageService extends GetxService {
       } else {
         locale.value = const Locale('en', 'US');
       }
+    } else {
       locale.value = Get.deviceLocale ?? const Locale('en', 'US');
     }
     Get.updateLocale(locale.value);


### PR DESCRIPTION
## Summary
- avoid resetting saved locale back to device default on load

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*
- `flutter analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*

------
https://chatgpt.com/codex/tasks/task_e_6890b8638f548328bfa765e629155607