### PR TITLE
Add PasteImageIntent for image pasting

### DIFF
--- a/lib/components/mention_text_field.dart
+++ b/lib/components/mention_text_field.dart
@@ -1,9 +1,11 @@
-import 'dart:typed_data';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_mentions/flutter_mentions.dart';
 import 'package:super_clipboard/super_clipboard.dart';
+
+class PasteImageIntent extends Intent {
+  const PasteImageIntent();
+}
 
 /// Text field with @ mention support.
 class MentionTextField extends StatelessWidget {
@@ -70,15 +72,15 @@ class MentionTextField extends StatelessWidget {
     );
 
     return Shortcuts(
-      shortcuts: const <LogicalKeySet, Intent>{
+      shortcuts: <LogicalKeySet, Intent>{
         LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyV):
-            PasteIntent(),
+            const PasteImageIntent(),
         LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyV):
-            PasteIntent(),
+            const PasteImageIntent(),
       },
       child: Actions(
         actions: <Type, Action<Intent>>{
-          PasteIntent: CallbackAction<PasteIntent>(
+          PasteImageIntent: CallbackAction<PasteImageIntent>(
             onInvoke: (intent) async {
               final clipboard = SystemClipboard.instance;
               if (onImagePaste != null && clipboard != null) {


### PR DESCRIPTION
## Summary
- add `PasteImageIntent` custom intent
- wire Meta/Ctrl+V shortcuts to `PasteImageIntent`
- handle `PasteImageIntent` via `CallbackAction`

## Testing
- `flutter analyze lib/components/mention_text_field.dart`
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_6894e72bc9948328a47b60ad2d5440b1