### PR TITLE
refactor: inject firestore auth and storage

### DIFF
--- a/lib/pages/feed_editor/bindings/feed_editor_binding.dart
+++ b/lib/pages/feed_editor/bindings/feed_editor_binding.dart
@@ -1,9 +1,24 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 import 'package:get/get.dart';
+
 import 'package:hoot/pages/feed_editor/controllers/feed_editor_controller.dart';
+import 'package:hoot/services/auth_service.dart';
 
 class FeedEditorBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut(() => FeedEditorController());
+    final authService = Get.find<AuthService>();
+    final bool isMock = authService.runtimeType.toString().contains('Mock');
+    final FirebaseFirestore firestore =
+        isMock ? FakeFirebaseFirestore() : FirebaseFirestore.instance;
+    final FirebaseStorage storage = FirebaseStorage.instance;
+
+    Get.lazyPut(() => FeedEditorController(
+          firestore: firestore,
+          authService: authService,
+          storage: storage,
+        ));
   }
 }

--- a/lib/pages/feed_editor/controllers/feed_editor_controller.dart
+++ b/lib/pages/feed_editor/controllers/feed_editor_controller.dart
@@ -3,7 +3,6 @@ import 'dart:typed_data';
 
 import 'package:blurhash/blurhash.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
@@ -23,6 +22,7 @@ import 'package:hoot/util/constants.dart';
 class FeedEditorController extends GetxController {
   final FirebaseFirestore _firestore;
   final AuthService _authService;
+  final FirebaseStorage _storage;
   final ProfileController? _profileController;
   final String _userId;
 
@@ -30,18 +30,20 @@ class FeedEditorController extends GetxController {
   Feed? feed;
 
   FeedEditorController({
-    FirebaseFirestore? firestore,
-    AuthService? authService,
+    required FirebaseFirestore firestore,
+    required AuthService authService,
+    required FirebaseStorage storage,
     ProfileController? profileController,
     String? userId,
     this.feed,
-  })  : _firestore = firestore ?? FirebaseFirestore.instance,
-        _authService = authService ?? Get.find<AuthService>(),
+  })  : _firestore = firestore,
+        _authService = authService,
+        _storage = storage,
         _profileController = profileController ??
             (Get.isRegistered<ProfileController>(tag: 'current')
                 ? Get.find<ProfileController>(tag: 'current')
                 : null),
-        _userId = userId ?? FirebaseAuth.instance.currentUser?.uid ?? '';
+        _userId = userId ?? authService.currentUser?.uid ?? '';
 
   /// Controllers for title/description fields and genre search.
   final TextEditingController titleController = TextEditingController();
@@ -144,10 +146,8 @@ class FeedEditorController extends GetxController {
         smallAvatarHash =
             await BlurHash.encode(smallData, kBlurHashX, kBlurHashY);
         bigAvatarHash = await BlurHash.encode(bigData, kBlurHashX, kBlurHashY);
-        final storageRef = FirebaseStorage.instance
-            .ref()
-            .child('feed_avatars')
-            .child(docRef.id);
+        final storageRef =
+            _storage.ref().child('feed_avatars').child(docRef.id);
         final smallRef = storageRef.child('small_avatar.jpg');
         final bigRef = storageRef.child('big_avatar.jpg');
         await smallRef.putData(
@@ -239,10 +239,7 @@ class FeedEditorController extends GetxController {
         smallAvatarHash =
             await BlurHash.encode(smallData, kBlurHashX, kBlurHashY);
         bigAvatarHash = await BlurHash.encode(bigData, kBlurHashX, kBlurHashY);
-        final storageRef = FirebaseStorage.instance
-            .ref()
-            .child('feed_avatars')
-            .child(feed!.id);
+        final storageRef = _storage.ref().child('feed_avatars').child(feed!.id);
         final smallRef = storageRef.child('small_avatar.jpg');
         final bigRef = storageRef.child('big_avatar.jpg');
         await smallRef.putData(

--- a/test/feed_editor_controller_test.dart
+++ b/test/feed_editor_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:toastification/toastification.dart';
 import 'package:get/get.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:firebase_storage/firebase_storage.dart';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hoot/models/feed.dart';
@@ -68,6 +69,8 @@ class FakeAuthService extends GetxService implements AuthService {
   bool get isStaff => throw UnimplementedError();
 }
 
+class FakeFirebaseStorage extends Fake implements FirebaseStorage {}
+
 class FakeFeedService implements BaseFeedService {
   @override
   Future<PostPage> fetchSubscribedPosts({
@@ -98,7 +101,10 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
     final controller = FeedEditorController(
-        firestore: firestore, userId: 'u1', authService: auth);
+        firestore: firestore,
+        userId: 'u1',
+        authService: auth,
+        storage: FakeFirebaseStorage());
     controller.titleController.text = 'My Feed';
     controller.descriptionController.text = 'Desc';
     controller.selectedType.value = FeedType.music;
@@ -122,7 +128,10 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
     final controller = FeedEditorController(
-        firestore: firestore, userId: 'u1', authService: auth);
+        firestore: firestore,
+        userId: 'u1',
+        authService: auth,
+        storage: FakeFirebaseStorage());
     controller.selectedType.value = FeedType.music;
 
     final result = await controller.submit();
@@ -142,7 +151,10 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
     final controller = FeedEditorController(
-        firestore: firestore, userId: 'u1', authService: auth);
+        firestore: firestore,
+        userId: 'u1',
+        authService: auth,
+        storage: FakeFirebaseStorage());
     controller.titleController.text = 'Feed';
 
     final result = await controller.submit();
@@ -192,7 +204,8 @@ void main() {
         firestore: firestore,
         userId: 'u1',
         authService: auth,
-        profileController: profile);
+        profileController: profile,
+        storage: FakeFirebaseStorage());
     controller.titleController.text = 'My Feed';
     controller.selectedType.value = FeedType.music;
 
@@ -215,7 +228,10 @@ void main() {
     final firestore = FakeFirebaseFirestore();
     final auth = FakeAuthService(U(uid: 'u1'));
     final controller = FeedEditorController(
-        firestore: firestore, userId: 'u1', authService: auth);
+        firestore: firestore,
+        userId: 'u1',
+        authService: auth,
+        storage: FakeFirebaseStorage());
     controller.titleController.text = 'My Feed';
     controller.selectedType.value = FeedType.music;
 
@@ -266,7 +282,11 @@ void main() {
     final auth = FakeAuthService(user);
 
     final controller = FeedEditorController(
-        firestore: firestore, authService: auth, feed: feed, userId: 'u1');
+        firestore: firestore,
+        authService: auth,
+        feed: feed,
+        userId: 'u1',
+        storage: FakeFirebaseStorage());
     controller.onInit();
     controller.titleController.text = 'New';
 


### PR DESCRIPTION
## Summary
- refactor FeedEditorController to receive FirebaseFirestore, AuthService, and FirebaseStorage via constructor
- inject FakeFirebaseFirestore in FeedEditorBinding when running under mock services
- update FeedEditorController tests to provide fake storage

## Testing
- `flutter test test/feed_editor_controller_test.dart`
- `flutter test` *(fails: DialogService prompt returns null on cancel)*
- `flutter analyze` *(issues found)*


------
https://chatgpt.com/codex/tasks/task_e_6890d89a87b08328b1eba96c6092e880