### PR TITLE
Ensure username lookups are case-insensitive

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -93,7 +93,7 @@ class AuthService {
   Future<U?> fetchUserByUsername(String username) async {
     final query = await _firestore
         .collection('users')
-        .where('username', isEqualTo: username)
+        .where('usernameLowercase', isEqualTo: username.toLowerCase())
         .limit(1)
         .get();
     if (query.docs.isEmpty) return null;
@@ -119,10 +119,11 @@ class AuthService {
 
   /// Returns users whose username starts with [query].
   Future<List<U>> searchUsers(String query, {int limit = 5}) async {
+    final q = query.toLowerCase();
     final snapshot = await _firestore
         .collection('users')
-        .where('username', isGreaterThanOrEqualTo: query)
-        .where('username', isLessThanOrEqualTo: '$query\uf8ff')
+        .where('usernameLowercase', isGreaterThanOrEqualTo: q)
+        .where('usernameLowercase', isLessThanOrEqualTo: '$q\uf8ff')
         .limit(limit)
         .get();
     return snapshot.docs.map((d) => U.fromJson(d.data())).toList();

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -40,10 +40,11 @@ class UserService implements BaseUserService {
 
   @override
   Future<List<U>> searchUsers(String query) async {
+    final q = query.toLowerCase();
     final snapshot = await _firestore
         .collection('users')
-        .where('username', isGreaterThanOrEqualTo: query)
-        .where('username', isLessThanOrEqualTo: '$query\uf8ff')
+        .where('usernameLowercase', isGreaterThanOrEqualTo: q)
+        .where('usernameLowercase', isLessThanOrEqualTo: '$q\uf8ff')
         .limit(5)
         .get();
     return snapshot.docs.map((d) => U.fromJson(d.data())).toList();

--- a/test/auth_service_test.dart
+++ b/test/auth_service_test.dart
@@ -3,6 +3,7 @@ import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'package:hoot/services/auth_service.dart';
 
@@ -47,6 +48,33 @@ void main() {
 
     final doc = await firestore.collection('users').doc('u1').get();
     expect(doc.get('displayName'), 'John');
+  });
+
+  test('fetchUserByUsername is case-insensitive', () async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('users').doc('u1').set({
+      'uid': 'u1',
+      'username': 'Alice',
+      'usernameLowercase': 'alice',
+      'createdAt': Timestamp.now(),
+    });
+    final service = AuthService(firestore: firestore);
+    final user = await service.fetchUserByUsername('ALICE');
+    expect(user, isNotNull);
+    expect(user!.username, 'Alice');
+  });
+
+  test('searchUsers matches usernames case-insensitively', () async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('users').doc('u1').set({
+      'uid': 'u1',
+      'username': 'Alice',
+      'usernameLowercase': 'alice',
+    });
+    final service = AuthService(firestore: firestore);
+    final results = await service.searchUsers('AL');
+    expect(results, hasLength(1));
+    expect(results.first.username, 'Alice');
   });
 }
 

--- a/test/user_service_test.dart
+++ b/test/user_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:hoot/services/user_service.dart';
+
+void main() {
+  test('searchUsers matches usernames case-insensitively', () async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('users').doc('u1').set({
+      'uid': 'u1',
+      'username': 'Alice',
+      'usernameLowercase': 'alice',
+    });
+    final service = UserService(firestore: firestore);
+    final results = await service.searchUsers('AL');
+    expect(results, hasLength(1));
+    expect(results.first.username, 'Alice');
+  });
+
+  test('isUsernameAvailable checks in lowercase', () async {
+    final firestore = FakeFirebaseFirestore();
+    await firestore.collection('users').doc('u1').set({
+      'uid': 'u1',
+      'username': 'Alice',
+      'usernameLowercase': 'alice',
+    });
+    final service = UserService(firestore: firestore);
+    expect(await service.isUsernameAvailable('ALICE'), isFalse);
+    expect(await service.isUsernameAvailable('bob'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- Query `usernameLowercase` in AuthService and UserService
- Add tests verifying case-insensitive username searches

## Testing
- `flutter test` *(fails: RenderFlex overflow in invite_friends_view_test; missing Cancel button in services_test)*

------
https://chatgpt.com/codex/tasks/task_e_68950304594c83289d07bc1f8d5f6d69