### PR TITLE
Pass image argument as map to photo viewer

### DIFF
--- a/lib/pages/photo_view/bindings/photo_view_binding.dart
+++ b/lib/pages/photo_view/bindings/photo_view_binding.dart
@@ -4,7 +4,15 @@ import 'package:hoot/pages/photo_view/controllers/photo_view_controller.dart';
 class PhotoViewBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut(
-        () => PhotoZoomViewController(imageUrl: Get.arguments['imageUrl']));
+    final args = Get.arguments;
+    String url;
+    if (args is Map && args['imageUrl'] != null) {
+      url = args['imageUrl'];
+    } else if (args is String) {
+      url = args;
+    } else {
+      url = '';
+    }
+    Get.lazyPut(() => PhotoZoomViewController(imageUrl: url));
   }
 }

--- a/lib/pages/staff_feedbacks/views/staff_feedbacks_view.dart
+++ b/lib/pages/staff_feedbacks/views/staff_feedbacks_view.dart
@@ -36,7 +36,7 @@ class StaffFeedbacksView extends GetView<StaffFeedbacksController> {
                   ? GestureDetector(
                       onTap: () => Get.toNamed(
                         AppRoutes.photoViewer,
-                        arguments: fb.screenshot,
+                        arguments: {'imageUrl': fb.screenshot},
                       ),
                       child: Image.network(
                         fb.screenshot!,
@@ -48,8 +48,10 @@ class StaffFeedbacksView extends GetView<StaffFeedbacksController> {
                   : null,
               title: Text(fb.message),
               onTap: fb.screenshot != null
-                  ? () => Get.toNamed(AppRoutes.photoViewer,
-                      arguments: fb.screenshot)
+                  ? () => Get.toNamed(
+                        AppRoutes.photoViewer,
+                        arguments: {'imageUrl': fb.screenshot},
+                      )
                   : null,
             );
           },

--- a/test/staff_feedbacks_view_photo_view_test.dart
+++ b/test/staff_feedbacks_view_photo_view_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+
+import 'package:hoot/models/feedback.dart' as fb;
+import 'package:hoot/pages/staff_feedbacks/controllers/staff_feedbacks_controller.dart';
+import 'package:hoot/pages/staff_feedbacks/views/staff_feedbacks_view.dart';
+import 'package:hoot/pages/photo_view/views/photo_view.dart';
+import 'package:hoot/pages/photo_view/bindings/photo_view_binding.dart';
+import 'package:hoot/pages/photo_view/controllers/photo_view_controller.dart';
+import 'package:hoot/util/routes/app_routes.dart';
+import 'package:hoot/services/feedback_service.dart';
+
+class FakeFeedbackService implements BaseFeedbackService {
+  @override
+  Future<List<fb.Feedback>> fetchFeedbacks() async => [
+        fb.Feedback(
+          id: '1',
+          message: 'msg',
+          screenshot: 'https://example.com/img.png',
+          userId: 'u1',
+          createdAt: DateTime.now(),
+        ),
+      ];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  Get.testMode = true;
+
+  testWidgets('tapping feedback navigates to photo viewer with imageUrl',
+      (tester) async {
+    final service = FakeFeedbackService();
+    Get.put(StaffFeedbacksController(service: service));
+
+    await tester.pumpWidget(GetMaterialApp(
+      getPages: [
+        GetPage(name: '/', page: () => const StaffFeedbacksView()),
+        GetPage(
+          name: AppRoutes.photoViewer,
+          page: () => const PhotoZoomView(),
+          binding: PhotoViewBinding(),
+        ),
+      ],
+    ));
+    await tester.pumpAndSettle();
+    // Clear network image exceptions which can occur because tests block HTTP
+    // requests by default.
+    while (tester.takeException() != null) {}
+
+    await tester.tap(find.byType(ListTile));
+    await tester.pumpAndSettle();
+    while (tester.takeException() != null) {}
+
+    final controller = Get.find<PhotoZoomViewController>();
+    expect(controller.imageUrl, 'https://example.com/img.png');
+    Get.reset();
+  });
+}


### PR DESCRIPTION
## Summary
- pass screenshot URLs to the photo viewer using a map from staff feedback items
- allow `PhotoViewBinding` to read either a map or direct string
- add a smoke test that navigates from staff feedbacks to the photo viewer

## Testing
- `flutter test test/staff_feedbacks_view_photo_view_test.dart -r json`
- `flutter test` *(fails: BaseChallengeService not found, network image exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_6895ad0bb6fc8328a845faf8e17cb590