### PR TITLE
feat: add made in Portugal translation

### DIFF
--- a/lib/pages/feed/views/feed_view.dart
+++ b/lib/pages/feed/views/feed_view.dart
@@ -40,12 +40,12 @@ class FeedView extends GetView<FeedController> {
             title: 'mainFeed'.tr,
             text: 'mainFeedDescription'.tr,
           ),
-          noMoreItemsIndicatorBuilder: (_) => const Padding(
-            padding: EdgeInsets.symmetric(vertical: 32, horizontal: 16),
+          noMoreItemsIndicatorBuilder: (_) => Padding(
+            padding: const EdgeInsets.symmetric(vertical: 32, horizontal: 16),
             child: Opacity(
               opacity: 0.75,
               child: Center(
-                child: Text('Made in Portugal 🇵🇹'),
+                child: Text('madeInPortugal'.tr),
               ),
             ),
           ),

--- a/lib/pages/notifications/views/notifications_view.dart
+++ b/lib/pages/notifications/views/notifications_view.dart
@@ -153,13 +153,13 @@ class NotificationsView extends GetView<NotificationsController> {
                       title: 'noNotifications'.tr,
                       text: 'noNotificationsText'.tr,
                     ),
-                    noMoreItemsIndicatorBuilder: (_) => const Padding(
-                      padding:
-                          EdgeInsets.symmetric(vertical: 32, horizontal: 16),
+                    noMoreItemsIndicatorBuilder: (_) => Padding(
+                      padding: const EdgeInsets.symmetric(
+                          vertical: 32, horizontal: 16),
                       child: Opacity(
                         opacity: 0.75,
                         child: Center(
-                          child: Text('Made in Portugal 🇵🇹'),
+                          child: Text('madeInPortugal'.tr),
                         ),
                       ),
                     ),

--- a/lib/util/translations/app_translations.dart
+++ b/lib/util/translations/app_translations.dart
@@ -438,6 +438,7 @@ class AppTranslations extends Translations {
           'searchForMusicTitle': 'Search for music',
           'searchForMusicDescription': 'Make your Hoot stand out with music',
           'feedbackSent': 'Thank you for your feedback!',
+          'madeInPortugal': 'Made in Portugal 🇵🇹',
         },
         'es': {
           'helloWorld': '¡Hola Mundo!',
@@ -882,6 +883,7 @@ class AppTranslations extends Translations {
           'searchForMusicTitle': 'Buscar música',
           'searchForMusicDescription': 'Haz que tu Hoot destaque con música',
           'feedbackSent': '¡Gracias por tus comentarios!',
+          'madeInPortugal': 'Hecho en Portugal 🇵🇹',
         },
         'pt_PT': {
           'helloWorld': 'Olá Mundo!',
@@ -1329,6 +1331,7 @@ class AppTranslations extends Translations {
           'searchForMusicDescription':
               'Faz com que o teu Hoot se destaque com música',
           'feedbackSent': 'Obrigado pelo teu feedback!',
+          'madeInPortugal': 'Feito em Portugal 🇵🇹',
         },
         'pt_BR': {
           'helloWorld': 'Olá Mundo!',
@@ -1771,6 +1774,7 @@ class AppTranslations extends Translations {
           'searchForMusicTitle': 'Procurar música',
           'searchForMusicDescription': 'Faça seu Hoot se destacar com música',
           'feedbackSent': 'Obrigado pelo seu feedback!',
+          'madeInPortugal': 'Feito em Portugal 🇵🇹',
         },
       };
 }


### PR DESCRIPTION
## Summary
- add `madeInPortugal` translation to each supported locale
- use translation string instead of hard-coded text in feed and notifications views

## Testing
- `dart format lib/util/translations/app_translations.dart lib/pages/feed/views/feed_view.dart lib/pages/notifications/views/notifications_view.dart`
- `flutter analyze` *(fails: 41 issues)*
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_6895f0c171ec83288c33a2dc05cf9925