### PR TITLE
feat: show top posts from last challenge

### DIFF
--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -14,6 +14,7 @@ import 'package:hoot/pages/explore/controllers/explore_controller.dart';
 import 'package:hoot/components/scale_on_press.dart';
 import 'package:hoot/services/challenge_service.dart';
 import 'package:hoot/models/daily_challenge.dart';
+import 'package:hoot/models/post.dart';
 
 class ExploreView extends GetView<ExploreController> {
   const ExploreView({super.key});
@@ -105,6 +106,41 @@ class ExploreView extends GetView<ExploreController> {
                   },
                 ),
                 const SizedBox(height: 16),
+                FutureBuilder<({DailyChallenge challenge, List<Post> posts})?>(
+                  future: Get.find<BaseChallengeService>()
+                      .fetchRecentExpiredChallengeTopPosts(),
+                  builder: (context, snapshot) {
+                    final data = snapshot.data;
+                    if (data == null || data.posts.isEmpty) {
+                      return const SizedBox.shrink();
+                    }
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: Text(
+                              'previousChallengeTopPosts'.tr,
+                              style: Theme.of(context).textTheme.titleLarge,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          ...data.posts.map(
+                            (p) => PostComponent(
+                              post: p,
+                              margin: const EdgeInsets.symmetric(
+                                horizontal: 16,
+                                vertical: 8,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
                 Padding(
                   padding: const EdgeInsets.symmetric(horizontal: 16),
                   child: TextField(

--- a/lib/services/challenge_service.dart
+++ b/lib/services/challenge_service.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'package:hoot/models/daily_challenge.dart';
+import 'package:hoot/models/post.dart';
 
 /// Abstraction for retrieving daily challenges.
 abstract class BaseChallengeService {
@@ -9,6 +10,11 @@ abstract class BaseChallengeService {
 
   /// Watches the currently active [DailyChallenge] in real-time.
   Stream<DailyChallenge?> watchCurrentChallenge();
+
+  /// Fetches the most recent expired [DailyChallenge] and its top posts
+  /// ordered by likes.
+  Future<({DailyChallenge challenge, List<Post> posts})?>
+      fetchRecentExpiredChallengeTopPosts({int limit = 3});
 }
 
 /// Service communicating with Firestore to retrieve challenges.
@@ -46,5 +52,34 @@ class ChallengeService implements BaseChallengeService {
       final doc = snapshot.docs.first;
       return DailyChallenge.fromJson({'id': doc.id, ...doc.data()});
     });
+  }
+
+  /// Retrieves the most recent expired [DailyChallenge] and its top posts
+  /// ordered by likes.
+  @override
+  Future<({DailyChallenge challenge, List<Post> posts})?>
+      fetchRecentExpiredChallengeTopPosts({int limit = 3}) async {
+    final challengeSnapshot = await _firestore
+        .collection('daily_challenges')
+        .where('expiresAt', isLessThan: Timestamp.now())
+        .orderBy('expiresAt', descending: true)
+        .limit(1)
+        .get();
+    if (challengeSnapshot.docs.isEmpty) return null;
+    final challengeDoc = challengeSnapshot.docs.first;
+    final challenge = DailyChallenge.fromJson(
+        {'id': challengeDoc.id, ...challengeDoc.data()});
+
+    final postsSnapshot = await _firestore
+        .collection('posts')
+        .where('challengeId', isEqualTo: challenge.id)
+        .orderBy('likes', descending: true)
+        .limit(limit)
+        .get();
+
+    final posts = postsSnapshot.docs
+        .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
+        .toList();
+    return (challenge: challenge, posts: posts);
   }
 }

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -201,6 +201,7 @@ class AppTranslations extends Translations {
           'challengePostsFiltered':
               'All challenge posts are hidden by your NSFW filter',
           'subscribeToSeeHoots': 'Subscribe to some feeds to see hoots here',
+          'previousChallengeTopPosts': 'Top posts from last challenge',
           'popularUsers': 'Popular users',
           'top10MostSubscribed': 'Popular feeds',
           'top10RecentPopularHoots': 'Popular hoots',
@@ -626,6 +627,7 @@ class AppTranslations extends Translations {
               'Todos los hoots del desafío están ocultos por tu filtro NSFW',
           'subscribeToSeeHoots':
               'Suscríbete a algunos feeds para ver hoots aquí',
+          'previousChallengeTopPosts': 'Mejores hoots del último desafío',
           'popularUsers': 'Usuarios populares',
           'top10MostSubscribed': 'Feeds populares',
           'top10RecentPopularHoots': 'Hoots populares',
@@ -1054,6 +1056,7 @@ class AppTranslations extends Translations {
           'challengePostsFiltered':
               'Todos os hoots do desafio estão ocultos pelo teu filtro NSFW',
           'subscribeToSeeHoots': 'Subscreve a alguns feeds para ver hoots aqui',
+          'previousChallengeTopPosts': 'Hoots principais do último desafio',
           'popularUsers': 'Utilizadores populares',
           'top10MostSubscribed': 'Feeds populares',
           'top10RecentPopularHoots': 'Hoots populares',
@@ -1479,6 +1482,7 @@ class AppTranslations extends Translations {
               'Todos os hoots do desafio estão ocultos pelo seu filtro NSFW',
           'subscribeToSeeHoots':
               'Inscreva-se em alguns feeds para ver hoots aqui',
+          'previousChallengeTopPosts': 'Principais hoots do último desafio',
           'popularUsers': 'Usuários populares',
           'top10MostSubscribed': 'Feeds populares',
           'top10RecentPopularHoots': 'Hoots populares',


### PR DESCRIPTION
## Summary
- fetch latest expired challenge with its most liked posts
- display top posts from previous challenge on explore page
- add translation for previous challenge section

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_68936483cc9c8328b79b855729678063