### PR TITLE
Guard Crashlytics in debug mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_mentions/flutter_mentions.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -37,8 +39,12 @@ void main() {
       appleProvider: AppleProvider.appAttestWithDeviceCheckFallback,
     );
     await DependencyInjector.init();
-    await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
-    FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+    await FirebaseCrashlytics.instance
+        .setCrashlyticsCollectionEnabled(!kDebugMode);
+    if (!kDebugMode) {
+      FlutterError.onError =
+          FirebaseCrashlytics.instance.recordFlutterFatalError;
+    }
 
     final languageService = Get.find<LanguageService>();
     TenorGifPicker.init(
@@ -91,6 +97,8 @@ void main() {
     });
     FlutterNativeSplash.remove();
   }, (error, stack) {
-    FirebaseCrashlytics.instance.recordError(error, stack);
+    if (!kDebugMode) {
+      FirebaseCrashlytics.instance.recordError(error, stack);
+    }
   });
 }

--- a/lib/pages/challenge/challenge_feed_controller.dart
+++ b/lib/pages/challenge/challenge_feed_controller.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:hoot/models/daily_challenge.dart';
 import 'package:hoot/models/post.dart';
@@ -75,11 +76,13 @@ class ChallengeFeedController extends GetxController {
       posts.value = filterPosts(fetched);
       postsLoading.value = false;
     }, onError: (e, st) {
-      FirebaseCrashlytics.instance.recordError(
-        e,
-        st,
-        reason: 'Failed to load challenge posts',
-      );
+      if (!kDebugMode) {
+        FirebaseCrashlytics.instance.recordError(
+          e,
+          st,
+          reason: 'Failed to load challenge posts',
+        );
+      }
       postsError.value = e;
       postsLoading.value = false;
     });

--- a/lib/pages/feed/controllers/feed_controller.dart
+++ b/lib/pages/feed/controllers/feed_controller.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
@@ -41,11 +42,13 @@ class FeedController extends GetxController {
       );
     } catch (e) {
       state.value = state.value.copyWith(error: e, isLoading: false);
-      FirebaseCrashlytics.instance.recordError(
-        e,
-        null,
-        reason: 'Failed to load feed posts',
-      );
+      if (!kDebugMode) {
+        FirebaseCrashlytics.instance.recordError(
+          e,
+          null,
+          reason: 'Failed to load feed posts',
+        );
+      }
     }
   }
 

--- a/lib/pages/post/controllers/post_controller.dart
+++ b/lib/pages/post/controllers/post_controller.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
@@ -99,11 +100,13 @@ class PostController extends GetxController {
     } catch (e) {
       commentsState.value =
           commentsState.value.copyWith(error: e, isLoading: false);
-      FirebaseCrashlytics.instance.recordError(
-        e,
-        null,
-        reason: 'Failed to load comments',
-      );
+      if (!kDebugMode) {
+        FirebaseCrashlytics.instance.recordError(
+          e,
+          null,
+          reason: 'Failed to load comments',
+        );
+      }
     }
   }
 
@@ -115,11 +118,13 @@ class PostController extends GetxController {
         post.value = fetched;
       }
     } catch (e) {
-      FirebaseCrashlytics.instance.recordError(
-        e,
-        null,
-        reason: 'Failed to refresh post',
-      );
+      if (!kDebugMode) {
+        FirebaseCrashlytics.instance.recordError(
+          e,
+          null,
+          reason: 'Failed to refresh post',
+        );
+      }
     }
   }
 
@@ -183,11 +188,13 @@ class PostController extends GetxController {
       post.value.comments = (post.value.comments ?? 0) + 1;
       post.refresh();
     } catch (e) {
-      FirebaseCrashlytics.instance.recordError(
-        e,
-        null,
-        reason: 'Failed to publish comment',
-      );
+      if (!kDebugMode) {
+        FirebaseCrashlytics.instance.recordError(
+          e,
+          null,
+          reason: 'Failed to publish comment',
+        );
+      }
     } finally {
       postingComment.value = false;
     }

--- a/lib/services/error_service.dart
+++ b/lib/services/error_service.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/foundation.dart';
 import 'package:hoot/services/toast_service.dart';
 
 /// Service providing a simple API to report non fatal errors.
@@ -8,11 +9,13 @@ class ErrorService {
   /// Logs [error] to Crashlytics and shows a toast with [message].
   static Future<void> reportError(dynamic error,
       {String? message, StackTrace? stack}) async {
-    await FirebaseCrashlytics.instance.recordError(
-      error,
-      stack ?? StackTrace.current,
-      reason: message,
-    );
+    if (!kDebugMode) {
+      await FirebaseCrashlytics.instance.recordError(
+        error,
+        stack ?? StackTrace.current,
+        reason: message,
+      );
+    }
     ToastService.showError(message ?? error.toString());
   }
 }


### PR DESCRIPTION
## Summary
- import kDebugMode and gate Crashlytics initialization in `main.dart`
- prevent Crashlytics logging in debug across controllers and services

## Testing
- `flutter build apk --debug` *(fails: No Android SDK found)*
- `flutter test` *(fails: InviteFriendsView test and others timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68959b7eb584832895aa9ca32f45a526