### PR TITLE
refactor: use AuthService in auth middleware

### DIFF
--- a/lib/middleware/auth_middleware.dart
+++ b/lib/middleware/auth_middleware.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 
+import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 
 /// Middleware that redirects unauthenticated users to the login page.
@@ -19,8 +19,8 @@ class AuthMiddleware extends GetMiddleware {
       return null; // Allow access to open routes
     }
 
-    final user = FirebaseAuth.instance.currentUser;
-    if (user == null || user.isAnonymous) {
+    final user = Get.find<AuthService>().currentUser;
+    if (user == null) {
       return RouteSettings(
         name: AppRoutes.login,
       );

--- a/lib/middleware/auth_middleware.dart
+++ b/lib/middleware/auth_middleware.dart
@@ -20,7 +20,7 @@ class AuthMiddleware extends GetMiddleware {
     }
 
     final user = Get.find<AuthService>().currentUser;
-    if (user == null) {
+    if (user == null || (user.isAnonymous == true)) {
       return RouteSettings(
         name: AppRoutes.login,
       );


### PR DESCRIPTION
## Summary
- inject AuthService into auth middleware
- redirect to login when AuthService has no current user

## Testing
- `dart analyze lib/middleware/auth_middleware.dart`
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_6890c04d70b88328a17a135938de2927