### PR TITLE
feat: support creating challenge posts

### DIFF
--- a/lib/pages/create_post/bindings/create_post_binding.dart
+++ b/lib/pages/create_post/bindings/create_post_binding.dart
@@ -6,9 +6,11 @@ class CreatePostBinding extends Bindings {
   @override
   void dependencies() {
     final authService = Get.find<AuthService>();
+    final challengeId = Get.parameters['challengeId'];
     Get.lazyPut(() => CreatePostController(
           authService: authService,
           userId: authService.currentUser?.uid,
+          challengeId: challengeId,
         ));
   }
 }

--- a/lib/pages/create_post/controllers/create_post_controller.dart
+++ b/lib/pages/create_post/controllers/create_post_controller.dart
@@ -27,6 +27,7 @@ class CreatePostController extends GetxController {
   final BaseStorageService _storageService;
   BaseUserService? _userService;
   final BaseNewsService _newsService;
+  final String? challengeId;
   late final String _userId;
 
   CreatePostController({
@@ -36,6 +37,7 @@ class CreatePostController extends GetxController {
     BaseStorageService? storageService,
     BaseUserService? userService,
     BaseNewsService? newsService,
+    this.challengeId,
   })  : _postService = postService ?? PostService(),
         _authService = authService ?? Get.find<AuthService>(),
         _storageService = storageService ?? StorageService(),
@@ -143,7 +145,10 @@ class CreatePostController extends GetxController {
         final place = placemarks.first;
         final city = place.locality;
         final country = place.country;
-        if (city != null && city.isNotEmpty && country != null && country.isNotEmpty) {
+        if (city != null &&
+            city.isNotEmpty &&
+            country != null &&
+            country.isNotEmpty) {
           location.value = '$city, $country';
         }
       }
@@ -271,7 +276,8 @@ class CreatePostController extends GetxController {
               'location': location.value,
               'createdAt': FieldValue.serverTimestamp(),
             }..removeWhere((key, value) => value == null),
-            id: postId);
+            id: postId,
+            challengeId: challengeId);
 
         final post = Post(
           id: postId,

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -94,7 +94,7 @@ class ExploreView extends GetView<ExploreController> {
                         onJoin: () {
                           final tag = '#${challenge.hashtag} ';
                           Get.toNamed(
-                            '${AppRoutes.createPost}?text=${Uri.encodeComponent(tag)}',
+                            '${AppRoutes.createPost}?challengeId=${challenge.id}&text=${Uri.encodeComponent(tag)}',
                           );
                         },
                         onViewEntries: () {


### PR DESCRIPTION
## Summary
- pass the active challenge ID when joining from Explore
- plumb optional challengeId through CreatePost binding/controller
- forward challengeId to post creation

## Testing
- `flutter test` *(fails: multiple widget and timeout errors)*

------
https://chatgpt.com/codex/tasks/task_e_689348a8562483288a95ae2ebe40a4f1