### PR TITLE
Add mock notifications tab

### DIFF
--- a/mock/data/sample_notifications.json
+++ b/mock/data/sample_notifications.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": 0,
+    "user": {
+      "uid": "user2",
+      "displayName": "Alice",
+      "username": "alice",
+      "avatarUrl": "https://picsum.photos/seed/alice/200/200"
+    },
+    "feed": { "id": "feed1", "title": "General" },
+    "text": "Alice liked your hoot",
+    "timestamp": "2024-06-01T12:00:00Z"
+  },
+  {
+    "type": 3,
+    "user": {
+      "uid": "user3",
+      "displayName": "Bob",
+      "username": "bob",
+      "avatarUrl": "https://picsum.photos/seed/bob/200/200"
+    },
+    "feed": { "id": "feed2", "title": "Mock Feed" },
+    "text": "Bob subscribed to your feed Mock Feed",
+    "timestamp": "2024-05-28T15:30:00Z"
+  },
+  {
+    "type": 5,
+    "user": {
+      "uid": "user4",
+      "displayName": "Charlie",
+      "username": "charlie",
+      "avatarUrl": "https://picsum.photos/seed/charlie/200/200"
+    },
+    "feed": null,
+    "text": "Charlie joined Hoot",
+    "timestamp": "2024-05-20T09:00:00Z"
+  }
+]

--- a/mock/pages/home_mock_page.dart
+++ b/mock/pages/home_mock_page.dart
@@ -9,6 +9,7 @@ import 'package:hoot/models/post.dart';
 import 'package:hoot/util/enums/app_colors.dart';
 
 import '../data/mock_user.dart';
+import 'notifications_mock_tab.dart';
 import 'profile_mock_page.dart';
 
 class HomeMockPage extends StatefulWidget {
@@ -52,7 +53,10 @@ class _HomeMockPageState extends State<HomeMockPage> {
       ),
       const Center(child: Text('Explore')),
       const SizedBox.shrink(),
-      const Center(child: Text('Notifications')),
+      NotificationsMockTab(
+        isActive: selectedIndex == 3,
+        onClearUnread: () => setState(() => unreadCount = 0),
+      ),
       ListView(
         padding: EdgeInsets.zero,
         children: [ProfileHeader(user: mockUser)],
@@ -173,10 +177,7 @@ class _HomeMockPageState extends State<HomeMockPage> {
                   ? Colors.white
                   : Colors.white.withAlpha(175),
             ),
-            onPressed: () => setState(() {
-              selectedIndex = 3;
-              unreadCount = 0;
-            }),
+            onPressed: () => setState(() => selectedIndex = 3),
           ),
           if (unreadCount > 0)
             Positioned(

--- a/mock/pages/notifications_mock_tab.dart
+++ b/mock/pages/notifications_mock_tab.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+import 'package:hoot/components/notification_item.dart';
+
+class NotificationsMockTab extends StatefulWidget {
+  final bool isActive;
+  final VoidCallback onClearUnread;
+
+  const NotificationsMockTab({
+    super.key,
+    required this.isActive,
+    required this.onClearUnread,
+  });
+
+  @override
+  State<NotificationsMockTab> createState() => _NotificationsMockTabState();
+}
+
+class _NotificationsMockTabState extends State<NotificationsMockTab> {
+  List<dynamic> notifications = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadNotifications();
+  }
+
+  Future<void> _loadNotifications() async {
+    final jsonString =
+        await rootBundle.loadString('mock/data/sample_notifications.json');
+    final data = json.decode(jsonString) as List<dynamic>;
+    setState(() {
+      notifications = data;
+    });
+  }
+
+  @override
+  void didUpdateWidget(covariant NotificationsMockTab oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isActive && !oldWidget.isActive) {
+      widget.onClearUnread();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (notifications.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return ListView.builder(
+      itemCount: notifications.length,
+      itemBuilder: (context, index) {
+        final n = notifications[index] as Map<String, dynamic>;
+        final user = n['user'] as Map<String, dynamic>? ?? {};
+        return ListItem(
+          avatarUrl: user['avatarUrl'] ?? '',
+          title: Text(n['text'] ?? ''),
+          subtitle: Text(n['timestamp'] ?? ''),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add sample notifications dataset
- create `NotificationsMockTab` to display mock notifications and clear unread badge
- integrate notifications tab into `HomeMockPage`

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*
- `dart analyze mock`


------
https://chatgpt.com/codex/tasks/task_e_68926e50db6c8328bae8f68a670879c4