### PR TITLE
Filter NSFW posts from challenge feed

### DIFF
--- a/lib/pages/challenge/challenge_feed_controller.dart
+++ b/lib/pages/challenge/challenge_feed_controller.dart
@@ -1,0 +1,31 @@
+import 'package:get/get.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/util/constants.dart';
+import 'package:hoot/util/enums/feed_types.dart';
+
+/// Controller for filtering challenge feed posts based on NSFW settings.
+class ChallengeFeedController extends GetxController {
+  final AuthService _authService;
+
+  ChallengeFeedController({AuthService? authService})
+      : _authService = authService ?? Get.find<AuthService>();
+
+  bool get _shouldHideAdultContent {
+    final user = _authService.currentUser;
+    final created = user?.createdAt;
+    if (created == null) return false;
+    return DateTime.now().difference(created) <
+        const Duration(days: kAdultContentAccountAgeDays);
+  }
+
+  /// Filters out adult or NSFW posts when the user filter is active.
+  List<Post> filterPosts(List<Post> posts) {
+    if (!_shouldHideAdultContent) return posts;
+    return posts
+        .where((p) =>
+            p.feed?.type != FeedType.adultContent &&
+            (p.feed?.nsfw ?? false) != true)
+        .toList();
+  }
+}

--- a/lib/pages/challenge/challenge_feed_page.dart
+++ b/lib/pages/challenge/challenge_feed_page.dart
@@ -7,6 +7,7 @@ import 'package:hoot/components/post_component.dart';
 import 'package:hoot/models/daily_challenge.dart';
 import 'package:hoot/models/post.dart';
 import 'package:hoot/services/challenge_service.dart';
+import 'package:hoot/pages/challenge/challenge_feed_controller.dart';
 
 /// Displays posts tagged with the currently active challenge.
 class ChallengeFeedPage extends StatelessWidget {
@@ -48,13 +49,21 @@ class ChallengeFeedPage extends StatelessWidget {
                   text: 'noHoots'.tr,
                 );
               }
+              final controller = Get.put(ChallengeFeedController());
               final posts = docs
                   .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
                   .toList();
