### PR TITLE
feat: add streak reminder scheduler

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,3 +13,4 @@ export * from "./triggers/onReportCreated";
 export * from "./triggers/onChallengeCreated";
 export * from "./feedback";
 export * from "./createDailyChallenge";
+export * from "./scheduler/sendStreakReminder";

--- a/functions/src/scheduler/sendStreakReminder.ts
+++ b/functions/src/scheduler/sendStreakReminder.ts
@@ -1,0 +1,24 @@
+import { onSchedule } from "firebase-functions/v2/scheduler";
+import { FieldValue } from "firebase-admin/firestore";
+import { db } from "../config";
+
+export const sendStreakReminder = onSchedule("0 18 * * *", async () => {
+  const today = new Date();
+  today.setUTCHours(0, 0, 0, 0);
+  const snapshot = await db
+    .collection("users")
+    .where("lastActionAt", "<", today)
+    .get();
+  const writes = snapshot.docs.map((doc) =>
+    db
+      .collection("users")
+      .doc(doc.id)
+      .collection("notifications")
+      .add({
+        type: 9,
+        read: false,
+        createdAt: FieldValue.serverTimestamp(),
+      })
+  );
+  await Promise.all(writes);
+});


### PR DESCRIPTION
## Summary
- add sendStreakReminder scheduled function to notify users who haven't acted today
- export sendStreakReminder from the main functions index

## Testing
- `npm test` *(fails: Could not find '/workspace/Hoot/functions/lib/**/*.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_6895e4406e808328b0318fc8fd9ffe7f