### PR TITLE
feat: add music picker and audio playback

### DIFF
--- a/lib/pages/create_post/views/create_post_view.dart
+++ b/lib/pages/create_post/views/create_post_view.dart
@@ -180,18 +180,56 @@ class CreatePostView extends GetView<CreatePostController> {
                     onChanged: controller.onTextChanged,
                   ),
                   const SizedBox(height: 16),
-                  Obx(() => PostMediaPreview(
-                        imageFiles: controller.imageFiles,
-                        gifUrl: controller.gifUrl.value,
-                        onOpenViewer: _openViewer,
-                        onRemoveImage: controller.removeImage,
-                        onCropImage: controller.cropImage,
-                        onRemoveGif: () => controller.gifUrl.value = null,
-                      )),
+                  Obx(() {
+                    final track = controller.music.value;
+                    if (track != null) {
+                      return ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: ClipRRect(
+                          borderRadius: BorderRadius.circular(8),
+                          child: Image.network(
+                            track.artworkUrl,
+                            width: 56,
+                            height: 56,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                        title: Text(track.title),
+                        subtitle: Text(track.artist),
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            IconButton(
+                              icon: Icon(controller.isPlaying.value
+                                  ? Icons.pause
+                                  : Icons.play_arrow),
+                              onPressed: controller.toggleMusicPlayback,
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.close),
+                              onPressed: controller.clearMusic,
+                            ),
+                          ],
+                        ),
+                      );
+                    }
+                    return PostMediaPreview(
+                      imageFiles: controller.imageFiles,
+                      gifUrl: controller.gifUrl.value,
+                      onOpenViewer: _openViewer,
+                      onRemoveImage: controller.removeImage,
+                      onCropImage: controller.cropImage,
+                      onRemoveGif: () => controller.gifUrl.value = null,
+                    );
+                  }),
                   Obx(() {
                     final disableImages = controller.gifUrl.value != null ||
-                        controller.imageFiles.length >= 4;
-                    final disableGif = controller.imageFiles.isNotEmpty;
+                        controller.imageFiles.length >= 4 ||
+                        controller.music.value != null;
+                    final disableGif = controller.imageFiles.isNotEmpty ||
+                        controller.music.value != null;
+                    final disableMusic = controller.imageFiles.isNotEmpty ||
+                        controller.gifUrl.value != null;
                     return Row(
                       children: [
                         IconButton(
@@ -204,6 +242,13 @@ class CreatePostView extends GetView<CreatePostController> {
                           icon: const Icon(Icons.gif_box_rounded),
                           onPressed: disableGif ? null : () => pickGif(context),
                           tooltip: 'addGif'.tr,
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.music_note),
+                          onPressed: disableMusic
+                              ? null
+                              : () => controller.pickMusic(context: context),
+                          tooltip: 'addMusic'.tr,
                         ),
                         IconButton(
                           icon: controller.location.value == null

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -97,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  audio_session:
+    dependency: "direct main"
+    description:
+      name: audio_session
+      sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.25"
   bloc:
     dependency: transitive
     description:
@@ -1141,6 +1149,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.20.2"
+  just_audio:
+    dependency: "direct main"
+    description:
+      name: just_audio
+      sha256: f978d5b4ccea08f267dae0232ec5405c1b05d3f3cd63f82097ea46c015d5c09e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.46"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: "4cd94536af0219fa306205a58e78d67e02b0555283c1c094ee41e402a14a5c4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: "6ba8a2a7e87d57d32f0f7b42856ade3d6a9fbe0f1a11fabae0a4f00bb73f0663"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.16"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -91,6 +91,8 @@ dependencies:
   reorderable_grid_view: ^2.2.8
   share_plus: ^11.0.0
   ticket_widget: ^1.0.2
+  just_audio: ^0.9.37
+  audio_session: ^0.1.18
 
   rss_dart: ^1.0.13
   http: ^1.4.0


### PR DESCRIPTION
## Summary
- add audio player to post creation controller
- show selected music with play/pause controls and removal option
- disable image and gif attachments when music is chosen and hide media preview
- include just_audio dependency

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_6894bf1173f08328bcc340fa29a20c98