+              final filtered = controller.filterPosts(posts);
+              if (filtered.isEmpty) {
+                return NothingToShowComponent(
+                  imageAsset: 'assets/images/empty.webp',
+                  text: 'challengePostsFiltered'.tr,
+                );
+              }
               return ListView.builder(
-                itemCount: posts.length,
+                itemCount: filtered.length,
                 itemBuilder: (context, index) => PostComponent(
-                  post: posts[index],
+                  post: filtered[index],
                   margin: const EdgeInsets.symmetric(
                     horizontal: 16,
                     vertical: 8,

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -198,6 +198,8 @@ class AppTranslations extends Translations {
           'mainFeedDescription':
               'When you subscribe to feeds, all hoots will be merged here.',
           'noHoots': 'No hoots to show',
+          'challengePostsFiltered':
+              'All challenge posts are hidden by your NSFW filter',
           'subscribeToSeeHoots': 'Subscribe to some feeds to see hoots here',
           'popularUsers': 'Popular users',
           'top10MostSubscribed': 'Popular feeds',
@@ -619,6 +621,8 @@ class AppTranslations extends Translations {
           'mainFeedDescription':
               'Cuando te suscribas a feeds, todos los hoots se combinarán aquí.',
           'noHoots': 'No hay hoots para mostrar',
+          'challengePostsFiltered':
+              'Todos los hoots del desafío están ocultos por tu filtro NSFW',
           'subscribeToSeeHoots':
               'Suscríbete a algunos feeds para ver hoots aquí',
           'popularUsers': 'Usuarios populares',
@@ -1045,6 +1049,8 @@ class AppTranslations extends Translations {
           'mainFeedDescription':
               'Quando subscreveres a feeds, todos os hoots serão reunidos aqui.',
           'noHoots': 'Não há hoots para mostrar',
+          'challengePostsFiltered':
+              'Todos os hoots do desafio estão ocultos pelo teu filtro NSFW',
           'subscribeToSeeHoots': 'Subscreve a alguns feeds para ver hoots aqui',
           'popularUsers': 'Utilizadores populares',
           'top10MostSubscribed': 'Feeds populares',
@@ -1466,6 +1472,8 @@ class AppTranslations extends Translations {
           'mainFeedDescription':
               'Quando você se inscrever em feeds, todos os hoots serão reunidos aqui.',
           'noHoots': 'Não há hoots para mostrar',
+          'challengePostsFiltered':
+              'Todos os hoots do desafio estão ocultos pelo seu filtro NSFW',
           'subscribeToSeeHoots':
               'Inscreva-se em alguns feeds para ver hoots aqui',
           'popularUsers': 'Usuários populares',

--- a/test/challenge_feed_controller_nsfw_filter_test.dart
+++ b/test/challenge_feed_controller_nsfw_filter_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:hoot/models/feed.dart';
+import 'package:hoot/models/post.dart';
+import 'package:hoot/models/user.dart';
+import 'package:hoot/pages/challenge/challenge_feed_controller.dart';
+import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/util/constants.dart';
+import 'package:hoot/util/enums/feed_types.dart';
+
+void main() {
+  group('ChallengeFeedController NSFW filtering', () {
+    test('filters adult posts for young accounts', () {
+      final auth = AuthService(
+          auth: MockFirebaseAuth(), firestore: FakeFirebaseFirestore());
+      final youngDate = DateTime.now().subtract(
+        const Duration(days: kAdultContentAccountAgeDays - 1),
+      );
+      auth.currentUserRx.value = U(uid: 'u1', createdAt: youngDate);
+      final controller = ChallengeFeedController(authService: auth);
+
+      final posts = [
+        Post(
+          id: 'p1',
+          feed: Feed(
+            id: 'f1',
+            userId: 'u1',
+            title: 't1',
+            description: 'd1',
+            nsfw: true,
+          ),
+        ),
+        Post(
+          id: 'p2',
+          feed: Feed(
+            id: 'f2',
+            userId: 'u1',
+            title: 't2',
+            description: 'd2',
+            type: FeedType.adultContent,
+          ),
+        ),
+      ];
+
+      final filtered = controller.filterPosts(posts);
+      expect(filtered, isEmpty);
+    });
+
+    test('keeps posts for old accounts', () {
+      final auth = AuthService(
+          auth: MockFirebaseAuth(), firestore: FakeFirebaseFirestore());
+      final oldDate = DateTime.now().subtract(
+        const Duration(days: kAdultContentAccountAgeDays + 1),
+      );
+      auth.currentUserRx.value = U(uid: 'u1', createdAt: oldDate);
+      final controller = ChallengeFeedController(authService: auth);
+
+      final posts = [
+        Post(
+          id: 'p1',
+          feed: Feed(
+            id: 'f1',
+            userId: 'u1',
+            title: 't1',
+            description: 'd1',
+            nsfw: true,
+          ),
+        ),
+        Post(
+          id: 'p2',
+          feed: Feed(
+            id: 'f2',
+            userId: 'u1',
+            title: 't2',
+            description: 'd2',
+            type: FeedType.adultContent,
+          ),
+        ),
+      ];
+
+      final filtered = controller.filterPosts(posts);
+      expect(filtered.length, 2);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add ChallengeFeedController for NSFW filtering
- filter challenge feed posts and show placeholder when all filtered
- localize new placeholder message

## Testing
- `flutter test test/challenge_feed_controller_nsfw_filter_test.dart`
- `flutter test` *(fails: TestDeviceException - hung during home_view_test)*

------
https://chatgpt.com/codex/tasks/task_e_68934e8749988328ab1b0353c402943f