### PR TITLE
Add music search service and model

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -13,6 +13,7 @@ import 'package:hoot/services/language_service.dart';
 import 'package:hoot/services/news_service.dart';
 import 'package:hoot/services/challenge_service.dart';
 import 'package:hoot/services/app_review_service.dart';
+import 'package:hoot/services/music_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -36,6 +37,7 @@ class DependencyInjector {
     await language.loadLocale();
     Get.put(InvitationService(), permanent: true);
     Get.put<BaseNewsService>(NewsService(), permanent: true);
+    Get.put<BaseMusicService>(MusicService(), permanent: true);
     Get.put<BaseChallengeService>(ChallengeService(), permanent: true);
     await Get.find<OneSignalService>().init();
     await Get.find<QuickActionsService>().init();

--- a/lib/models/music_attachment.dart
+++ b/lib/models/music_attachment.dart
@@ -1,0 +1,22 @@
+class MusicAttachment {
+  final String title;
+  final String artist;
+  final String artworkUrl;
+  final String previewUrl;
+
+  MusicAttachment({
+    required this.title,
+    required this.artist,
+    required this.artworkUrl,
+    required this.previewUrl,
+  });
+
+  factory MusicAttachment.fromJson(Map<String, dynamic> json) {
+    return MusicAttachment(
+      title: json['trackName'] ?? '',
+      artist: json['artistName'] ?? '',
+      artworkUrl: json['artworkUrl100'] ?? '',
+      previewUrl: json['previewUrl'] ?? '',
+    );
+  }
+}

--- a/lib/services/music_service.dart
+++ b/lib/services/music_service.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import 'package:hoot/models/music_attachment.dart';
+
+abstract class BaseMusicService {
+  Future<List<MusicAttachment>> searchSongs(String term);
+}
+
+class MusicService implements BaseMusicService {
+  MusicService({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  @override
+  Future<List<MusicAttachment>> searchSongs(String term) async {
+    try {
+      final uri = Uri.https('itunes.apple.com', '/search', {
+        'term': term,
+        'entity': 'song',
+      });
+      final response = await _client.get(uri);
+      if (response.statusCode != 200) {
+        return [];
+      }
+      final Map<String, dynamic> json = jsonDecode(response.body);
+      final List<dynamic> results = json['results'] as List<dynamic>? ?? [];
+      return results
+          .whereType<Map<String, dynamic>>()
+          .map(MusicAttachment.fromJson)
+          .toList();
+    } catch (_) {
+      return [];
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `MusicAttachment` model for track details
- implement `MusicService` for iTunes song search
- register `MusicService` in dependency injector

## Testing
- `dart analyze lib/models/music_attachment.dart lib/services/music_service.dart lib/dependency_injector.dart`
- `flutter test` *(fails: Some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6894a9d49f1083289a20c2693fa4b453