### PR TITLE
fix: register notification service

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -6,6 +6,7 @@ import 'package:hoot/services/post_service.dart';
 import 'package:hoot/services/subscription_service.dart';
 import 'package:hoot/services/feed_request_service.dart';
 import 'package:hoot/services/subscription_manager.dart';
+import 'package:hoot/services/notification_service.dart';
 import 'package:hoot/services/quick_actions_service.dart';
 import 'package:hoot/services/onesignal_service.dart';
 import 'package:hoot/services/language_service.dart';
@@ -23,6 +24,7 @@ class DependencyInjector {
     Get.put(PostService(), permanent: true);
     Get.put(SubscriptionService(), permanent: true);
     Get.put(FeedRequestService(), permanent: true);
+    Get.put(NotificationService(), permanent: true);
     Get.put(SubscriptionManager(), permanent: true);
     final quickActions = Get.put(QuickActionsService(), permanent: true);
     final oneSignal = Get.put(OneSignalService(), permanent: true);


### PR DESCRIPTION
## Summary
- register NotificationService with GetX during startup to ensure availability for controllers

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6891bb6ee29c8328b47937b64b4b6ad8