### PR TITLE
feat(mock): add notification and feed request mocks

### DIFF
--- a/lib/pages/notifications/controllers/notifications_controller.dart
+++ b/lib/pages/notifications/controllers/notifications_controller.dart
@@ -19,7 +19,8 @@ class NotificationsController extends GetxController {
     BaseNotificationService? notificationService,
     FeedRequestService? feedRequestService,
   })  : _authService = authService ?? Get.find<AuthService>(),
-        _notificationService = notificationService ?? NotificationService(),
+        _notificationService =
+            notificationService ?? Get.find<BaseNotificationService>(),
         _feedRequestService =
             feedRequestService ?? Get.find<FeedRequestService>();
 

--- a/mock/mock_dependency_injector.dart
+++ b/mock/mock_dependency_injector.dart
@@ -1,11 +1,20 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:get/get.dart';
-import 'package:hoot/services/theme_service.dart';
-import 'package:hoot/services/feed_service.dart';
-import 'package:hoot/services/post_service.dart';
-import 'services/mock_auth_service.dart';
-import 'services/mock_feed_service.dart';
-import 'services/mock_post_service.dart';
 import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/feed_service.dart';
+import 'package:hoot/services/notification_service.dart';
+import 'package:hoot/services/post_service.dart';
+import 'package:hoot/services/subscription_manager.dart';
+import 'package:hoot/services/subscription_service.dart';
+import 'package:hoot/services/theme_service.dart';
+
+import 'services/mock_auth_service.dart';
+import 'services/mock_feed_request_service.dart';
+import 'services/mock_feed_service.dart';
+import 'services/mock_notification_service.dart';
+import 'services/mock_post_service.dart';
+import 'services/mock_subscription_service.dart';
 
 /// Registers mock dependencies for running the app without backend services.
 class MockDependencyInjector {
@@ -13,12 +22,44 @@ class MockDependencyInjector {
 
   /// Initializes mock services and theme settings.
   static Future<void> init() async {
-    Get.put<AuthService>(MockAuthService(), permanent: true);
+    final auth = Get.put<AuthService>(MockAuthService(), permanent: true);
+    final firestore = FakeFirebaseFirestore();
+
+    final subscriptionService = Get.put<SubscriptionService>(
+      MockSubscriptionService(firestore: firestore),
+      permanent: true,
+    );
+
+    Get.put<FeedRequestService>(
+      MockFeedRequestService(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+        authService: auth,
+      ),
+      permanent: true,
+    );
+
+    Get.put<BaseNotificationService>(
+      MockNotificationService(firestore: firestore),
+      permanent: true,
+    );
+
+    Get.put(
+      SubscriptionManager(
+        firestore: firestore,
+        subscriptionService: subscriptionService,
+        feedRequestService: Get.find<FeedRequestService>(),
+      ),
+      permanent: true,
+    );
+
     final postService = MockPostService();
     await postService.load();
     Get.put<BasePostService>(postService, permanent: true);
-    Get.put<BaseFeedService>(MockFeedService(postService: postService),
-        permanent: true);
+    Get.put<BaseFeedService>(
+      MockFeedService(postService: postService),
+      permanent: true,
+    );
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeSettings();
   }

--- a/mock/services/mock_feed_request_service.dart
+++ b/mock/services/mock_feed_request_service.dart
@@ -1,0 +1,21 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:get/get.dart';
+
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/feed_request_service.dart';
+import 'package:hoot/services/subscription_service.dart';
+
+/// Mock implementation of [FeedRequestService] backed by
+/// [FakeFirebaseFirestore].
+class MockFeedRequestService extends FeedRequestService {
+  MockFeedRequestService({
+    FakeFirebaseFirestore? firestore,
+    SubscriptionService? subscriptionService,
+    AuthService? authService,
+  }) : super(
+          firestore: firestore ?? FakeFirebaseFirestore(),
+          subscriptionService:
+              subscriptionService ?? Get.find<SubscriptionService>(),
+          authService: authService ?? Get.find<AuthService>(),
+        );
+}

--- a/mock/services/mock_notification_service.dart
+++ b/mock/services/mock_notification_service.dart
@@ -1,0 +1,9 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:hoot/services/notification_service.dart';
+
+/// Mock implementation of [BaseNotificationService] backed by
+/// [FakeFirebaseFirestore].
+class MockNotificationService extends NotificationService {
+  MockNotificationService({FakeFirebaseFirestore? firestore})
+      : super(firestore: firestore ?? FakeFirebaseFirestore());
+}

--- a/mock/services/mock_subscription_service.dart
+++ b/mock/services/mock_subscription_service.dart
@@ -1,0 +1,8 @@
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:hoot/services/subscription_service.dart';
+
+/// Mock implementation of [SubscriptionService] using [FakeFirebaseFirestore].
+class MockSubscriptionService extends SubscriptionService {
+  MockSubscriptionService({FakeFirebaseFirestore? firestore})
+      : super(firestore: firestore ?? FakeFirebaseFirestore());
+}


### PR DESCRIPTION
## Summary
- mock notification, subscription, and feed request services using FakeFirebaseFirestore
- wire mock services into MockDependencyInjector for mock mode
- allow NotificationsController to receive injected BaseNotificationService

## Testing
- `dart analyze`
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_68912202b080832889f33f6fc1de6e7a