### PR TITLE
Respect notification permission denial flag

### DIFF
--- a/lib/pages/home/controllers/home_controller.dart
+++ b/lib/pages/home/controllers/home_controller.dart
@@ -1,10 +1,11 @@
 import 'package:get/get.dart';
-import 'package:hoot/services/quick_actions_service.dart';
-import 'package:screen_corner_radius/screen_corner_radius.dart';
+import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
 import 'package:hoot/services/auth_service.dart';
 import 'package:hoot/services/onesignal_service.dart';
+import 'package:hoot/services/quick_actions_service.dart';
 import 'package:hoot/util/routes/app_routes.dart';
-import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
+import 'package:screen_corner_radius/screen_corner_radius.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class HomeController extends GetxController {
   final selectedIndex = 0.obs;
@@ -42,7 +43,10 @@ class HomeController extends GetxController {
 
     final oneSignal = Get.find<OneSignalService>();
     await oneSignal.login(user.uid);
-    if (await oneSignal.canRequestPermission()) {
+    final prefs = await SharedPreferences.getInstance();
+    const prefKey = 'notificationPermissionDenied';
+    final permissionDenied = prefs.getBool(prefKey) ?? false;
+    if (!permissionDenied && await oneSignal.canRequestPermission()) {
       Get.offAllNamed(AppRoutes.notificationsPermission);
       return;
     }

--- a/lib/pages/notifications_permission/controllers/notification_permission_controller.dart
+++ b/lib/pages/notifications_permission/controllers/notification_permission_controller.dart
@@ -1,12 +1,19 @@
 import 'package:get/get.dart';
 import 'package:hoot/services/onesignal_service.dart';
 import 'package:hoot/util/routes/app_routes.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class NotificationPermissionController extends GetxController {
   final OneSignalService _oneSignalService = Get.find<OneSignalService>();
+  static const _prefKeyNotificationPermissionDenied =
+      'notificationPermissionDenied';
 
   Future<void> requestPermission() async {
-    await _oneSignalService.requestPermission();
+    final granted = await _oneSignalService.requestPermission();
+    if (!granted) {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setBool(_prefKeyNotificationPermissionDenied, true);
+    }
     Get.offAllNamed(AppRoutes.home);
   }
 }


### PR DESCRIPTION
## Summary
- persist a flag when notifications permission is denied
- skip notification permission screen if user previously denied

## Testing
- `flutter analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_689282e8ff788328a1e39897b1732abd