### PR TITLE
feat: add iOS location usage descriptions

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -64,6 +64,10 @@
 		<string>Access to your camera is needed to create new media for your hoots and profile</string>
 		<key>NSPhotoLibraryUsageDescription</key>
 		<string>Access to your gallery is needed to upload media to your hoots and profile</string>
+                <key>NSLocationWhenInUseUsageDescription</key>
+                <string>Needed to determine your position for nearby content</string>
+                <key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+                <string>Needed to determine your position for nearby content</string>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 		<true/>
 		<key>UIBackgroundModes</key>


### PR DESCRIPTION
## Summary
- specify in-app and background location usage descriptions

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_68926b1c1d2c8328815cab351b482cd0