### PR TITLE
feat(functions): track user streaks

### DIFF
--- a/functions/src/triggers/onCommentCreated.ts
+++ b/functions/src/triggers/onCommentCreated.ts
@@ -1,6 +1,7 @@
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { db } from "../config";
+import { updateStreak } from "../utils/updateStreak";
 
 export const onCommentCreated = onDocumentCreated(
   "posts/{postId}/comments/{commentId}",
@@ -66,5 +67,6 @@ export const onCommentCreated = onDocumentCreated(
       .collection("users")
       .doc(userId)
       .update({ activityScore: FieldValue.increment(1) });
+    await updateStreak(userId);
   }
 );

--- a/functions/src/triggers/onLikeCreated.ts
+++ b/functions/src/triggers/onLikeCreated.ts
@@ -1,6 +1,7 @@
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { db } from "../config";
+import { updateStreak } from "../utils/updateStreak";
 
 export const onLikeCreated = onDocumentCreated(
   "posts/{postId}/likes/{userId}",
@@ -31,5 +32,6 @@ export const onLikeCreated = onDocumentCreated(
       .collection("users")
       .doc(ownerId)
       .update({ popularityScore: FieldValue.increment(1) });
+    await updateStreak(userId);
   }
 );

--- a/functions/src/triggers/onPostCreated.ts
+++ b/functions/src/triggers/onPostCreated.ts
@@ -1,6 +1,7 @@
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { FieldValue } from "firebase-admin/firestore";
 import { db } from "../config";
+import { updateStreak } from "../utils/updateStreak";
 
 export const onPostCreated = onDocumentCreated(
   "posts/{postId}",
@@ -73,5 +74,6 @@ export const onPostCreated = onDocumentCreated(
     }
 
     await db.collection("users").doc(userId).update(updates);
+    await updateStreak(userId);
   }
 );

--- a/functions/src/utils/updateStreak.ts
+++ b/functions/src/utils/updateStreak.ts
@@ -1,0 +1,29 @@
+import { db } from "../config";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
+
+export async function updateStreak(userId: string) {
+  await db.runTransaction(async (tx) => {
+    const ref = db.collection("users").doc(userId);
+    const snap = await tx.get(ref);
+    if (!snap.exists) return;
+
+    const lastAction = snap.get("lastActionAt") as Timestamp | undefined;
+    const lastActionDate = lastAction?.toDate();
+    const now = new Date();
+    const startOfToday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+    const startOfYesterday = new Date(startOfToday);
+    startOfYesterday.setUTCDate(startOfYesterday.getUTCDate() - 1);
+    let streak = (snap.get("streakCount") as number) || 0;
+    if (!lastActionDate || lastActionDate < startOfToday) {
+      if (lastActionDate && lastActionDate >= startOfYesterday) {
+        streak += 1;
+      } else {
+        streak = 1;
+      }
+    }
+    tx.update(ref, {
+      streakCount: streak,
+      lastActionAt: FieldValue.serverTimestamp(),
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add transactional `updateStreak` helper for user streaks
- call `updateStreak` from post, like, and comment triggers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e0feaf948328a2b636393b67307f