### PR TITLE
Handle empty challenge state in feed

### DIFF
--- a/lib/pages/challenge/challenge_feed_controller.dart
+++ b/lib/pages/challenge/challenge_feed_controller.dart
@@ -26,6 +26,7 @@ class ChallengeFeedController extends GetxController {
         _firestore = firestore ?? FirebaseFirestore.instance;
 
   final Rxn<DailyChallenge> challenge = Rxn<DailyChallenge>();
+  final RxBool challengeLoading = true.obs;
   final RxList<Post> posts = <Post>[].obs;
   final RxBool postsLoading = false.obs;
   final Rxn<Object> postsError = Rxn<Object>();
@@ -39,6 +40,7 @@ class ChallengeFeedController extends GetxController {
     super.onInit();
     _challengeSub = _challengeService.watchCurrentChallenge().listen((c) {
       challenge.value = c;
+      challengeLoading.value = false;
       if (c == null) {
         posts.clear();
         postsLoading.value = false;
@@ -51,6 +53,9 @@ class ChallengeFeedController extends GetxController {
       }
     });
   }
+
+  bool get noActiveChallenge =>
+      !challengeLoading.value && challenge.value == null;
 
   void _subscribeToPosts(String challengeId) {
     postsLoading.value = true;

--- a/lib/pages/challenge/views/challenge_feed_view.dart
+++ b/lib/pages/challenge/views/challenge_feed_view.dart
@@ -16,43 +16,48 @@ class ChallengeFeedView extends GetView<ChallengeFeedController> {
         title: 'challenge'.tr,
       ),
       body: Obx(() {
-        final challenge = controller.challenge.value;
-        if (challenge == null) {
+        if (controller.challengeLoading.value) {
           return const Center(child: CircularProgressIndicator());
         }
-        return Obx(() {
-          if (controller.postsLoading.value) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          if (controller.postsError.value != null) {
-            return Center(
-              child: NothingToShowComponent(
-                icon: const Icon(Icons.error_outline),
-                text: 'somethingWentWrong'.tr,
-              ),
-            );
-          }
-          if (controller.posts.isEmpty) {
-            return Center(
-              child: NothingToShowComponent(
-                imageAsset: 'assets/images/empty.webp',
-                text: controller.hasAnyPosts.value
-                    ? 'challengePostsFiltered'.tr
-                    : 'noHoots'.tr,
-              ),
-            );
-          }
-          return ListView.builder(
-            itemCount: controller.posts.length,
-            itemBuilder: (context, index) => PostComponent(
-              post: controller.posts[index],
-              margin: const EdgeInsets.symmetric(
-                horizontal: 16,
-                vertical: 8,
-              ),
+        if (controller.noActiveChallenge) {
+          return Center(
+            child: NothingToShowComponent(
+              imageAsset: 'assets/images/empty.webp',
+              text: 'noActiveChallenge'.tr,
             ),
           );
-        });
+        }
+        if (controller.postsLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.postsError.value != null) {
+          return Center(
+            child: NothingToShowComponent(
+              icon: const Icon(Icons.error_outline),
+              text: 'somethingWentWrong'.tr,
+            ),
+          );
+        }
+        if (controller.posts.isEmpty) {
+          return Center(
+            child: NothingToShowComponent(
+              imageAsset: 'assets/images/empty.webp',
+              text: controller.hasAnyPosts.value
+                  ? 'challengePostsFiltered'.tr
+                  : 'noHoots'.tr,
+            ),
+          );
+        }
+        return ListView.builder(
+          itemCount: controller.posts.length,
+          itemBuilder: (context, index) => PostComponent(
+            post: controller.posts[index],
+            margin: const EdgeInsets.symmetric(
+              horizontal: 16,
+              vertical: 8,
+            ),
+          ),
+        );
       }),
     );
   }

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -198,6 +198,7 @@ class AppTranslations extends Translations {
           'mainFeedDescription':
               'When you subscribe to feeds, all hoots will be merged here.',
           'noHoots': 'No hoots to show',
+          'noActiveChallenge': 'No challenge is active',
           'challengePostsFiltered':
               'All challenge posts are hidden by your NSFW filter',
           'subscribeToSeeHoots': 'Subscribe to some feeds to see hoots here',
@@ -629,6 +630,7 @@ class AppTranslations extends Translations {
           'mainFeedDescription':
               'Cuando te suscribas a feeds, todos los hoots se combinarán aquí.',
           'noHoots': 'No hay hoots para mostrar',
+          'noActiveChallenge': 'No hay desafío activo',
           'challengePostsFiltered':
               'Todos los hoots del desafío están ocultos por tu filtro NSFW',
           'subscribeToSeeHoots':
@@ -1065,6 +1067,7 @@ class AppTranslations extends Translations {
           'mainFeedDescription':
               'Quando subscreveres a feeds, todos os hoots serão reunidos aqui.',
           'noHoots': 'Não há hoots para mostrar',
+          'noActiveChallenge': 'Nenhum desafio ativo',
           'challengePostsFiltered':
               'Todos os hoots do desafio estão ocultos pelo teu filtro NSFW',
           'subscribeToSeeHoots': 'Subscreve a alguns feeds para ver hoots aqui',
@@ -1496,6 +1499,7 @@ class AppTranslations extends Translations {
           'mainFeedDescription':
               'Quando você se inscrever em feeds, todos os hoots serão reunidos aqui.',
           'noHoots': 'Não há hoots para mostrar',
+          'noActiveChallenge': 'Nenhum desafio ativo',
           'challengePostsFiltered':
               'Todos os hoots do desafio estão ocultos pelo seu filtro NSFW',
           'subscribeToSeeHoots':


### PR DESCRIPTION
## Summary
- track loading and empty challenge states in ChallengeFeedController
- show NothingToShowComponent in ChallengeFeedView when no challenge is active
- add "noActiveChallenge" translations for supported locales

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_68937e3d55c08328bf542ece61791f70