### PR TITLE
feat: show streak count in profile

### DIFF
--- a/lib/pages/profile/views/profile_view.dart
+++ b/lib/pages/profile/views/profile_view.dart
@@ -470,6 +470,19 @@ class _ProfileViewState extends State<ProfileView> {
                         ),
                       ],
                     ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          '🔥 ${user.streakCount ?? 0} Day Streak',
+                          style: Get.textTheme.bodySmall?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ],
+                    ),
                   ],
                 ),
               ),


### PR DESCRIPTION
## Summary
- show a user's day streak count under profile details

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*

------
https://chatgpt.com/codex/tasks/task_e_6895ed79e748832893b8793e2b1899a1