### PR TITLE
Add challenge feed route and view entries action

### DIFF
--- a/lib/components/challenge_card.dart
+++ b/lib/components/challenge_card.dart
@@ -8,10 +8,12 @@ class ChallengeCard extends StatefulWidget {
     super.key,
     required this.challenge,
     required this.onJoin,
+    required this.onViewEntries,
   });
 
   final DailyChallenge challenge;
   final VoidCallback onJoin;
+  final VoidCallback onViewEntries;
 
   @override
   State<ChallengeCard> createState() => _ChallengeCardState();
@@ -71,12 +73,19 @@ class _ChallengeCardState extends State<ChallengeCard> {
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 12),
-            Align(
-              alignment: Alignment.centerRight,
-              child: ElevatedButton(
-                onPressed: widget.onJoin,
-                child: const Text('Join Challenge'),
-              ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                TextButton(
+                  onPressed: widget.onViewEntries,
+                  child: const Text('View entries'),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                  onPressed: widget.onJoin,
+                  child: const Text('Join Challenge'),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -97,6 +97,9 @@ class ExploreView extends GetView<ExploreController> {
                             '${AppRoutes.createPost}?text=${Uri.encodeComponent(tag)}',
                           );
                         },
+                        onViewEntries: () {
+                          Get.toNamed(AppRoutes.challenge);
+                        },
                       ),
                     );
                   },

--- a/lib/util/routes/app_pages.dart
+++ b/lib/util/routes/app_pages.dart
@@ -47,6 +47,7 @@ import 'package:hoot/pages/feed_page/bindings/feed_page_binding.dart';
 import 'package:hoot/pages/feed_page/views/feed_page_view.dart';
 import 'package:hoot/pages/post/bindings/post_binding.dart';
 import 'package:hoot/pages/post/views/post_view.dart';
+import 'package:hoot/pages/challenge/challenge_feed_page.dart';
 import 'package:hoot/pages/report/bindings/report_binding.dart';
 import 'package:hoot/pages/report/views/report_view.dart';
 import 'package:hoot/pages/contacts/bindings/contacts_binding.dart';
@@ -205,6 +206,11 @@ class AppPages {
       name: AppRoutes.feed,
       page: () => const FeedPageView(),
       binding: FeedPageBinding(),
+      middlewares: [AuthMiddleware()],
+    ),
+    GetPage(
+      name: AppRoutes.challenge,
+      page: () => const ChallengeFeedPage(),
       middlewares: [AuthMiddleware()],
     ),
     GetPage(

--- a/lib/util/routes/app_routes.dart
+++ b/lib/util/routes/app_routes.dart
@@ -20,6 +20,7 @@ class AppRoutes {
   static const subscribers = '/subscribers';
   static const feed = '/feed';
   static const post = '/post';
+  static const challenge = '/challenge';
   static const report = '/report';
   static const aboutUs = '/about_us';
   static const contacts = '/contacts';


### PR DESCRIPTION
## Summary
- add dedicated `/challenge` route
- register `ChallengeFeedPage` in router
- extend `ChallengeCard` with "View entries" action and wire it up from Explore view

## Testing
- `flutter analyze` (fails: 39 issues)
- `flutter test` (fails: No file or variants found for asset: assets/.env.)

------
https://chatgpt.com/codex/tasks/task_e_689345fe30dc83288894437f0c2ff510