### PR TITLE
Add lowercase feed title field and backfill script

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -3,9 +3,12 @@
     {
       "collectionGroup": "users",
       "queryScope": "COLLECTION",
-      "fields": [
-        { "fieldPath": "usernameLowercase", "order": "ASCENDING" }
-      ]
+      "fields": [{ "fieldPath": "usernameLowercase", "order": "ASCENDING" }]
+    },
+    {
+      "collectionGroup": "feeds",
+      "queryScope": "COLLECTION",
+      "fields": [{ "fieldPath": "titleLowercase", "order": "ASCENDING" }]
     }
   ],
   "fieldOverrides": []

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,8 @@
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log",
-    "test": "npm run build && node --test lib/**/*.test.js"
+    "test": "npm run build && node --test lib/**/*.test.js",
+    "backfill:title-lowercase": "npm run build && node lib/backfillTitleLowercase.js"
   },
   "engines": {
     "node": "22"

--- a/functions/src/backfillTitleLowercase.ts
+++ b/functions/src/backfillTitleLowercase.ts
@@ -1,0 +1,23 @@
+import { db } from "./config";
+
+async function backfillTitleLowercase() {
+  const snapshot = await db.collection("feeds").get();
+  const updates = snapshot.docs.map((doc) => {
+    const title = doc.get("title");
+    if (typeof title === "string") {
+      return doc.ref.update({ titleLowercase: title.toLowerCase() });
+    }
+    return Promise.resolve();
+  });
+  await Promise.all(updates);
+}
+
+backfillTitleLowercase()
+  .then(() => {
+    console.log("Backfill completed");
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("Backfill failed", err);
+    process.exit(1);
+  });

--- a/lib/pages/feed_editor/controllers/feed_editor_controller.dart
+++ b/lib/pages/feed_editor/controllers/feed_editor_controller.dart
@@ -168,6 +168,7 @@ class FeedEditorController extends GetxController {
 
     await docRef.set({
       'title': title,
+      'titleLowercase': title.toLowerCase(),
       'description': description,
       'color': selectedColor.value.value.toString(),
       'type': type.toString().split('.').last,
@@ -253,6 +254,7 @@ class FeedEditorController extends GetxController {
 
     await _firestore.collection('feeds').doc(feed!.id).update({
       'title': title,
+      'titleLowercase': title.toLowerCase(),
       'description': description,
       'color': selectedColor.value.value.toString(),
       'type': type.toString().split('.').last,


### PR DESCRIPTION
## Summary
- store lowercase feed title when creating or updating feeds
- add script to backfill existing feed documents with lowercase titles
- index feeds.titleLowercase to support range queries

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*
- `npm --prefix functions test` *(fails: Could not find '/workspace/Hoot/functions/lib/**/*.test.js')*
- `npm --prefix functions run backfill:title-lowercase` *(fails: Unable to detect a Project Id in the current environment)*
- `npx firebase-tools firestore:indexes` *(fails: Failed to authenticate, have you run firebase login?)*

------
https://chatgpt.com/codex/tasks/task_e_6894fdd3acb483288396f6b8519f6fac