### PR TITLE
Add staff import JSON input view

### DIFF
--- a/lib/pages/staff_import/bindings/staff_import_binding.dart
+++ b/lib/pages/staff_import/bindings/staff_import_binding.dart
@@ -1,9 +1,10 @@
 import 'package:get/get.dart';
+import 'package:hoot/pages/staff_import/controllers/staff_import_controller.dart';
 
 /// Binding for the staff import view.
 class StaffImportBinding extends Bindings {
   @override
   void dependencies() {
-    // Add controllers or services for staff import here when needed.
+    Get.lazyPut(() => StaffImportController());
   }
 }

--- a/lib/pages/staff_import/controllers/staff_import_controller.dart
+++ b/lib/pages/staff_import/controllers/staff_import_controller.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+class StaffImportController extends GetxController {
+  final TextEditingController jsonController = TextEditingController();
+
+  void importData() {
+    final text = jsonController.text;
+    try {
+      final data = jsonDecode(text);
+      debugPrint('Imported data: $data');
+      Get.snackbar('Success', 'Data imported');
+    } catch (_) {
+      Get.snackbar('Error', 'Invalid JSON');
+    }
+  }
+
+  @override
+  void onClose() {
+    jsonController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/pages/staff_import/views/staff_import_view.dart
+++ b/lib/pages/staff_import/views/staff_import_view.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/pages/staff_import/controllers/staff_import_controller.dart';
 
-/// Simple placeholder view for staff imports.
-class StaffImportView extends StatelessWidget {
+class StaffImportView extends GetView<StaffImportController> {
   const StaffImportView({super.key});
 
   @override
@@ -12,8 +12,29 @@ class StaffImportView extends StatelessWidget {
       appBar: AppBarComponent(
         title: 'import'.tr,
       ),
-      body: Center(
-        child: Text('comingSoon'.tr),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: controller.jsonController,
+                maxLines: null,
+                expands: true,
+                keyboardType: TextInputType.multiline,
+                decoration: InputDecoration(
+                  hintText: 'Enter JSON data',
+                  border: const OutlineInputBorder(),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: controller.importData,
+              child: Text('submit'.tr),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- build staff import view with JSON TextField and submit button
- add controller handling JSON import logic
- register controller in binding

## Testing
- `dart analyze` *(fails: only "Analyzing Hoot..." output)*
- `flutter test` *(fails: Unable to find directory entry in pubspec.yaml: /workspace/Hoot/mock/data/)*

------
https://chatgpt.com/codex/tasks/task_e_689617ebb8a88328835b36d0914534a2