### PR TITLE
Add lowercase username storage and Firestore index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,12 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "users",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "usernameLowercase", "order": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -132,6 +132,7 @@ class U {
     return {
       'displayName': name,
       'username': username,
+      'usernameLowercase': username?.toLowerCase(),
       'smallAvatar': smallProfilePictureUrl,
       'bigAvatar': largeProfilePictureUrl,
       'smallAvatarHash': smallAvatarHash,
@@ -159,6 +160,7 @@ class U {
         'uid': uid,
         'displayName': name,
         'username': username,
+        'usernameLowercase': username?.toLowerCase(),
         'smallAvatar': smallProfilePictureUrl,
         'bigAvatar': largeProfilePictureUrl,
         'smallAvatarHash': smallAvatarHash,

--- a/lib/pages/welcome/controllers/welcome_controller.dart
+++ b/lib/pages/welcome/controllers/welcome_controller.dart
@@ -79,6 +79,7 @@ class WelcomeController extends GetxController {
       await _userService.updateUserData(uid, {
         'uid': uid,
         'username': username,
+        'usernameLowercase': username.toLowerCase(),
       });
     }
     _auth.currentUser?.username = username;

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -17,10 +17,15 @@ class UserService implements BaseUserService {
 
   @override
   Future<void> updateUserData(String uid, Map<String, dynamic> data) {
+    final updated = Map<String, dynamic>.from(data);
+    if (updated.containsKey('username')) {
+      updated['usernameLowercase'] =
+          (updated['username'] as String?)?.toLowerCase();
+    }
     return _firestore
         .collection('users')
         .doc(uid)
-        .set(data, SetOptions(merge: true));
+        .set(updated, SetOptions(merge: true));
   }
 
   @override

--- a/test/models_test.dart
+++ b/test/models_test.dart
@@ -71,6 +71,7 @@ void main() {
       final json = user.toJson();
       expect(json['displayName'], 'John');
       expect(json['username'], 'john');
+      expect(json['usernameLowercase'], 'john');
       expect(json.containsKey('uid'), isFalse);
       expect(json['invitationCode'], 'ABCDEF');
       expect(json['smallAvatarHash'], 'uhash');
@@ -80,6 +81,7 @@ void main() {
       final cache = user.toCache();
       expect(cache['activityScore'], 5);
       expect(cache['popularityScore'], 10);
+      expect(cache['usernameLowercase'], 'john');
       expect(cache['smallAvatarHash'], 'uhash');
       expect(cache['bigAvatarHash'], 'ubhash');
       expect(cache['createdAt'], isNotNull);

--- a/test/welcome_controller_test.dart
+++ b/test/welcome_controller_test.dart
@@ -91,6 +91,7 @@ void main() {
     expect(result, isTrue);
     expect(userService.lastUid, 'u1');
     expect(userService.lastData?['username'], 'jane_doe');
+    expect(userService.lastData?['usernameLowercase'], 'jane_doe');
     expect(authService.currentUser?.username, 'jane_doe');
 
     controller.onClose();


### PR DESCRIPTION
## Summary
- store a lowercase username alongside user data for case-insensitive search
- propagate usernameLowercase when saving usernames and through UserService
- define Firestore index on users.usernameLowercase for range queries

## Testing
- `flutter test test/welcome_controller_test.dart test/models_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_6894f9c6b85483288472bb3a43919e7e