### PR TITLE
Show active challenge card before posts

### DIFF
--- a/lib/pages/challenge/views/challenge_feed_view.dart
+++ b/lib/pages/challenge/views/challenge_feed_view.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
 import 'package:hoot/components/empty_message.dart';
 import 'package:hoot/components/post_component.dart';
+import 'package:hoot/components/challenge_card.dart';
 import 'package:hoot/pages/challenge/challenge_feed_controller.dart';
 
 /// Displays posts tagged with the currently active challenge.
@@ -49,14 +50,28 @@ class ChallengeFeedView extends GetView<ChallengeFeedController> {
           );
         }
         return ListView.builder(
-          itemCount: controller.posts.length,
-          itemBuilder: (context, index) => PostComponent(
-            post: controller.posts[index],
-            margin: const EdgeInsets.symmetric(
-              horizontal: 16,
-              vertical: 8,
-            ),
-          ),
+          itemCount: controller.posts.length + 1,
+          itemBuilder: (context, index) {
+            if (index == 0) {
+              return Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 8,
+                ),
+                child: ChallengeCard.withoutActions(
+                  challenge: controller.challenge.value!,
+                ),
+              );
+            }
+            final post = controller.posts[index - 1];
+            return PostComponent(
+              post: post,
+              margin: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 8,
+              ),
+            );
+          },
         );
       }),
     );


### PR DESCRIPTION
## Summary
- include active ChallengeCard at top of challenge feed
- adjust ListView itemCount and index mapping for new card
- pass current challenge data to card and use no-action variant

## Testing
- `flutter test` *(fails: flutter: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6894a7ed77148328a441dad4a4d1a8f4