### PR TITLE
Use reactive streams for challenge feed

### DIFF
--- a/lib/pages/challenge/challenge_feed_controller.dart
+++ b/lib/pages/challenge/challenge_feed_controller.dart
@@ -1,15 +1,84 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:get/get.dart';
+import 'package:hoot/models/daily_challenge.dart';
 import 'package:hoot/models/post.dart';
 import 'package:hoot/services/auth_service.dart';
+import 'package:hoot/services/challenge_service.dart';
 import 'package:hoot/util/constants.dart';
 import 'package:hoot/util/enums/feed_types.dart';
 
 /// Controller for filtering challenge feed posts based on NSFW settings.
 class ChallengeFeedController extends GetxController {
   final AuthService _authService;
+  final BaseChallengeService _challengeService;
+  final FirebaseFirestore _firestore;
 
-  ChallengeFeedController({AuthService? authService})
-      : _authService = authService ?? Get.find<AuthService>();
+  ChallengeFeedController({
+    AuthService? authService,
+    BaseChallengeService? challengeService,
+    FirebaseFirestore? firestore,
+  })  : _authService = authService ?? Get.find<AuthService>(),
+        _challengeService =
+            challengeService ?? Get.find<BaseChallengeService>(),
+        _firestore = firestore ?? FirebaseFirestore.instance;
+
+  final Rxn<DailyChallenge> challenge = Rxn<DailyChallenge>();
+  final RxList<Post> posts = <Post>[].obs;
+  final RxBool postsLoading = false.obs;
+  final Rxn<Object> postsError = Rxn<Object>();
+  final RxBool hasAnyPosts = false.obs;
+
+  late final StreamSubscription<DailyChallenge?> _challengeSub;
+  StreamSubscription<QuerySnapshot<Map<String, dynamic>>>? _postsSub;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _challengeSub = _challengeService.watchCurrentChallenge().listen((c) {
+      challenge.value = c;
+      if (c == null) {
+        posts.clear();
+        postsLoading.value = false;
+        postsError.value = null;
+        hasAnyPosts.value = false;
+        _postsSub?.cancel();
+        _postsSub = null;
+      } else {
+        _subscribeToPosts(c.id);
+      }
+    });
+  }
+
+  void _subscribeToPosts(String challengeId) {
+    postsLoading.value = true;
+    postsError.value = null;
+    hasAnyPosts.value = false;
+    _postsSub?.cancel();
+    _postsSub = _firestore
+        .collection('posts')
+        .where('challengeId', isEqualTo: challengeId)
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .listen((snapshot) {
+      final fetched = snapshot.docs
+          .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
+          .toList();
+      hasAnyPosts.value = fetched.isNotEmpty;
+      posts.value = filterPosts(fetched);
+      postsLoading.value = false;
+    }, onError: (e, st) {
+      FirebaseCrashlytics.instance.recordError(
+        e,
+        st,
+        reason: 'Failed to load challenge posts',
+      );
+      postsError.value = e;
+      postsLoading.value = false;
+    });
+  }
 
   bool get _shouldHideAdultContent {
     final user = _authService.currentUser;
@@ -28,5 +97,12 @@ class ChallengeFeedController extends GetxController {
             (p.feed?.nsfw ?? false) != true &&
             (p.nsfw ?? false) != true)
         .toList();
+  }
+
+  @override
+  void onClose() {
+    _challengeSub.cancel();
+    _postsSub?.cancel();
+    super.onClose();
   }
 }

--- a/lib/pages/challenge/views/challenge_feed_view.dart
+++ b/lib/pages/challenge/views/challenge_feed_view.dart
@@ -1,13 +1,8 @@
-import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/components/post_component.dart';
-import 'package:hoot/models/daily_challenge.dart';
-import 'package:hoot/models/post.dart';
-import 'package:hoot/services/challenge_service.dart';
 import 'package:hoot/pages/challenge/challenge_feed_controller.dart';
 
 /// Displays posts tagged with the currently active challenge.
@@ -20,69 +15,45 @@ class ChallengeFeedView extends GetView<ChallengeFeedController> {
       appBar: AppBarComponent(
         title: 'challenge'.tr,
       ),
-      body: StreamBuilder<DailyChallenge?>(
-        stream: Get.find<BaseChallengeService>().watchCurrentChallenge(),
-        builder: (context, challengeSnapshot) {
-          final challenge = challengeSnapshot.data;
-          if (challenge == null) {
+      body: Obx(() {
+        final challenge = controller.challenge.value;
+        if (challenge == null) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        return Obx(() {
+          if (controller.postsLoading.value) {
             return const Center(child: CircularProgressIndicator());
           }
-          return StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-            stream: FirebaseFirestore.instance
-                .collection('posts')
-                .where('challengeId', isEqualTo: challenge.id)
-                .orderBy('createdAt', descending: true)
-                .snapshots(),
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              if (snapshot.hasError) {
-                FirebaseCrashlytics.instance.recordError(
-                  snapshot.error!,
-                  snapshot.stackTrace,
-                  reason: 'Failed to load challenge posts',
-                );
-                return Center(
-                  child: NothingToShowComponent(
-                    icon: const Icon(Icons.error_outline),
-                    text: 'somethingWentWrong'.tr,
-                  ),
-                );
-              }
-              final docs = snapshot.data?.docs ?? [];
-              if (docs.isEmpty) {
-                return Center(
-                  child: NothingToShowComponent(
-                    imageAsset: 'assets/images/empty.webp',
-                    text: 'noHoots'.tr,
-                  ),
-                );
-              }
-              final posts = docs
-                  .map((d) => Post.fromJson({'id': d.id, ...d.data()}))
-                  .toList();
-              final filtered = controller.filterPosts(posts);
-              if (filtered.isEmpty) {
-                return NothingToShowComponent(
-                  imageAsset: 'assets/images/empty.webp',
-                  text: 'challengePostsFiltered'.tr,
-                );
-              }
-              return ListView.builder(
-                itemCount: filtered.length,
-                itemBuilder: (context, index) => PostComponent(
-                  post: filtered[index],
-                  margin: const EdgeInsets.symmetric(
-                    horizontal: 16,
-                    vertical: 8,
-                  ),
-                ),
-              );
-            },
+          if (controller.postsError.value != null) {
+            return Center(
+              child: NothingToShowComponent(
+                icon: const Icon(Icons.error_outline),
+                text: 'somethingWentWrong'.tr,
+              ),
+            );
+          }
+          if (controller.posts.isEmpty) {
+            return Center(
+              child: NothingToShowComponent(
+                imageAsset: 'assets/images/empty.webp',
+                text: controller.hasAnyPosts.value
+                    ? 'challengePostsFiltered'.tr
+                    : 'noHoots'.tr,
+              ),
+            );
+          }
+          return ListView.builder(
+            itemCount: controller.posts.length,
+            itemBuilder: (context, index) => PostComponent(
+              post: controller.posts[index],
+              margin: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 8,
+              ),
+            ),
           );
-        },
-      ),
+        });
+      }),
     );
   }
 }


### PR DESCRIPTION
## Summary
- watch current challenge and its posts in `ChallengeFeedController`
- swap `StreamBuilder`s for `Obx` in `ChallengeFeedView`

## Testing
- `flutter test` *(fails: InviteFriendsView shows invite code and remaining count)*

------
https://chatgpt.com/codex/tasks/task_e_68937a4b78c883289854fcaa9341f7c3