### PR TITLE
Make challenge card actions optional

### DIFF
--- a/lib/components/challenge_card.dart
+++ b/lib/components/challenge_card.dart
@@ -9,13 +9,15 @@ class ChallengeCard extends StatefulWidget {
   const ChallengeCard({
     super.key,
     required this.challenge,
-    required this.onJoin,
-    required this.onViewEntries,
+    this.onJoin,
+    this.onViewEntries,
+    this.showActions = true,
   });
 
   final DailyChallenge challenge;
-  final VoidCallback onJoin;
-  final VoidCallback onViewEntries;
+  final VoidCallback? onJoin;
+  final VoidCallback? onViewEntries;
+  final bool showActions;
 
   @override
   State<ChallengeCard> createState() => _ChallengeCardState();
@@ -96,7 +98,10 @@ class _ChallengeCardState extends State<ChallengeCard> {
                   _formatDuration(_remaining),
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                        color: Theme.of(context).colorScheme.onPrimaryContainer.withAlpha(175),
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onPrimaryContainer
+                            .withAlpha(175),
                       ),
                 ),
                 const Divider(
@@ -108,33 +113,43 @@ class _ChallengeCardState extends State<ChallengeCard> {
                   widget.challenge.prompt,
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                    color: Theme.of(context).colorScheme.onPrimaryContainer,
-                  ),
-                ),
-                const SizedBox(height: 32),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: widget.onViewEntries,
-                      style: TextButton.styleFrom(
-                        foregroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
+                        color: Theme.of(context).colorScheme.onPrimaryContainer,
                       ),
-                      child: const Text('View entries'),
-                    ),
-                    const SizedBox(width: 16),
-                    Expanded(
-                      child: ElevatedButton(
-                        onPressed: widget.onJoin,
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Theme.of(context).colorScheme.onPrimaryContainer,
-                          foregroundColor: Theme.of(context).colorScheme.primaryContainer,
+                ),
+                if (widget.showActions) ...[
+                  const SizedBox(height: 32),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: widget.onViewEntries == null
+                            ? null
+                            : () => widget.onViewEntries!(),
+                        style: TextButton.styleFrom(
+                          foregroundColor:
+                              Theme.of(context).colorScheme.onPrimaryContainer,
                         ),
-                        child: const Text('Join Challenge'),
+                        child: const Text('View entries'),
                       ),
-                    ),
-                  ],
-                ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: ElevatedButton(
+                          onPressed: widget.onJoin == null
+                              ? null
+                              : () => widget.onJoin!(),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Theme.of(context)
+                                .colorScheme
+                                .onPrimaryContainer,
+                            foregroundColor:
+                                Theme.of(context).colorScheme.primaryContainer,
+                          ),
+                          child: const Text('Join Challenge'),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ],
             ),
           ).frosted(

--- a/lib/pages/challenge/views/challenge_feed_view.dart
+++ b/lib/pages/challenge/views/challenge_feed_view.dart
@@ -58,8 +58,9 @@ class ChallengeFeedView extends GetView<ChallengeFeedController> {
                   horizontal: 16,
                   vertical: 8,
                 ),
-                child: ChallengeCard.withoutActions(
+                child: ChallengeCard(
                   challenge: controller.challenge.value!,
+                  showActions: false,
                 ),
               );
             }

--- a/lib/pages/explore/views/explore_view.dart
+++ b/lib/pages/explore/views/explore_view.dart
@@ -32,7 +32,7 @@ class ExploreView extends GetView<ExploreController> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           ...controller.userSuggestions.map(
-                (u) => ListTile(
+            (u) => ListTile(
               leading: ProfileAvatarComponent(
                 image: u.largeProfilePictureUrl ?? '',
                 hash: u.bigAvatarHash ?? u.smallAvatarHash,
@@ -47,7 +47,7 @@ class ExploreView extends GetView<ExploreController> {
             ),
           ),
           ...controller.feedSuggestions.map(
-                (f) => ListTile(
+            (f) => ListTile(
               leading: ProfileAvatarComponent(
                 image: f.smallAvatar ?? f.bigAvatar ?? '',
                 hash: f.smallAvatarHash ?? f.bigAvatarHash,
@@ -130,9 +130,10 @@ class ExploreView extends GetView<ExploreController> {
                     onChanged: controller.search,
                   ),
                 ),
-                const SizedBox(height: 16),StreamBuilder<DailyChallenge?>(
+                const SizedBox(height: 16),
+                StreamBuilder<DailyChallenge?>(
                   stream:
-                  Get.find<BaseChallengeService>().watchCurrentChallenge(),
+                      Get.find<BaseChallengeService>().watchCurrentChallenge(),
                   builder: (context, snapshot) {
                     final challenge = snapshot.data;
                     if (challenge == null) return const SizedBox.shrink();
@@ -140,6 +141,7 @@ class ExploreView extends GetView<ExploreController> {
                       padding: const EdgeInsets.symmetric(horizontal: 16),
                       child: ChallengeCard(
                         challenge: challenge,
+                        showActions: true,
                         onJoin: () {
                           final tag = '#${challenge.hashtag} ';
                           Get.toNamed(


### PR DESCRIPTION
## Summary
- Allow ChallengeCard to hide actions via new `showActions` flag
- Make action callbacks optional with null checks
- Update Explore and Challenge feed views to specify `showActions`

## Testing
- `dart analyze` *(fails: Target of URI doesn't exist: 'package:hoot/firebase_options.dart')*
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_6894aa82dd8883288960810d5bd501d6