### PR TITLE
Log missing UID during invitation verification

### DIFF
--- a/lib/pages/invitation/controllers/invitation_controller.dart
+++ b/lib/pages/invitation/controllers/invitation_controller.dart
@@ -36,7 +36,8 @@ class InvitationController extends GetxController {
     try {
       final uid = _authService.currentUser?.uid;
       if (uid == null) {
-        ToastService.showError('somethingWentWrong'.tr);
+        await ErrorService.reportError('Missing UID',
+            message: 'somethingWentWrong'.tr);
         return;
       }
       final success = await _invitationService.useInvitationCode(uid, code);


### PR DESCRIPTION
## Summary
- log missing UID in invitation code verification and surface toast

## Testing
- `dart analyze`
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_6895a3c919fc83289bd6d270a98edd38