### PR TITLE
Add daily challenge card

### DIFF
--- a/lib/components/challenge_card.dart
+++ b/lib/components/challenge_card.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:hoot/models/daily_challenge.dart';
+
+/// Card displaying the active daily challenge.
+class ChallengeCard extends StatefulWidget {
+  const ChallengeCard({
+    super.key,
+    required this.challenge,
+    required this.onJoin,
+  });
+
+  final DailyChallenge challenge;
+  final VoidCallback onJoin;
+
+  @override
+  State<ChallengeCard> createState() => _ChallengeCardState();
+}
+
+class _ChallengeCardState extends State<ChallengeCard> {
+  late Duration _remaining;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _remaining = _calculateRemaining();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      setState(() {
+        _remaining = _calculateRemaining();
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Duration _calculateRemaining() {
+    final expiresAt = widget.challenge.expiresAt;
+    if (expiresAt == null) return Duration.zero;
+    final diff = expiresAt.difference(DateTime.now());
+    return diff.isNegative ? Duration.zero : diff;
+  }
+
+  String _formatDuration(Duration d) {
+    final hours = d.inHours.toString().padLeft(2, '0');
+    final minutes = (d.inMinutes % 60).toString().padLeft(2, '0');
+    final seconds = (d.inSeconds % 60).toString().padLeft(2, '0');
+    return '$hours:$minutes:$seconds';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.challenge.prompt,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              _formatDuration(_remaining),
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: ElevatedButton(
+                onPressed: widget.onJoin,
+                child: const Text('Join Challenge'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/create_post/views/create_post_view.dart
+++ b/lib/pages/create_post/views/create_post_view.dart
@@ -52,6 +52,14 @@ class CreatePostView extends GetView<CreatePostController> {
 
   @override
   Widget build(BuildContext context) {
+    final prefill = Get.parameters['text'];
+    if (prefill != null && controller.textController.text.isEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final text = Uri.decodeComponent(prefill);
+        controller.mentionKey.currentState?.controller?.text = text;
+        controller.onTextChanged(text);
+      });
+    }
     return Scaffold(
       appBar: AppBarComponent(
         title: 'createPost'.tr,

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -5,12 +5,15 @@ import 'package:hoot/components/feed_card.dart';
 import 'package:hoot/components/type_box_component.dart';
 import 'package:hoot/components/avatar_component.dart';
 import 'package:hoot/components/post_component.dart';
+import 'package:hoot/components/challenge_card.dart';
 import 'package:hoot/util/routes/args/feed_page_args.dart';
 import 'package:solar_icons/solar_icons.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/routes/args/profile_args.dart';
 import 'package:hoot/pages/explore/controllers/explore_controller.dart';
 import 'package:hoot/components/scale_on_press.dart';
+import 'package:hoot/services/challenge_service.dart';
+import 'package:hoot/models/daily_challenge.dart';
 
 class ExploreView extends GetView<ExploreController> {
   const ExploreView({super.key});
@@ -78,6 +81,27 @@ class ExploreView extends GetView<ExploreController> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                StreamBuilder<DailyChallenge?>(
+                  stream:
+                      Get.find<BaseChallengeService>().watchCurrentChallenge(),
+                  builder: (context, snapshot) {
+                    final challenge = snapshot.data;
+                    if (challenge == null) return const SizedBox.shrink();
+                    return Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: ChallengeCard(
+                        challenge: challenge,
+                        onJoin: () {
+                          final tag = '#${challenge.hashtag} ';
+                          Get.toNamed(
+                            '${AppRoutes.createPost}?text=${Uri.encodeComponent(tag)}',
+                          );
+                        },
+                      ),
+                    );
+                  },
+                ),
+                const SizedBox(height: 16),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   child: TextField(


### PR DESCRIPTION
## Summary
- display a daily challenge card with prompt, countdown and join button
- show active challenge on Explore page and link to post creation with tag
- allow Create Post page to prefill text from navigation parameter

## Testing
- `flutter analyze` *(fails: The asset file 'assets/.env' doesn't exist)*
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_689314b734f08328b5a871c0770c9cf9