### PR TITLE
Use translated labels for challenge card actions

### DIFF
--- a/lib/components/challenge_card.dart
+++ b/lib/components/challenge_card.dart
@@ -3,6 +3,7 @@ import 'package:blur/blur.dart';
 import 'package:flutter/material.dart';
 import 'package:hash_cached_image/hash_cached_image.dart';
 import 'package:hoot/models/daily_challenge.dart';
+import 'package:get/get.dart';
 
 /// Card displaying the active daily challenge.
 class ChallengeCard extends StatefulWidget {
@@ -129,7 +130,7 @@ class _ChallengeCardState extends State<ChallengeCard> {
                           foregroundColor:
                               Theme.of(context).colorScheme.onPrimaryContainer,
                         ),
-                        child: const Text('View entries'),
+                        child: Text('viewEntries'.tr),
                       ),
                       const SizedBox(width: 16),
                       Expanded(
@@ -144,7 +145,7 @@ class _ChallengeCardState extends State<ChallengeCard> {
                             foregroundColor:
                                 Theme.of(context).colorScheme.primaryContainer,
                           ),
-                          child: const Text('Join Challenge'),
+                          child: Text('joinChallenge'.tr),
                         ),
                       ),
                     ],

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -435,6 +435,8 @@ class AppTranslations extends Translations {
           'inviteFriendsDescription':
               'Share your invite code with friends and let them join Hoot!',
           'challenge': 'Challenge',
+          'viewEntries': 'View entries',
+          'joinChallenge': 'Join challenge',
           'searchForMusicTitle': 'Search for music',
           'searchForMusicDescription': 'Make your Hoot stand out with music',
           'feedbackSent': 'Thank you for your feedback!',
@@ -879,6 +881,8 @@ class AppTranslations extends Translations {
           'inviteFriendsDescription':
               '¡Comparte tu código de invitación con amigos y deja que se unan a Hoot!',
           'challenge': 'Desafío',
+          'viewEntries': 'Ver participaciones',
+          'joinChallenge': 'Unirse al desafío',
           'searchForMusicTitle': 'Buscar música',
           'searchForMusicDescription': 'Haz que tu Hoot destaque con música',
           'feedbackSent': '¡Gracias por tus comentarios!',
@@ -1325,6 +1329,8 @@ class AppTranslations extends Translations {
           'inviteFriendsDescription':
               'Partilha o teu código de convite com amigos e deixa-os entrar no Hoot!',
           'challenge': 'Desafio',
+          'viewEntries': 'Ver participações',
+          'joinChallenge': 'Participar no desafio',
           'searchForMusicTitle': 'Procurar música',
           'searchForMusicDescription':
               'Faz com que o teu Hoot se destaque com música',
@@ -1768,6 +1774,8 @@ class AppTranslations extends Translations {
           'inviteFriendsDescription':
               'Compartilhe seu código de convite com amigos e deixe-os entrar no Hoot!',
           'challenge': 'Desafio',
+          'viewEntries': 'Ver participações',
+          'joinChallenge': 'Participar do desafio',
           'searchForMusicTitle': 'Procurar música',
           'searchForMusicDescription': 'Faça seu Hoot se destacar com música',
           'feedbackSent': 'Obrigado pelo seu feedback!',


### PR DESCRIPTION
## Summary
- add `viewEntries` and `joinChallenge` translations for all locales
- localize ChallengeCard buttons with these translations

## Testing
- `flutter analyze lib/components/challenge_card.dart lib/util/translations/app_translations.dart`
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_6895f0c269e4832884e71572dfbe3a2b