### PR TITLE
Add streak reminder notification

### DIFF
--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -87,6 +87,9 @@ class NotificationsView extends GetView<NotificationsController> {
                             'feedName': feed?.title ?? '',
                           });
                           break;
+                        case 9:
+                          text = 'streakReminder'.tr;
+                          break;
                         default:
                           text = '';
                       }

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -387,6 +387,8 @@ class AppTranslations extends Translations {
               '@username rejected your request to see their private feed: @feedName',
           'userLikedYourHoot': '@username liked your hoot',
           'userReFeededYourHoot': '@username reFeeded your hoot',
+          'streakReminder':
+              'Hoot, like, comment or rehoot to keep your streak!',
           'hootMightBeBuggy':
               'I wanted to let you know that I created Hoot all by myself during my summer break. It was a labor of love, and I poured my heart and soul into crafting a platform that could connect people and foster community. But, being a one-person team working within a limited timeframe, there might be a few bugs or features that don\'t quite work as intended. I appreciate your patience and understanding as I iron out these kinks and make the app better. I want to emphasize that your security and the protection of your information have been my top priorities from the get-go. I\'ve implemented strong security measures to ensure your data is safe and handled with the utmost care. While I am just one person, I\'m fully dedicated to improving Hoot. I\'m committed to updating and refining the app, making it the best it can be. Your feedback and support mean the world to me, and I\'m excited to grow Hoot into something truly exceptional in the future. Thank you for being a part of this journey, and I can\'t wait for you to see how Hoot evolves and becomes even greater over time.',
           'messageFromCreator': 'Message from the creator',
@@ -430,7 +432,8 @@ class AppTranslations extends Translations {
           'trendingNews': 'Trending News',
           'trendingIn': 'Trending in @topic',
           'reorderFeeds': 'You can reorder your feeds by dragging them',
-          'inviteFriendsDescription': 'Share your invite code with friends and let them join Hoot!',
+          'inviteFriendsDescription':
+              'Share your invite code with friends and let them join Hoot!',
           'challenge': 'Challenge',
           'searchForMusicTitle': 'Search for music',
           'searchForMusicDescription': 'Make your Hoot stand out with music',
@@ -828,6 +831,8 @@ class AppTranslations extends Translations {
               '@username rechazó tu solicitud para ver su feed privado: @feedName',
           'userLikedYourHoot': '@username le dio me gusta a tu hoot',
           'userReFeededYourHoot': '@username rehootió tu hoot',
+          'streakReminder':
+              'Haz un Hoot, dale me gusta, comenta o rehootea para mantener tu racha!',
           'hootMightBeBuggy':
               'Quería informarte que creé Hoot por mi cuenta durante mis vacaciones de verano. Fue un trabajo lleno de amor, y puse todo mi corazón y alma en crear una plataforma que pudiera conectar a las personas y fomentar la comunidad. Sin embargo, al ser un equipo de una sola persona trabajando en un marco de tiempo limitado, es posible que haya algunos errores o características que no funcionen como se pretendía. Agradezco tu paciencia y comprensión mientras corrijo estos problemas y mejoro la aplicación. Quiero enfatizar que tu seguridad y la protección de tu información han sido mis principales prioridades desde el principio. He implementado fuertes medidas de seguridad para garantizar que tus datos estén seguros y se manejen con el mayor cuidado. Aunque soy solo una persona, estoy totalmente dedicado a mejorar Hoot. Me comprometo a actualizar y perfeccionar la aplicación, para que sea lo mejor posible. Tus comentarios y apoyo significan mucho para mí, y estoy emocionado de hacer que Hoot se convierta en algo verdaderamente excepcional en el futuro. Gracias por ser parte de este viaje, y no puedo esperar a que veas cómo Hoot evoluciona y se vuelve aún mejor con el tiempo.',
           'messageFromCreator': 'Mensaje del creador',
@@ -871,7 +876,8 @@ class AppTranslations extends Translations {
           'trendingNews': 'Noticias de Tendencia',
           'trendingIn': 'Tendencias en @topic',
           'reorderFeeds': 'Puedes reordenar tus feeds arrastrándolos',
-          'inviteFriendsDescription': '¡Comparte tu código de invitación con amigos y deja que se unan a Hoot!',
+          'inviteFriendsDescription':
+              '¡Comparte tu código de invitación con amigos y deja que se unan a Hoot!',
           'challenge': 'Desafío',
           'searchForMusicTitle': 'Buscar música',
           'searchForMusicDescription': 'Haz que tu Hoot destaque con música',
@@ -1270,6 +1276,8 @@ class AppTranslations extends Translations {
               '@username rejeitou o teu pedido para ver o seu feed privado: @feedName',
           'userLikedYourHoot': '@username gostou do teu hoot',
           'userReFeededYourHoot': '@username rehootou o teu hoot',
+          'streakReminder':
+              'Faz um hoot, gosta, comenta ou rehoota para manter a tua sequência!',
           'hootMightBeBuggy':
               'Queria informar-te que criei o Hoot sozinho durante as minhas férias de verão. Foi um trabalho de amor, e dediquei-me de corpo e alma a criar uma plataforma que pudesse conectar pessoas e fomentar a comunidade. No entanto, sendo uma equipa de uma só pessoa a trabalhar num período limitado, poderão existir alguns bugs ou funcionalidades que não funcionem como planeado. Agradeço a tua paciência e compreensão enquanto resolvo estas questões e melhoro a aplicação. Quero salientar que a tua segurança e a proteção da tua informação foram sempre as minhas principais prioridades. Implementei medidas de segurança rigorosas para garantir que os teus dados estão seguros e são tratados com o máximo cuidado. Apesar de ser apenas uma pessoa, estou totalmente empenhado em melhorar o Hoot. Comprometo-me a atualizar e aperfeiçoar a aplicação, tornando-a o melhor que pode ser. As tuas opiniões e apoio significam muito para mim, e estou entusiasmado por fazer com que o Hoot se torne algo verdadeiramente excepcional no futuro. Obrigado por fazeres parte desta jornada, e mal posso esperar que vejas como o Hoot evolui e se torna ainda melhor ao longo do tempo.',
           'messageFromCreator': 'Mensagem do criador',
@@ -1314,10 +1322,12 @@ class AppTranslations extends Translations {
           'trendingNews': 'Notícias em Alta',
           'trendingIn': 'Em Alta em @topic',
           'reorderFeeds': 'Podes reorganizar os teus feeds arrastando-os',
-          'inviteFriendsDescription': 'Partilha o teu código de convite com amigos e deixa-os entrar no Hoot!',
+          'inviteFriendsDescription':
+              'Partilha o teu código de convite com amigos e deixa-os entrar no Hoot!',
           'challenge': 'Desafio',
           'searchForMusicTitle': 'Procurar música',
-          'searchForMusicDescription': 'Faz com que o teu Hoot se destaque com música',
+          'searchForMusicDescription':
+              'Faz com que o teu Hoot se destaque com música',
           'feedbackSent': 'Obrigado pelo teu feedback!',
         },
         'pt_BR': {
@@ -1709,6 +1719,8 @@ class AppTranslations extends Translations {
               '@username rejeitou sua solicitação para ver o feed privado: @feedName',
           'userLikedYourHoot': '@username curtiu seu hoot',
           'userReFeededYourHoot': '@username rehootou seu hoot',
+          'streakReminder':
+              'Faça um hoot, curta, comente ou rehoote para manter sua sequência!',
           'hootMightBeBuggy':
               'Queria te informar que criei o Hoot sozinho durante as minhas férias de verão. Foi um trabalho de amor, e dediquei-me de corpo e alma a criar uma plataforma que pudesse conectar pessoas e fomentar a comunidade. No entanto, sendo uma equipe de uma só pessoa trabalhando num período limitado, pode ser que ocorram alguns bugs ou funcionalidades que não estejam exatamente como planejado. Agradeço a sua paciência e compreensão enquanto resolvo essas questões e melhoro o aplicativo. Quero salientar que a sua segurança e a proteção das suas informações sempre foram as minhas principais prioridades. Implementei medidas de segurança rigorosas para garantir que seus dados estejam seguros e sejam tratados com o máximo cuidado. Apesar de ser apenas uma pessoa, estou totalmente dedicado a melhorar o Hoot. Comprometo-me a atualizar e aprimorar o aplicativo, tornando-o o melhor possível. Suas opiniões e apoio significam muito para mim, e estou empolgado para fazer com que o Hoot se torne algo verdadeiramente excepcional no futuro. Obrigado por fazer parte desta jornada, e mal posso esperar para que veja como o Hoot evolui e se torna ainda melhor ao longo do tempo.',
           'messageFromCreator': 'Mensagem do criador',
@@ -1753,7 +1765,8 @@ class AppTranslations extends Translations {
           'trendingNews': 'Notícias em Alta',
           'trendingIn': 'Em Alta em @topic',
           'reorderFeeds': 'Você pode reorganizar seus feeds arrastando-os',
-          'inviteFriendsDescription': 'Compartilhe seu código de convite com amigos e deixe-os entrar no Hoot!',
+          'inviteFriendsDescription':
+              'Compartilhe seu código de convite com amigos e deixe-os entrar no Hoot!',
           'challenge': 'Desafio',
           'searchForMusicTitle': 'Procurar música',
           'searchForMusicDescription': 'Faça seu Hoot se destacar com música',


### PR DESCRIPTION
## Summary
- show streak reminder in notifications
- add `streakReminder` translations for en, es, pt-PT, and pt-BR

## Testing
- `flutter test` *(fails: NetworkImageLoadException)*

------
https://chatgpt.com/codex/tasks/task_e_6895e7c9e4808328a0c10aea75183cb7