### PR TITLE
Add challenge feed support

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,13 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "posts",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "challengeId", "order": "ASCENDING"},
+        {"fieldPath": "createdAt", "order": "DESCENDING"}
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,11 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /posts/{postId} {
+      // Allow clients to query posts by challengeId and createdAt.
+      allow read: if true;
+      allow create: if request.auth != null;
+      allow update, delete: if false;
+    }
+  }
+}

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -11,6 +11,7 @@ class Post {
   String? location;
   U? user;
   String? feedId;
+  String? challengeId;
   Feed? feed;
   bool liked;
   int? likes;
@@ -43,6 +44,7 @@ class Post {
     this.location,
     this.user,
     this.feedId,
+    this.challengeId,
     this.feed,
     this.liked = false,
     this.likes,
@@ -70,6 +72,7 @@ class Post {
       url: json['url'],
       location: json['location'],
       feedId: json['feedId'],
+      challengeId: json['challengeId'],
       feed: json['feed'] != null ? Feed.fromJson(json['feed']) : null,
       user: json['user'] != null ? U.fromJson(json['user']) : null,
       liked: json['liked'] ?? false,
@@ -106,6 +109,7 @@ class Post {
       url: null,
       location: null,
       feedId: '0',
+      challengeId: null,
       feed: null,
       user: null,
       liked: false,
@@ -126,6 +130,7 @@ class Post {
       'images': media,
       'hashes': hashes,
       'feedId': feedId,
+      'challengeId': challengeId,
       'url': url,
       'location': location,
     };
@@ -138,6 +143,7 @@ class Post {
       'media': media,
       'hashes': hashes,
       'feedId': feedId,
+      'challengeId': challengeId,
       'url': url,
       'location': location,
       'feed': feed?.toCache(),
@@ -163,6 +169,7 @@ class Post {
       url: json['url'],
       location: json['location'],
       feedId: json['feedId'],
+      challengeId: json['challengeId'],
       feed: json['feed'] != null ? Feed.fromJson(json['feed']) : null,
       user: json['user'] != null ? U.fromJson(json['user']) : null,
       liked: json['liked'] ?? false,

--- a/lib/pages/challenge/challenge_feed_page.dart
+++ b/lib/pages/challenge/challenge_feed_page.dart
@@ -1,0 +1,70 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/components/empty_message.dart';
+import 'package:hoot/components/post_component.dart';
+import 'package:hoot/models/daily_challenge.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/services/challenge_service.dart';
+
+/// Displays posts tagged with the currently active challenge.
+class ChallengeFeedPage extends StatelessWidget {
+  const ChallengeFeedPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBarComponent(
+        title: 'challenge'.tr,
+      ),
+      body: StreamBuilder<DailyChallenge?>(
+        stream: Get.find<BaseChallengeService>().watchCurrentChallenge(),
+        builder: (context, challengeSnapshot) {
+          final challenge = challengeSnapshot.data;
+          if (challenge == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+            stream: FirebaseFirestore.instance
+                .collection('posts')
+                .where('challengeId', isEqualTo: challenge.id)
+                .orderBy('createdAt', descending: true)
+                .snapshots(),
+            builder: (context, snapshot) {
+              if (snapshot.connectionState == ConnectionState.waiting) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              if (snapshot.hasError) {
+                return NothingToShowComponent(
+                  icon: const Icon(Icons.error_outline),
+                  text: 'somethingWentWrong'.tr,
+                );
+              }
+              final docs = snapshot.data?.docs ?? [];
+              if (docs.isEmpty) {
+                return NothingToShowComponent(
+                  imageAsset: 'assets/images/empty.webp',
+                  text: 'noHoots'.tr,
+                );
+              }
+              final posts = docs
+                  .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
+                  .toList();
+              return ListView.builder(
+                itemCount: posts.length,
+                itemBuilder: (context, index) => PostComponent(
+                  post: posts[index],
+                  margin: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 8,
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- support optional challengeId in posts
- allow querying posts by challenge
- add challenge feed page and Firestore index/rules

## Testing
- `flutter test` *(fails: InviteFriendsView shows invite code and remaining count)*


------
https://chatgpt.com/codex/tasks/task_e_68931758afbc8328ac2aa2f4a51fade4