### PR TITLE
refactor: rely on Get for services

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -23,14 +23,10 @@ import 'package:hoot/util/routes/args/profile_args.dart';
 
 class PostComponent extends StatefulWidget {
   final Post post;
-  final PostService? postService;
-  final ReportService? reportService;
   final EdgeInsetsGeometry? margin;
 
   const PostComponent({
     required this.post,
-    this.postService,
-    this.reportService,
     this.margin,
     super.key,
   });
@@ -41,24 +37,17 @@ class PostComponent extends StatefulWidget {
 
 class _PostComponentState extends State<PostComponent> {
   late Post _post;
-  late PostService _postService;
-  late AuthService _authService;
-  late ReportService _reportService;
+  final PostService _postService =
+      Get.isRegistered<PostService>() ? Get.find<PostService>() : PostService();
+  final AuthService _authService =
+      Get.isRegistered<AuthService>() ? Get.find<AuthService>() : AuthService();
+  final ReportService _reportService = Get.isRegistered<ReportService>()
+      ? Get.find<ReportService>()
+      : ReportService();
 
   @override
   void initState() {
     _post = widget.post;
-    _postService = widget.postService ??
-        (Get.isRegistered<PostService>()
-            ? Get.find<PostService>()
-            : PostService());
-    _authService = Get.isRegistered<AuthService>()
-        ? Get.find<AuthService>()
-        : AuthService();
-    _reportService = widget.reportService ??
-        (Get.isRegistered<ReportService>()
-            ? Get.find<ReportService>()
-            : ReportService());
     super.initState();
 
     if (_post.reFeeded &&

--- a/lib/pages/create_post/bindings/create_post_binding.dart
+++ b/lib/pages/create_post/bindings/create_post_binding.dart
@@ -1,14 +1,9 @@
 import 'package:get/get.dart';
 import 'package:hoot/pages/create_post/controllers/create_post_controller.dart';
-import 'package:hoot/services/auth_service.dart';
 
 class CreatePostBinding extends Bindings {
   @override
   void dependencies() {
-    final authService = Get.find<AuthService>();
-    Get.lazyPut(() => CreatePostController(
-          authService: authService,
-          userId: authService.currentUser?.uid,
-        ));
+    Get.lazyPut(() => CreatePostController());
   }
 }

--- a/lib/pages/create_post/controllers/create_post_controller.dart
+++ b/lib/pages/create_post/controllers/create_post_controller.dart
@@ -20,25 +20,14 @@ import 'package:hoot/util/enums/feed_types.dart';
 
 /// Manages state for creating a new post.
 class CreatePostController extends GetxController {
-  final PostService _postService;
-  final AuthService _authService;
-  final StorageService _storageService;
+  final PostService _postService = Get.find<PostService>();
+  final AuthService _authService = Get.find<AuthService>();
+  final StorageService _storageService = StorageService();
   UserService? _userService;
-  final NewsService _newsService;
+  final NewsService _newsService = Get.find<NewsService>();
   late final String _userId;
 
-  CreatePostController({
-    PostService? postService,
-    AuthService? authService,
-    String? userId,
-    StorageService? storageService,
-    UserService? userService,
-    NewsService? newsService,
-  })  : _postService = postService ?? PostService(),
-        _authService = authService ?? Get.find<AuthService>(),
-        _storageService = storageService ?? StorageService(),
-        _userService = userService,
-        _newsService = newsService ?? Get.find<NewsService>() {
+  CreatePostController({String? userId}) {
     _userId = userId ?? _authService.currentUser?.uid ?? '';
   }
 

--- a/lib/pages/edit_profile/controllers/edit_profile_controller.dart
+++ b/lib/pages/edit_profile/controllers/edit_profile_controller.dart
@@ -17,13 +17,11 @@ import 'package:hoot/models/user.dart';
 import 'package:hoot/util/constants.dart';
 
 class EditProfileController extends GetxController {
-  final AuthService _authService;
-  final UserService _userService;
+  final AuthService _authService = Get.find<AuthService>();
+  final UserService _userService = UserService();
   final ImagePicker _picker = ImagePicker();
 
-  EditProfileController({AuthService? authService, UserService? userService})
-      : _authService = authService ?? Get.find<AuthService>(),
-        _userService = userService ?? UserService();
+  EditProfileController();
 
   final TextEditingController nameController = TextEditingController();
   final TextEditingController bioController = TextEditingController();

--- a/lib/pages/explore/bindings/explore_binding.dart
+++ b/lib/pages/explore/bindings/explore_binding.dart
@@ -1,10 +1,9 @@
 import 'package:get/get.dart';
 import 'package:hoot/pages/explore/controllers/explore_controller.dart';
-import 'package:hoot/services/auth_service.dart';
 
 class ExploreBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut(() => ExploreController(authService: Get.find<AuthService>()));
+    Get.lazyPut(() => ExploreController());
   }
 }

--- a/lib/pages/explore/controllers/explore_controller.dart
+++ b/lib/pages/explore/controllers/explore_controller.dart
@@ -11,12 +11,10 @@ import 'package:hoot/util/constants.dart';
 
 /// Controller in charge of fetching data for the explore page.
 class ExploreController extends GetxController {
-  final FirebaseFirestore _firestore;
-  final AuthService _authService;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final AuthService _authService = Get.find<AuthService>();
 
-  ExploreController({FirebaseFirestore? firestore, AuthService? authService})
-      : _firestore = firestore ?? FirebaseFirestore.instance,
-        _authService = authService ?? Get.find<AuthService>();
+  ExploreController();
 
   /// Text editing controller used by the search field.
   final TextEditingController searchController = TextEditingController();

--- a/lib/pages/feed/controllers/feed_controller.dart
+++ b/lib/pages/feed/controllers/feed_controller.dart
@@ -8,10 +8,9 @@ import 'package:hoot/services/feed_service.dart';
 
 /// Controller responsible for fetching posts for the feed view.
 class FeedController extends GetxController {
-  FeedController({FeedService? service})
-      : _feedService = service ?? Get.find<FeedService>();
+  FeedController();
 
-  final FeedService _feedService;
+  final FeedService _feedService = Get.find<FeedService>();
 
   final Rx<PagingState<DocumentSnapshot?, Post>> state =
       PagingState<DocumentSnapshot?, Post>().obs;

--- a/lib/pages/feed_page/controllers/feed_page_controller.dart
+++ b/lib/pages/feed_page/controllers/feed_page_controller.dart
@@ -17,27 +17,15 @@ import 'package:hoot/util/routes/args/feed_page_args.dart';
 
 class FeedPageController extends GetxController {
   final FeedPageArgs? args;
-  final AuthService _authService;
-  final FeedService _feedService;
-  final SubscriptionService _subscriptionService;
-  final FeedRequestService _feedRequestService;
-  final SubscriptionManager _subscriptionManager;
+  final AuthService _authService = Get.find<AuthService>();
+  final FeedService _feedService = Get.find<FeedService>();
+  final SubscriptionService _subscriptionService =
+      Get.find<SubscriptionService>();
+  final FeedRequestService _feedRequestService = Get.find<FeedRequestService>();
+  final SubscriptionManager _subscriptionManager =
+      Get.find<SubscriptionManager>();
 
-  FeedPageController({
-    this.args,
-    AuthService? authService,
-    FeedService? feedService,
-    SubscriptionService? subscriptionService,
-    FeedRequestService? feedRequestService,
-    SubscriptionManager? subscriptionManager,
-  })  : _authService = authService ?? Get.find<AuthService>(),
-        _feedService = feedService ?? Get.find<FeedService>(),
-        _subscriptionService =
-            subscriptionService ?? Get.find<SubscriptionService>(),
-        _feedRequestService =
-            feedRequestService ?? Get.find<FeedRequestService>(),
-        _subscriptionManager =
-            subscriptionManager ?? Get.find<SubscriptionManager>();
+  FeedPageController({this.args});
 
   final Rxn<Feed> feed = Rxn<Feed>();
   final RxBool loading = false.obs;

--- a/lib/pages/home/bindings/home_binding.dart
+++ b/lib/pages/home/bindings/home_binding.dart
@@ -1,5 +1,3 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:get/get.dart';
 import 'package:hoot/pages/home/controllers/home_controller.dart';
 import 'package:hoot/pages/feed/controllers/feed_controller.dart';
@@ -7,23 +5,13 @@ import 'package:hoot/pages/explore/controllers/explore_controller.dart';
 import 'package:hoot/pages/create_post/controllers/create_post_controller.dart';
 import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
 import 'package:hoot/pages/profile/controllers/profile_controller.dart';
-import 'package:hoot/services/auth_service.dart';
 
 class HomeBinding extends Bindings {
   @override
   void dependencies() {
     Get.lazyPut(() => HomeController());
     Get.lazyPut(() => FeedController());
-
-    final authService = Get.find<AuthService>();
-    final bool isMock = authService.runtimeType.toString().contains('Mock');
-    final FirebaseFirestore firestore =
-        isMock ? FakeFirebaseFirestore() : FirebaseFirestore.instance;
-
-    Get.lazyPut(() => ExploreController(
-          authService: authService,
-          firestore: firestore,
-        ));
+    Get.lazyPut(() => ExploreController());
     Get.lazyPut(() => CreatePostController());
     Get.lazyPut(() => NotificationsController());
     Get.lazyPut(() => ProfileController(), tag: 'current');

--- a/lib/pages/notifications/controllers/notifications_controller.dart
+++ b/lib/pages/notifications/controllers/notifications_controller.dart
@@ -10,19 +10,12 @@ import 'package:hoot/services/notification_service.dart';
 import 'package:hoot/services/feed_request_service.dart';
 
 class NotificationsController extends GetxController {
-  final AuthService _authService;
-  final NotificationService _notificationService;
-  final FeedRequestService _feedRequestService;
+  final AuthService _authService = Get.find<AuthService>();
+  final NotificationService _notificationService =
+      Get.find<NotificationService>();
+  final FeedRequestService _feedRequestService = Get.find<FeedRequestService>();
 
-  NotificationsController({
-    AuthService? authService,
-    NotificationService? notificationService,
-    FeedRequestService? feedRequestService,
-  })  : _authService = authService ?? Get.find<AuthService>(),
-        _notificationService =
-            notificationService ?? Get.find<NotificationService>(),
-        _feedRequestService =
-            feedRequestService ?? Get.find<FeedRequestService>();
+  NotificationsController();
 
   final RxList<HootNotification> notifications = <HootNotification>[].obs;
   final Rx<PagingState<DocumentSnapshot?, HootNotification>> state =

--- a/lib/pages/post/controllers/post_controller.dart
+++ b/lib/pages/post/controllers/post_controller.dart
@@ -16,23 +16,13 @@ import 'package:hoot/services/toast_service.dart';
 
 class PostController extends GetxController {
   final Rx<Post> post = Post.empty().obs;
-  final CommentService _commentService;
-  final AuthService _authService;
-  final PostService _postService;
-  final ReportService _reportService;
+  final CommentService _commentService = CommentService();
+  final AuthService _authService = Get.find<AuthService>();
+  final PostService _postService = Get.find<PostService>();
+  final ReportService _reportService = ReportService();
   UserService? _userService;
 
-  PostController({
-    CommentService? commentService,
-    AuthService? authService,
-    UserService? userService,
-    PostService? postService,
-    ReportService? reportService,
-  })  : _commentService = commentService ?? CommentService(),
-        _authService = authService ?? Get.find<AuthService>(),
-        _postService = postService ?? Get.find<PostService>(),
-        _reportService = reportService ?? ReportService(),
-        _userService = userService;
+  PostController();
 
   final Rx<PagingState<DocumentSnapshot?, Comment>> commentsState =
       PagingState<DocumentSnapshot?, Comment>().obs;

--- a/lib/pages/profile/controllers/profile_controller.dart
+++ b/lib/pages/profile/controllers/profile_controller.dart
@@ -20,29 +20,17 @@ import 'package:url_launcher/url_launcher_string.dart';
 /// Loads the current user profile data and owned feeds.
 class ProfileController extends GetxController {
   final ProfileArgs? args;
-  final AuthService _authService;
-  final FeedService _feedService;
-  final SubscriptionService _subscriptionService;
-  final FeedRequestService _feedRequestService;
-  final SubscriptionManager _subscriptionManager;
+  final AuthService _authService = Get.find<AuthService>();
+  final FeedService _feedService = Get.find<FeedService>();
+  final SubscriptionService _subscriptionService =
+      Get.find<SubscriptionService>();
+  final FeedRequestService _feedRequestService = Get.find<FeedRequestService>();
+  final SubscriptionManager _subscriptionManager =
+      Get.find<SubscriptionManager>();
 
-  ProfileController({
-    this.args,
-    AuthService? authService,
-    FeedService? feedService,
-    SubscriptionService? subscriptionService,
-    FeedRequestService? feedRequestService,
-    SubscriptionManager? subscriptionManager,
-  })  : uid = args?.uid,
-        initialFeedId = args?.feedId,
-        _authService = authService ?? Get.find<AuthService>(),
-        _feedService = feedService ?? Get.find<FeedService>(),
-        _subscriptionService =
-            subscriptionService ?? Get.find<SubscriptionService>(),
-        _feedRequestService =
-            feedRequestService ?? Get.find<FeedRequestService>(),
-        _subscriptionManager =
-            subscriptionManager ?? Get.find<SubscriptionManager>();
+  ProfileController({this.args})
+      : uid = args?.uid,
+        initialFeedId = args?.feedId;
 
   final Rxn<U> user = Rxn<U>();
   final RxList<Feed> feeds = <Feed>[].obs;

--- a/lib/pages/staff_dashboard/controllers/staff_dashboard_controller.dart
+++ b/lib/pages/staff_dashboard/controllers/staff_dashboard_controller.dart
@@ -2,13 +2,11 @@ import 'package:get/get.dart';
 import 'package:hoot/services/stats_service.dart';
 
 class StaffDashboardController extends GetxController {
-  final StatsService _service;
+  final StatsService _service = Get.isRegistered<StatsService>()
+      ? Get.find<StatsService>()
+      : StatsService();
 
-  StaffDashboardController({StatsService? service})
-      : _service = service ??
-            (Get.isRegistered<StatsService>()
-                ? Get.find<StatsService>()
-                : StatsService());
+  StaffDashboardController();
 
   /// Aggregated statistics including feedback counts.
   final Rx<Stats?> stats = Rx<Stats?>(null);

--- a/lib/pages/staff_feedbacks/controllers/staff_feedbacks_controller.dart
+++ b/lib/pages/staff_feedbacks/controllers/staff_feedbacks_controller.dart
@@ -3,13 +3,9 @@ import 'package:hoot/models/feedback.dart' as fb;
 import 'package:hoot/services/feedback_service.dart';
 
 class StaffFeedbacksController extends GetxController {
-  final FeedbackService _service;
-
-  StaffFeedbacksController({FeedbackService? service})
-      : _service = service ??
-            (Get.isRegistered<FeedbackService>()
-                ? Get.find<FeedbackService>()
-                : FeedbackService());
+  final FeedbackService _service = Get.isRegistered<FeedbackService>()
+      ? Get.find<FeedbackService>()
+      : FeedbackService();
 
   final RxList<fb.Feedback> feedbacks = <fb.Feedback>[].obs;
   final RxBool loading = false.obs;

--- a/lib/pages/staff_reports/controllers/staff_reports_controller.dart
+++ b/lib/pages/staff_reports/controllers/staff_reports_controller.dart
@@ -4,18 +4,11 @@ import 'package:hoot/services/post_service.dart';
 import 'package:hoot/services/report_service.dart';
 
 class StaffReportsController extends GetxController {
-  final ReportService _service;
-  final PostService _postService;
-
-  StaffReportsController({ReportService? service, PostService? postService})
-      : _service = service ??
-            (Get.isRegistered<ReportService>()
-                ? Get.find<ReportService>()
-                : ReportService()),
-        _postService = postService ??
-            (Get.isRegistered<PostService>()
-                ? Get.find<PostService>()
-                : PostService());
+  final ReportService _service = Get.isRegistered<ReportService>()
+      ? Get.find<ReportService>()
+      : ReportService();
+  final PostService _postService =
+      Get.isRegistered<PostService>() ? Get.find<PostService>() : PostService();
 
   final RxList<Report> reports = <Report>[].obs;
   final RxBool loading = false.obs;

--- a/lib/pages/welcome/controllers/welcome_controller.dart
+++ b/lib/pages/welcome/controllers/welcome_controller.dart
@@ -12,10 +12,9 @@ class WelcomeController extends GetxController {
   final usernameController = TextEditingController();
 
   final _auth = Get.find<AuthService>();
-  final UserService _userService;
+  final UserService _userService = UserService();
 
-  WelcomeController({UserService? userService})
-      : _userService = userService ?? UserService();
+  WelcomeController();
 
   @override
   void onInit() {


### PR DESCRIPTION
## Summary
- remove service parameters from widgets/controllers and resolve them via Get
- clean up bindings now that constructors have no service args

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*
- `flutter test` *(fails: Test directory "test" not found.)*


------
https://chatgpt.com/codex/tasks/task_e_6891afca29ec8328b6ddc3ff1de6e0fc