### PR TITLE
Handle base64 images in photo view

### DIFF
--- a/lib/pages/photo_view/views/photo_view.dart
+++ b/lib/pages/photo_view/views/photo_view.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/pages/photo_view/controllers/photo_view_controller.dart';
@@ -11,8 +13,27 @@ class PhotoZoomView extends GetView<PhotoZoomViewController> {
     final imageUrl = controller.imageUrl;
     if (imageUrl.startsWith('http')) {
       return NetworkImage(imageUrl);
-    } else {
-      return AssetImage(imageUrl);
+    }
+    if (imageUrl.startsWith('data:')) {
+      final base64Data = imageUrl.split(',').last;
+      return MemoryImage(base64Decode(base64Data));
+    }
+    if (_isBase64(imageUrl)) {
+      return MemoryImage(base64Decode(imageUrl));
+    }
+    return AssetImage(imageUrl);
+  }
+
+  bool _isBase64(String str) {
+    final regex = RegExp(r'^[A-Za-z0-9+/]+={0,2}$');
+    if (str.length % 4 != 0 || !regex.hasMatch(str)) {
+      return false;
+    }
+    try {
+      base64Decode(str);
+      return true;
+    } catch (_) {
+      return false;
     }
   }
 

--- a/test/photo_view_base64_test.dart
+++ b/test/photo_view_base64_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:photo_view/photo_view.dart';
+
+import 'package:hoot/pages/photo_view/controllers/photo_view_controller.dart';
+import 'package:hoot/pages/photo_view/views/photo_view.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  Get.testMode = true;
+
+  testWidgets('displays base64 image', (tester) async {
+    const base64Image =
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+    Get.put(PhotoZoomViewController(imageUrl: base64Image));
+    await tester.pumpWidget(const GetMaterialApp(home: PhotoZoomView()));
+    await tester.pump();
+    final photoView = tester.widget<PhotoView>(find.byType(PhotoView));
+    expect(photoView.imageProvider, isA<MemoryImage>());
+    Get.reset();
+  });
+}


### PR DESCRIPTION
## Summary
- support base64 strings and data URIs in PhotoZoomView image provider
- add widget test to confirm base64 images render as MemoryImage

## Testing
- `flutter test test/photo_view_base64_test.dart`


------
https://chatgpt.com/codex/tasks/task_e_6895aadfa9248328a5d77fb4eb05a92d