### PR TITLE
Add music attachment support to Post model

### DIFF
--- a/lib/models/music_attachment.dart
+++ b/lib/models/music_attachment.dart
@@ -19,4 +19,18 @@ class MusicAttachment {
       previewUrl: json['previewUrl'] ?? '',
     );
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'trackName': title,
+      'artistName': artist,
+      'artworkUrl100': artworkUrl,
+      'previewUrl': previewUrl,
+    };
+  }
+
+  Map<String, dynamic> toCache() => toJson();
+
+  factory MusicAttachment.fromCache(Map<String, dynamic> json) =>
+      MusicAttachment.fromJson(json);
 }

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hoot/models/feed.dart';
+import 'package:hoot/models/music_attachment.dart';
 import 'package:hoot/models/user.dart';
 
 class Post {
@@ -9,6 +10,7 @@ class Post {
   List<String>? hashes;
   String? url;
   String? location;
+  MusicAttachment? music;
   U? user;
   String? feedId;
   String? challengeId;
@@ -43,6 +45,7 @@ class Post {
     this.hashes,
     this.url,
     this.location,
+    this.music,
     this.user,
     this.feedId,
     this.challengeId,
@@ -73,6 +76,9 @@ class Post {
       hashes: json['hashes'] != null ? List<String>.from(json['hashes']) : null,
       url: json['url'],
       location: json['location'],
+      music: json['music'] != null
+          ? MusicAttachment.fromJson(json['music'])
+          : null,
       feedId: json['feedId'],
       challengeId: json['challengeId'],
       feed: json['feed'] != null ? Feed.fromJson(json['feed']) : null,
@@ -137,6 +143,7 @@ class Post {
       'challengeId': challengeId,
       'url': url,
       'location': location,
+      'music': music?.toJson(),
       'nsfw': nsfw,
     };
   }
@@ -151,6 +158,7 @@ class Post {
       'challengeId': challengeId,
       'url': url,
       'location': location,
+      'music': music?.toCache(),
       'feed': feed?.toCache(),
       'user': user?.toCache(),
       'liked': liked,
@@ -174,6 +182,9 @@ class Post {
       hashes: json['hashes'] != null ? List<String>.from(json['hashes']) : null,
       url: json['url'],
       location: json['location'],
+      music: json['music'] != null
+          ? MusicAttachment.fromCache(json['music'])
+          : null,
       feedId: json['feedId'],
       challengeId: json['challengeId'],
       feed: json['feed'] != null ? Feed.fromJson(json['feed']) : null,


### PR DESCRIPTION
## Summary
- allow posts to reference an optional music attachment
- serialize/deserialize music attachments for JSON and cache

## Testing
- `flutter test` *(fails: ChallengeFeedController NSFW filtering filters adult posts for young accounts, InviteFriendsView shows invite code and remaining count, DialogService prompt returns null on cancel, plus others)*

------
https://chatgpt.com/codex/tasks/task_e_6894b34244488328bfebfaa5095d6165