### PR TITLE
Add Explore mock tab with sample data

### DIFF
--- a/mock/data/sample_explore.json
+++ b/mock/data/sample_explore.json
@@ -1,0 +1,31 @@
+{
+  "popularUsers": [
+    "https://placehold.co/100x100?text=U1",
+    "https://placehold.co/100x100?text=U2",
+    "https://placehold.co/100x100?text=U3",
+    "https://placehold.co/100x100?text=U4"
+  ],
+  "topFeeds": [
+    {
+      "id": "1",
+      "userId": "1",
+      "title": "Tech Feed",
+      "description": "Latest in tech",
+      "bigAvatar": "https://placehold.co/600x400?text=Tech",
+      "bigAvatarHash": "",
+      "color": "4280391411",
+      "subscriberCount": 1234
+    },
+    {
+      "id": "2",
+      "userId": "2",
+      "title": "Sports Feed",
+      "description": "All about sports",
+      "bigAvatar": "https://placehold.co/600x400?text=Sports",
+      "bigAvatarHash": "",
+      "color": "4283215696",
+      "subscriberCount": 2345
+    }
+  ],
+  "genres": ["technology", "sports", "music", "art"]
+}

--- a/mock/pages/explore_mock_tab.dart
+++ b/mock/pages/explore_mock_tab.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:solar_icons/solar_icons.dart';
+
+import 'package:hoot/components/feed_card.dart';
+import 'package:hoot/components/type_box_component.dart';
+import 'package:hoot/components/avatar_component.dart';
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/util/enums/feed_types.dart';
+
+class ExploreMockTab extends StatefulWidget {
+  const ExploreMockTab({super.key});
+
+  @override
+  State<ExploreMockTab> createState() => _ExploreMockTabState();
+}
+
+class _ExploreMockTabState extends State<ExploreMockTab> {
+  List<String> popularUsers = [];
+  List<Feed> topFeeds = [];
+  List<FeedType> genres = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final jsonString =
+        await rootBundle.loadString('mock/data/sample_explore.json');
+    final data = json.decode(jsonString) as Map<String, dynamic>;
+
+    setState(() {
+      popularUsers =
+          List<String>.from(data['popularUsers'] as List<dynamic>? ?? []);
+      topFeeds = (data['topFeeds'] as List<dynamic>? ?? [])
+          .map((e) => Feed.fromJson(e as Map<String, dynamic>))
+          .toList();
+      genres = (data['genres'] as List<dynamic>? ?? [])
+          .map((e) => FeedTypeExtension.fromString(e as String))
+          .toList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(vertical: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: TextField(
+              decoration: const InputDecoration(
+                hintText: 'Search',
+                prefixIcon: Icon(SolarIconsOutline.magnifier),
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              'Popular Users',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            height: 80,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              itemCount: popularUsers.length,
+              itemBuilder: (context, index) {
+                final image = popularUsers[index];
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                  child: ProfileAvatarComponent(
+                    image: image,
+                    size: 80,
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withAlpha(38),
+                        blurRadius: 16,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: 42),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              'Top 10 Most Subscribed',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+          ),
+          SizedBox(
+            height: 200,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.all(16),
+              itemCount: topFeeds.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 16),
+              itemBuilder: (context, index) {
+                final feed = topFeeds[index];
+                return FeedCard(feed: feed, onTap: () {});
+              },
+            ),
+          ),
+          const SizedBox(height: 32),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Text(
+              'Popular Types',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+          ),
+          SizedBox(
+            height: 200,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.all(16),
+              itemCount: genres.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 12),
+              itemBuilder: (context, index) {
+                final type = genres[index];
+                return TypeBoxComponent(type: type);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mock/pages/home_mock_page.dart
+++ b/mock/pages/home_mock_page.dart
@@ -10,6 +10,7 @@ import 'package:hoot/util/enums/app_colors.dart';
 
 import '../data/mock_user.dart';
 import 'profile_mock_page.dart';
+import 'explore_mock_tab.dart';
 
 class HomeMockPage extends StatefulWidget {
   const HomeMockPage({super.key});
@@ -50,7 +51,7 @@ class _HomeMockPageState extends State<HomeMockPage> {
           return PostComponent(post: post);
         },
       ),
-      const Center(child: Text('Explore')),
+      const ExploreMockTab(),
       const SizedBox.shrink(),
       const Center(child: Text('Notifications')),
       ListView(


### PR DESCRIPTION
## Summary
- add mock explore data with users, feeds, and genres
- create ExploreMockTab widget to display explore layout
- plug ExploreMockTab into HomeMockPage

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_68926e4b95ac8328bf4154691b109534