### PR TITLE
Add location permissions to Android manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.READ_CONTACTS"/>
     <uses-permission android:name="android.permission.WRITE_CONTACTS"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <application
         android:label="hoot"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- add ACCESS_COARSE_LOCATION and ACCESS_FINE_LOCATION permissions to Android manifest

## Testing
- `flutter pub get`
- `flutter test` *(stuck loading `news_service_test.dart` and aborted)*
- `flutter build apk` *(fails: No Android SDK found)*

------
https://chatgpt.com/codex/tasks/task_e_68926b1ddae48328b4cbf5156a08b2e4