### PR TITLE
feat: notify feed owner on feed request

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ export * from "./triggers/onSubscriptionCreated";
 export * from "./triggers/onPostDeleted";
 export * from "./triggers/onUserUpdated";
 export * from "./triggers/onFeedUpdated";
+export * from "./triggers/onFeedRequestCreated";
 export * from "./triggers/onInvitationUsed";
 export * from "./triggers/onReportCreated";
 export * from "./triggers/onChallengeCreated";

--- a/functions/src/triggers/onFeedRequestCreated.ts
+++ b/functions/src/triggers/onFeedRequestCreated.ts
@@ -1,0 +1,56 @@
+import { onDocumentCreated } from "firebase-functions/v2/firestore";
+import { defineSecret } from "firebase-functions/params";
+import { db } from "../config";
+
+const onesignalApiKey = defineSecret("ONESIGNAL_API_KEY");
+const onesignalAppId = defineSecret("ONESIGNAL_APP_ID");
+
+export const onFeedRequestCreated = onDocumentCreated(
+  {
+    document: "feeds/{feedId}/requests/{userId}",
+    secrets: [onesignalApiKey, onesignalAppId],
+  },
+  async (event) => {
+    const { feedId, userId } = event.params;
+    const appId = onesignalAppId.value();
+    const apiKey = onesignalApiKey.value();
+    if (!appId || !apiKey) return;
+
+    const feedSnap = await db.collection("feeds").doc(feedId).get();
+    if (!feedSnap.exists) return;
+    const ownerId = feedSnap.get("userId") as string | undefined;
+    if (!ownerId || ownerId === userId) return;
+
+    const payload: Record<string, unknown> = {
+      app_id: appId,
+      include_aliases: { external_id: [ownerId] },
+      target_channel: "push",
+      headings: { en: "New Feed Request" },
+      contents: { en: "Someone requested to join your feed" },
+      android_channel_id: "b6b704fe-d3eb-40d7-ba28-9870ad6820cc",
+      ios_sound: "notification.wav",
+      ios_badgeType: "Increase",
+      ios_badgeCount: 1,
+      data: {
+        action: "view_feed_requests",
+      },
+    };
+
+    const res = await fetch(
+      "https://api.onesignal.com/notifications?c=push",
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json; charset=utf-8",
+          Authorization: `Key ${apiKey}`,
+        },
+        body: JSON.stringify(payload),
+      }
+    ).catch(() => undefined);
+
+    if (!res || !res.ok) {
+      const json = JSON.parse((await res?.text()) || "{}");
+      console.error("Failed to send feed request notification", json);
+    }
+  }
+);

--- a/lib/services/onesignal_service.dart
+++ b/lib/services/onesignal_service.dart
@@ -9,6 +9,7 @@ import 'package:hoot/util/routes/args/profile_args.dart';
 /// Wrapper around the OneSignal SDK.
 class OneSignalService extends GetxService {
   Map<String, dynamic>? _pendingData;
+
   /// Initializes the OneSignal SDK.
   Future<void> init() async {
     OneSignal.initialize(dotenv.env['ONESIGNAL_APP_ID']!);
@@ -42,14 +43,17 @@ class OneSignalService extends GetxService {
       Get.toNamed(AppRoutes.post, arguments: {'id': data['postId']});
       return;
     }
+    if (data['action'] == 'view_feed_requests') {
+      Get.toNamed(AppRoutes.feedRequests);
+      return;
+    }
     if (data['feedId'] != null) {
       Get.toNamed(AppRoutes.feed,
           arguments: FeedPageArgs(feedId: data['feedId']));
       return;
     }
     if (data['uid'] != null) {
-      Get.toNamed(AppRoutes.profile,
-          arguments: ProfileArgs(uid: data['uid']));
+      Get.toNamed(AppRoutes.profile, arguments: ProfileArgs(uid: data['uid']));
     }
   }
 }


### PR DESCRIPTION
## Summary
- notify feed owner via OneSignal when a feed request is created
- route `view_feed_requests` OneSignal action to feed request page

## Testing
- `npm test` *(fails: Could not find '/workspace/Hoot/functions/lib/**/*.test.js')*
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_6894592433c4832890ed24e2de75a3af