### PR TITLE
feat: clear app badge when opening

### DIFF
--- a/lib/pages/home/controllers/home_controller.dart
+++ b/lib/pages/home/controllers/home_controller.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:get/get.dart';
 import 'package:hoot/pages/notifications/controllers/notifications_controller.dart';
 import 'package:hoot/services/auth_service.dart';
@@ -7,7 +8,7 @@ import 'package:hoot/util/routes/app_routes.dart';
 import 'package:screen_corner_radius/screen_corner_radius.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class HomeController extends GetxController {
+class HomeController extends GetxController with WidgetsBindingObserver {
   final selectedIndex = 0.obs;
   final _auth = Get.find<AuthService>();
 
@@ -16,7 +17,21 @@ class HomeController extends GetxController {
   @override
   void onInit() {
     super.onInit();
+    WidgetsBinding.instance.addObserver(this);
     _verifyUser();
+  }
+
+  @override
+  void onClose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.onClose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      Get.find<OneSignalService>().clearBadge();
+    }
   }
 
   Future<void> _setRadius() async {
@@ -54,6 +69,7 @@ class HomeController extends GetxController {
     final quickActions = Get.find<QuickActionsService>();
     quickActions.handlePendingAction();
     oneSignal.handlePendingNotification();
+    await oneSignal.clearBadge();
 
     _setRadius();
   }

--- a/lib/services/onesignal_service.dart
+++ b/lib/services/onesignal_service.dart
@@ -35,6 +35,11 @@ class OneSignalService extends GetxService {
     return OneSignal.Notifications.canRequest();
   }
 
+  /// Clears notifications and resets the app badge.
+  Future<void> clearBadge() {
+    return OneSignal.Notifications.clearAll();
+  }
+
   void handlePendingNotification() {
     final data = _pendingData;
     if (data == null) return;


### PR DESCRIPTION
## Summary
- add `clearBadge` method to OneSignal service to clear notifications and badge count
- reset badge after handling notifications and when app resumes

## Testing
- `flutter analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*
- `flutter test` *(fails: RenderFlex overflow and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68946a399e78832889c2cbccd9554f69