### PR TITLE
feat: track daily challenge count

### DIFF
--- a/functions/src/triggers/onPostCreated.ts
+++ b/functions/src/triggers/onPostCreated.ts
@@ -64,9 +64,14 @@ export const onPostCreated = onDocumentCreated(
           });
       }
     }
-    await db
-      .collection("users")
-      .doc(userId)
-      .update({ activityScore: FieldValue.increment(1) });
+    const updates: Record<string, unknown> = {
+      activityScore: FieldValue.increment(1),
+    };
+
+    if (post.challengeId) {
+      updates.challengeCount = FieldValue.increment(1);
+    }
+
+    await db.collection("users").doc(userId).update(updates);
   }
 );

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -32,6 +32,7 @@ class U {
   int? subscriptionCount;
   int? activityScore;
   int? popularityScore;
+  int? challengeCount;
   List<Feed>? feeds;
   UserRole role;
 
@@ -61,6 +62,7 @@ class U {
     this.subscriptionCount,
     this.activityScore = 0,
     this.popularityScore = 0,
+    this.challengeCount = 0,
     this.feeds,
     this.role = UserRole.user,
   });
@@ -118,6 +120,7 @@ class U {
       subscriptionCount: json['subscriptionCount'],
       activityScore: json['activityScore'],
       popularityScore: json['popularityScore'],
+      challengeCount: json['challengeCount'] ?? 0,
       feeds: json['feeds'] != null
           ? List<Feed>.from(json['feeds'].map((x) => Feed.fromJson(x)))
           : [],
@@ -148,6 +151,7 @@ class U {
       'birthday': birthday,
       'role': role.name,
       'verified': verified,
+      'challengeCount': challengeCount,
     };
   }
 
@@ -177,6 +181,7 @@ class U {
         'subscriptionCount': subscriptionCount,
         'activityScore': activityScore,
         'popularityScore': popularityScore,
+        'challengeCount': challengeCount,
         'feeds': feeds?.map((e) => e.toCache()).toList(),
         'role': role.name,
       };
@@ -210,6 +215,7 @@ class U {
       subscriptionCount: json['subscriptionCount'],
       activityScore: json['activityScore'],
       popularityScore: json['popularityScore'],
+      challengeCount: json['challengeCount'] ?? 0,
       feeds: json['feeds'] != null
           ? List<Feed>.from(json['feeds'].map((x) => Feed.fromJson(x)))
           : [],

--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -446,6 +446,17 @@ class _ProfileViewState extends State<ProfileView> {
                       ],
                     ),
                   ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text(
+                      '🌟 ${user.challengeCount ?? 0} Daily Challenges',
+                      style: Get.textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
               ],
             )),
             const SliverToBoxAdapter(child: SizedBox(height: 32)),


### PR DESCRIPTION
## Summary
- add `challengeCount` field to user model with serialization
- bump challengeCount when creating challenge posts
- show daily challenge badge on profile page

## Testing
- `npm test` (fails: Cannot find module 'firebase-functions')
- `flutter test` (fails: No file or variants found for asset: assets/.env.)
- `flutter analyze` (39 issues found)


------
https://chatgpt.com/codex/tasks/task_e_68935c46d3f4832894123c70a1deb5c4