### PR TITLE
feat: add scheduled daily challenge cloud function

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -16,11 +16,13 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^12.6.0",
-    "firebase-functions": "^6.0.1"
+    "firebase-functions": "^6.0.1",
+    "@google-cloud/tasks": "^6.2.0"
   },
   "devDependencies": {
     "typescript": "^5.7.3",
-    "firebase-functions-test": "^3.1.0"
+    "firebase-functions-test": "^3.1.0",
+    "@types/node": "^22.7.4"
   },
   "private": true
 }

--- a/functions/src/createDailyChallenge.ts
+++ b/functions/src/createDailyChallenge.ts
@@ -1,0 +1,68 @@
+import { onCall, onRequest } from "firebase-functions/v2/https";
+import { FieldValue } from "firebase-admin/firestore";
+import { CloudTasksClient } from "@google-cloud/tasks";
+import { db } from "./config";
+
+const tasksClient = new CloudTasksClient();
+
+export const createDailyChallenge = onCall(async (request) => {
+  const prompt = request.data.prompt as string | undefined;
+  const hashtag = request.data.hashtag as string | undefined;
+  const expiresAt = request.data.expiresAt as number | string | undefined;
+  const createAt = request.data.createAt as number | string | undefined;
+
+  if (!prompt || !expiresAt || !createAt) {
+    throw new Error("Missing parameters");
+  }
+
+  const createDate = new Date(createAt);
+  if (createDate.getTime() <= Date.now()) {
+    await db.collection("daily_challenges").add({
+      prompt,
+      ...(hashtag ? { hashtag } : {}),
+      expiresAt: new Date(expiresAt),
+      createdAt: FieldValue.serverTimestamp(),
+    });
+    return { scheduled: false };
+  }
+
+  const project = process.env.GCLOUD_PROJECT || process.env.GCP_PROJECT || "";
+  const location = process.env.FUNCTION_REGION || "us-central1";
+  const queue = process.env.DAILY_CHALLENGE_QUEUE || "daily-challenge";
+  const url =
+    process.env.CREATE_DAILY_CHALLENGE_URL ||
+    `https://${location}-${project}.cloudfunctions.net/createDailyChallengeTask`;
+
+  const task = {
+    httpRequest: {
+      httpMethod: "POST" as const,
+      url,
+      headers: { "Content-Type": "application/json" },
+      body: Buffer.from(
+        JSON.stringify({ prompt, hashtag, expiresAt })
+      ).toString("base64"),
+    },
+    scheduleTime: { seconds: Math.floor(createDate.getTime() / 1000) },
+  };
+
+  await tasksClient.createTask({
+    parent: tasksClient.queuePath(project, location, queue),
+    task,
+  });
+  return { scheduled: true };
+});
+
+export const createDailyChallengeTask = onRequest(async (req, res) => {
+  const { prompt, hashtag, expiresAt } = req.body as {
+    prompt: string;
+    hashtag?: string;
+    expiresAt: number | string;
+  };
+  await db.collection("daily_challenges").add({
+    prompt,
+    ...(hashtag ? { hashtag } : {}),
+    expiresAt: new Date(expiresAt),
+    createdAt: FieldValue.serverTimestamp(),
+  });
+  res.status(200).json({ success: true });
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -11,3 +11,4 @@ export * from "./triggers/onInvitationUsed";
 export * from "./triggers/onReportCreated";
 export * from "./triggers/onChallengeCreated";
 export * from "./feedback";
+export * from "./createDailyChallenge";

--- a/functions/test/createDailyChallenge.test.ts
+++ b/functions/test/createDailyChallenge.test.ts
@@ -1,0 +1,55 @@
+import test, { mock } from "node:test";
+import assert from "node:assert";
+import functionsTest from "firebase-functions-test";
+import { createDailyChallenge } from "../src/createDailyChallenge";
+import { db } from "../src/config";
+import { CloudTasksClient } from "@google-cloud/tasks";
+
+process.env.GCLOUD_PROJECT = "demo-project";
+process.env.FUNCTION_REGION = "us-central1";
+
+const testEnv = functionsTest();
+
+test.after(() => {
+  testEnv.cleanup();
+});
+
+test("creates challenge immediately when createAt is past", async () => {
+  const add = mock.fn(async () => ({}));
+  const restoreCollection = mock.method(db, "collection", () => ({ add }));
+  const wrapped = testEnv.wrap(createDailyChallenge);
+  await wrapped({
+    data: {
+      prompt: "Prompt",
+      hashtag: "#tag",
+      expiresAt: Date.now() + 3600,
+      createAt: Date.now() - 1000,
+    },
+  } as any);
+  assert.equal(add.mock.callCount(), 1);
+  restoreCollection.mock.restore();
+});
+
+test("schedules challenge via Cloud Tasks when createAt in future", async () => {
+  const add = mock.fn(async () => ({}));
+  const restoreCollection = mock.method(db, "collection", () => ({ add }));
+  const restoreTask = mock.method(
+    CloudTasksClient.prototype,
+    "createTask",
+    async () => [{}]
+  );
+  const wrapped = testEnv.wrap(createDailyChallenge);
+  const future = Date.now() + 60000;
+  await wrapped({
+    data: {
+      prompt: "Prompt",
+      hashtag: "#tag",
+      expiresAt: Date.now() + 3600,
+      createAt: future,
+    },
+  } as any);
+  assert.equal(restoreTask.mock.callCount(), 1);
+  assert.equal(add.mock.callCount(), 0);
+  restoreTask.mock.restore();
+  restoreCollection.mock.restore();
+});

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -12,6 +12,7 @@
   },
   "compileOnSave": true,
   "include": [
-    "src"
+    "src",
+    "test"
   ]
 }


### PR DESCRIPTION
## Summary
- add `createDailyChallenge` callable function to insert daily challenges immediately or via scheduled Cloud Tasks
- export new function and handler
- add unit tests for immediate and scheduled challenge creation paths

## Testing
- `cd functions && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893754f3d0c8328bad5fe76715b3438