### PR TITLE
refactor: centralize feed error reporting

### DIFF
--- a/lib/pages/feed/controllers/feed_controller.dart
+++ b/lib/pages/feed/controllers/feed_controller.dart
@@ -1,11 +1,10 @@
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
-import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
 import 'package:hoot/models/post.dart';
 import 'package:hoot/services/feed_service.dart';
+import 'package:hoot/services/error_service.dart';
 
 /// Controller responsible for fetching posts for the feed view.
 class FeedController extends GetxController {
@@ -42,13 +41,7 @@ class FeedController extends GetxController {
       );
     } catch (e) {
       state.value = state.value.copyWith(error: e, isLoading: false);
-      if (!kDebugMode) {
-        FirebaseCrashlytics.instance.recordError(
-          e,
-          null,
-          reason: 'Failed to load feed posts',
-        );
-      }
+      ErrorService.reportError(e, message: 'Failed to load feed posts');
     }
   }
 


### PR DESCRIPTION
## Summary
- route feed errors through ErrorService instead of direct Crashlytics use

## Testing
- `flutter analyze` *(fails: 41 issues found)*
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_6895a3c53e948328a7ade6b0e76c30ea