### PR TITLE
Use translation for no results message in create post

### DIFF
--- a/lib/pages/create_post/controllers/create_post_controller.dart
+++ b/lib/pages/create_post/controllers/create_post_controller.dart
@@ -477,7 +477,7 @@ class _MusicSearchDelegate extends SearchDelegate<MusicAttachment?> {
         }
         final results = snapshot.data ?? [];
         if (results.isEmpty) {
-          return const Center(child: Text('No results'));
+          return Center(child: Text('noResults'.tr));
         }
         return ListView(
           children: results


### PR DESCRIPTION
## Summary
- replace hardcoded `No results` text with translation key

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env.)*
- `dart test` *(fails: Could not find package `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6895f0c35e3c832882a2e749f444bd1c