### PR TITLE
refactor: simplify invitation uid retrieval

### DIFF
--- a/lib/pages/invitation/controllers/invitation_controller.dart
+++ b/lib/pages/invitation/controllers/invitation_controller.dart
@@ -1,6 +1,5 @@
 import 'package:get/get.dart';
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/services/invitation_service.dart';
@@ -35,9 +34,11 @@ class InvitationController extends GetxController {
     if (code.isEmpty) return;
     verifying.value = true;
     try {
-      final uid = _authService.currentUser?.uid ??
-          FirebaseAuth.instance.currentUser?.uid;
-      if (uid == null) return;
+      final uid = _authService.currentUser?.uid;
+      if (uid == null) {
+        ToastService.showError('somethingWentWrong'.tr);
+        return;
+      }
       final success = await _invitationService.useInvitationCode(uid, code);
       if (success) {
         await _authService.refreshUser();


### PR DESCRIPTION
## Summary
- rely solely on `AuthService` for current user id during invitation verification
- show error toast when no user id is available

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*


------
https://chatgpt.com/codex/tasks/task_e_6890e39ae27083289e3bd2a117a88304