### PR TITLE
feat: notify users of feed request decisions

### DIFF
--- a/functions/src/triggers/onNotificationCreated.ts
+++ b/functions/src/triggers/onNotificationCreated.ts
@@ -26,6 +26,8 @@ export const onNotificationCreated = onDocumentCreated(
       4: "New ReHoot",
       5: "Friend Joined",
       6: "New Report",
+      7: "Request Accepted",
+      8: "Request Rejected",
     };
     const title = titles[data.type as number];
     if (!title) return;
@@ -42,6 +44,7 @@ export const onNotificationCreated = onDocumentCreated(
     if (user?.uid) trimmedData.uid = user.uid;
     if (user?.username) trimmedData.username = user.username;
     if (user?.bigAvatar) trimmedData.bigAvatar = user.bigAvatar;
+    const feedName = data.feed?.title ? `${data.feed.title}` : "their feed";
     const bodyTemplates: Record<number, string> = {
       0: `${username} liked your post`,
       1: `${username} commented on your post`,
@@ -50,6 +53,8 @@ export const onNotificationCreated = onDocumentCreated(
       4: `${username} reFeeded your post`,
       5: `${username} joined Hoot using your invite code`,
       6: user?.username ? `${username} submitted a report` : "An anonymous user submitted a report",
+      7: `${username} accepted your request to see ${feedName}`,
+      8: `${username} rejected your request to see ${feedName}`,
     };
     const body =
       bodyTemplates[data.type as number] ?? "You have a new notification";

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -74,6 +74,18 @@ class NotificationsView extends GetView<NotificationsController> {
                         case 6:
                           text = 'newReport'.tr;
                           break;
+                        case 7:
+                          text = 'privateFeedRequestAccepted'.trParams({
+                            'username': user.username ?? '',
+                            'feedName': feed?.title ?? '',
+                          });
+                          break;
+                        case 8:
+                          text = 'privateFeedRequestRejected'.trParams({
+                            'username': user.username ?? '',
+                            'feedName': feed?.title ?? '',
+                          });
+                          break;
                         default:
                           text = '';
                       }

--- a/lib/services/feed_request_service.dart
+++ b/lib/services/feed_request_service.dart
@@ -44,8 +44,25 @@ class FeedRequestService {
         .doc(feedId)
         .collection('requests')
         .doc(userId);
+    final feedDoc = await _firestore.collection('feeds').doc(feedId).get();
     await _firestore.runTransaction((txn) async {
       txn.delete(requestRef);
+    });
+    final userData = _authService.currentUser?.toCache() ?? {};
+    final feedData = {
+      'id': feedDoc.id,
+      'title': feedDoc.data()?['title'],
+    };
+    await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('notifications')
+        .add({
+      'user': userData,
+      'feed': feedData,
+      'type': 7,
+      'read': false,
+      'createdAt': FieldValue.serverTimestamp(),
     });
   }
 
@@ -55,8 +72,25 @@ class FeedRequestService {
         .doc(feedId)
         .collection('requests')
         .doc(userId);
+    final feedDoc = await _firestore.collection('feeds').doc(feedId).get();
     await _firestore.runTransaction((txn) async {
       txn.delete(requestRef);
+    });
+    final userData = _authService.currentUser?.toCache() ?? {};
+    final feedData = {
+      'id': feedDoc.id,
+      'title': feedDoc.data()?['title'],
+    };
+    await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('notifications')
+        .add({
+      'user': userData,
+      'feed': feedData,
+      'type': 8,
+      'read': false,
+      'createdAt': FieldValue.serverTimestamp(),
     });
   }
 


### PR DESCRIPTION
## Summary
- notify users when their private feed request is accepted or rejected
- send push notifications for accepted/rejected request types
- display accepted/rejected request notifications in app

## Testing
- `dart analyze lib/services/feed_request_service.dart lib/pages/notifications/views/notifications_view.dart`
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*
- `npm test` *(fails: Could not find '/workspace/Hoot/functions/lib/**/*.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_689461ee2d948328b9d7f4f711687455