### PR TITLE
Inject InvitationService globally

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -10,6 +10,7 @@ import 'package:hoot/services/quick_actions_service.dart';
 import 'package:hoot/services/onesignal_service.dart';
 import 'package:hoot/services/language_service.dart';
 import 'package:hoot/services/news_service.dart';
+import 'package:hoot/services/invitation_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -26,6 +27,7 @@ class DependencyInjector {
     Get.put(SubscriptionManager(), permanent: true);
     Get.put(QuickActionsService(), permanent: true);
     Get.put(OneSignalService(), permanent: true);
+    Get.put(InvitationService(), permanent: true);
     final theme = Get.put(ThemeService(), permanent: true);
     await theme.loadThemeSettings();
     final language = Get.put(LanguageService(), permanent: true);


### PR DESCRIPTION
## Summary
- add InvitationService to dependency injector
- import InvitationService for global GetX registration

## Testing
- `flutter test test/invite_friends_view_test.dart`
- `flutter test` *(fails: [core/no-app] No Firebase App '[DEFAULT]' has been created)*

------
https://chatgpt.com/codex/tasks/task_e_6891c6ca24d4832884e4cd46c4008650