### PR TITLE
Use ErrorService for location errors

### DIFF
--- a/lib/pages/create_post/controllers/create_post_controller.dart
+++ b/lib/pages/create_post/controllers/create_post_controller.dart
@@ -193,8 +193,11 @@ class CreatePostController extends GetxController {
         }
       }
     } catch (e, s) {
-      await ErrorService.reportError(e, stack: s);
-      ToastService.showError('couldNotGetLocation'.tr);
+      await ErrorService.reportError(
+        e,
+        message: 'couldNotGetLocation'.tr,
+        stack: s,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- use `ErrorService.reportError` to log and show location fetch failures in `toggleLocation`

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_6895a3c7e2248328ab2f170946cce4fe