### PR TITLE
Add feed requests notification handling

### DIFF
--- a/lib/services/onesignal_service.dart
+++ b/lib/services/onesignal_service.dart
@@ -41,18 +41,12 @@ class OneSignalService extends GetxService {
     _pendingData = null;
     if (data['postId'] != null) {
       Get.toNamed(AppRoutes.post, arguments: {'id': data['postId']});
-      return;
-    }
-    if (data['action'] == 'view_feed_requests') {
+    } else if (data['action'] == 'view_feed_requests') {
       Get.toNamed(AppRoutes.feedRequests);
-      return;
-    }
-    if (data['feedId'] != null) {
+    } else if (data['feedId'] != null) {
       Get.toNamed(AppRoutes.feed,
           arguments: FeedPageArgs(feedId: data['feedId']));
-      return;
-    }
-    if (data['uid'] != null) {
+    } else if (data['uid'] != null) {
       Get.toNamed(AppRoutes.profile, arguments: ProfileArgs(uid: data['uid']));
     }
   }


### PR DESCRIPTION
## Summary
- handle `view_feed_requests` notification action and open Feed Requests page
- refactor pending notification routing logic into `else-if` chain

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*


------
https://chatgpt.com/codex/tasks/task_e_689466707e7883289ee4fd1681cc27e4