### PR TITLE
refactor: remove conditional service lookups

### DIFF
--- a/lib/components/post_component.dart
+++ b/lib/components/post_component.dart
@@ -37,13 +37,9 @@ class PostComponent extends StatefulWidget {
 
 class _PostComponentState extends State<PostComponent> {
   late Post _post;
-  final PostService _postService =
-      Get.isRegistered<PostService>() ? Get.find<PostService>() : PostService();
-  final AuthService _authService =
-      Get.isRegistered<AuthService>() ? Get.find<AuthService>() : AuthService();
-  final ReportService _reportService = Get.isRegistered<ReportService>()
-      ? Get.find<ReportService>()
-      : ReportService();
+  final PostService _postService = Get.find<PostService>();
+  final AuthService _authService = Get.find<AuthService>();
+  final ReportService _reportService = Get.find<ReportService>();
 
   @override
   void initState() {

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -60,9 +60,7 @@ class _ProfileViewState extends State<ProfileView> {
     );
     final reason = reasons?.first;
     if (reason == null || reason.isEmpty) return;
-    final service = Get.isRegistered<ReportService>()
-        ? Get.find<ReportService>()
-        : ReportService();
+    final service = Get.find<ReportService>();
     try {
       await service.reportUser(userId: user.uid, reason: reason);
       ToastService.showSuccess('reportSent'.tr);

--- a/lib/pages/staff_dashboard/controllers/staff_dashboard_controller.dart
+++ b/lib/pages/staff_dashboard/controllers/staff_dashboard_controller.dart
@@ -2,9 +2,7 @@ import 'package:get/get.dart';
 import 'package:hoot/services/stats_service.dart';
 
 class StaffDashboardController extends GetxController {
-  final StatsService _service = Get.isRegistered<StatsService>()
-      ? Get.find<StatsService>()
-      : StatsService();
+  final StatsService _service = Get.find<StatsService>();
 
   StaffDashboardController();
 

--- a/lib/pages/staff_feedbacks/controllers/staff_feedbacks_controller.dart
+++ b/lib/pages/staff_feedbacks/controllers/staff_feedbacks_controller.dart
@@ -3,9 +3,7 @@ import 'package:hoot/models/feedback.dart' as fb;
 import 'package:hoot/services/feedback_service.dart';
 
 class StaffFeedbacksController extends GetxController {
-  final FeedbackService _service = Get.isRegistered<FeedbackService>()
-      ? Get.find<FeedbackService>()
-      : FeedbackService();
+  final FeedbackService _service = Get.find<FeedbackService>();
 
   final RxList<fb.Feedback> feedbacks = <fb.Feedback>[].obs;
   final RxBool loading = false.obs;

--- a/lib/pages/staff_reports/controllers/staff_reports_controller.dart
+++ b/lib/pages/staff_reports/controllers/staff_reports_controller.dart
@@ -4,11 +4,8 @@ import 'package:hoot/services/post_service.dart';
 import 'package:hoot/services/report_service.dart';
 
 class StaffReportsController extends GetxController {
-  final ReportService _service = Get.isRegistered<ReportService>()
-      ? Get.find<ReportService>()
-      : ReportService();
-  final PostService _postService =
-      Get.isRegistered<PostService>() ? Get.find<PostService>() : PostService();
+  final ReportService _service = Get.find<ReportService>();
+  final PostService _postService = Get.find<PostService>();
 
   final RxList<Report> reports = <Report>[].obs;
   final RxBool loading = false.obs;

--- a/lib/util/mention_utils.dart
+++ b/lib/util/mention_utils.dart
@@ -9,8 +9,7 @@ import 'package:hoot/util/routes/args/profile_args.dart';
 /// Parses [text] and returns spans where @username mentions are highlighted
 /// in blue and tappable to open the mentioned user's profile.
 List<TextSpan> parseMentions(String text) {
-  final authService =
-      Get.isRegistered<AuthService>() ? Get.find<AuthService>() : AuthService();
+  final authService = Get.find<AuthService>();
   final regex = RegExp(r'@([A-Za-z0-9_]+)');
   final spans = <TextSpan>[];
   var currentIndex = 0;


### PR DESCRIPTION
## Summary
- remove Get.isRegistered checks in views and controllers; use Get.find for concrete services

## Testing
- `flutter analyze` (fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')
- `flutter test` (fails: Test directory "test" not found)

------
https://chatgpt.com/codex/tasks/task_e_6891b65cd73883288fa7aa1e51267105