### PR TITLE
Use AuthService for welcome flow

### DIFF
--- a/lib/pages/welcome/controllers/welcome_controller.dart
+++ b/lib/pages/welcome/controllers/welcome_controller.dart
@@ -1,6 +1,5 @@
 import 'package:get/get.dart';
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/services/toast_service.dart';
@@ -34,7 +33,7 @@ class WelcomeController extends GetxController {
       ToastService.showError('displayNameTooShort'.tr);
       return false;
     }
-    final uid = FirebaseAuth.instance.currentUser?.uid;
+    final uid = _auth.currentUser?.uid;
     if (uid == null) return false;
 
     final user = _auth.currentUser;
@@ -70,7 +69,7 @@ class WelcomeController extends GetxController {
       return false;
     }
 
-    final uid = FirebaseAuth.instance.currentUser?.uid;
+    final uid = _auth.currentUser?.uid;
     if (uid == null) return false;
     final user = _auth.currentUser;
     if (user != null) {

--- a/test/welcome_controller_test.dart
+++ b/test/welcome_controller_test.dart
@@ -6,6 +6,27 @@ import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/pages/welcome/controllers/welcome_controller.dart';
 import 'package:hoot/models/user.dart';
+import 'package:hoot/services/user_service.dart';
+
+class _FakeUserService implements BaseUserService {
+  String? lastUid;
+  Map<String, dynamic>? lastData;
+  bool usernameAvailable = true;
+
+  @override
+  Future<void> updateUserData(String uid, Map<String, dynamic> data) async {
+    lastUid = uid;
+    lastData = data;
+  }
+
+  @override
+  Future<bool> isUsernameAvailable(String username) async {
+    return usernameAvailable;
+  }
+
+  @override
+  Future<List<U>> searchUsers(String query) async => [];
+}
 
 void main() {
   setUp(() {
@@ -21,13 +42,56 @@ void main() {
       auth: MockFirebaseAuth(),
       firestore: FakeFirebaseFirestore(),
     );
-    authService.currentUserRx.value = U(uid: 'u1', name: 'Jane');
+    authService.currentUserRx.value = U(uid: 'u1');
+    authService.displayName = 'Jane';
     Get.put<AuthService>(authService);
 
-    final controller = WelcomeController();
+    final controller = WelcomeController(userService: _FakeUserService());
     controller.onInit();
 
     expect(controller.displayNameController.text, 'Jane');
+
+    controller.onClose();
+  });
+
+  test('saveDisplayName uses AuthService uid', () async {
+    final authService = AuthService(
+      auth: MockFirebaseAuth(),
+      firestore: FakeFirebaseFirestore(),
+    );
+    authService.currentUserRx.value = U(uid: 'u1');
+    Get.put<AuthService>(authService);
+    final userService = _FakeUserService();
+
+    final controller = WelcomeController(userService: userService);
+    controller.displayNameController.text = 'Jane';
+    final result = await controller.saveDisplayName();
+
+    expect(result, isTrue);
+    expect(userService.lastUid, 'u1');
+    expect(userService.lastData?['displayName'], 'Jane');
+    expect(authService.currentUser?.name, 'Jane');
+
+    controller.onClose();
+  });
+
+  test('saveUsername uses AuthService uid', () async {
+    final authService = AuthService(
+      auth: MockFirebaseAuth(),
+      firestore: FakeFirebaseFirestore(),
+    );
+    authService.currentUserRx.value = U(uid: 'u1');
+    Get.put<AuthService>(authService);
+    final userService = _FakeUserService();
+
+    final controller = WelcomeController(userService: userService);
+    controller.usernameController.text = 'jane_doe';
+    final result = await controller.saveUsername();
+
+    expect(result, isTrue);
+    expect(userService.lastUid, 'u1');
+    expect(userService.lastData?['username'], 'jane_doe');
+    expect(authService.currentUser?.username, 'jane_doe');
 
     controller.onClose();
   });


### PR DESCRIPTION
## Summary
- Retrieve uid from AuthService instead of FirebaseAuth in welcome flow
- Test display-name and username save flows using AuthService

## Testing
- `flutter test test/welcome_controller_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_6890d30040f48328ab6f037d2a64932a