### PR TITLE
Add DailyChallenge model

### DIFF
--- a/lib/models/daily_challenge.dart
+++ b/lib/models/daily_challenge.dart
@@ -1,0 +1,46 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class DailyChallenge {
+  final String id;
+  final String prompt;
+  final String hashtag;
+  final DateTime? expiresAt;
+  final DateTime? createdAt;
+
+  DailyChallenge({
+    required this.id,
+    required this.prompt,
+    required this.hashtag,
+    this.expiresAt,
+    this.createdAt,
+  });
+
+  factory DailyChallenge.fromJson(Map<String, dynamic> json) {
+    return DailyChallenge(
+      id: json['id'],
+      prompt: json['prompt'] ?? '',
+      hashtag: json['hashtag'] ?? '',
+      expiresAt: json['expiresAt'] != null
+          ? json['expiresAt'] is Timestamp
+              ? (json['expiresAt'] as Timestamp).toDate()
+              : DateTime.fromMillisecondsSinceEpoch(
+                  json['expiresAt']['_seconds'] * 1000)
+          : null,
+      createdAt: json['createdAt'] != null
+          ? json['createdAt'] is Timestamp
+              ? (json['createdAt'] as Timestamp).toDate()
+              : DateTime.fromMillisecondsSinceEpoch(
+                  json['createdAt']['_seconds'] * 1000)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'prompt': prompt,
+      'hashtag': hashtag,
+      if (expiresAt != null) 'expiresAt': Timestamp.fromDate(expiresAt!),
+      if (createdAt != null) 'createdAt': Timestamp.fromDate(createdAt!),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add DailyChallenge model for Firestore

## Testing
- `flutter analyze`
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_68930b5d78108328963a09d0f63f881d