### PR TITLE
feat: add Firebase analytics service

### DIFF
--- a/lib/dependency_injector.dart
+++ b/lib/dependency_injector.dart
@@ -14,6 +14,7 @@ import 'package:hoot/services/news_service.dart';
 import 'package:hoot/services/challenge_service.dart';
 import 'package:hoot/services/app_review_service.dart';
 import 'package:hoot/services/music_service.dart';
+import 'package:hoot/services/analytics_service.dart';
 
 /// Registers global dependencies for the application.
 class DependencyInjector {
@@ -23,6 +24,7 @@ class DependencyInjector {
   static Future<void> init() async {
     final auth = Get.put(AuthService(), permanent: true);
     await auth.fetchUser();
+    Get.put(AnalyticsService(authService: auth), permanent: true);
     Get.put<BaseFeedService>(FeedService(), permanent: true);
     Get.put<BasePostService>(PostService(authService: auth), permanent: true);
     Get.put(SubscriptionService(), permanent: true);

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -1,0 +1,58 @@
+import 'dart:io';
+
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:get/get.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:hoot/services/auth_service.dart';
+
+/// Provides helpers for logging analytics events with common metadata.
+class AnalyticsService {
+  final FirebaseAnalytics _analytics;
+  final AuthService _authService;
+  PackageInfo? _packageInfo;
+
+  AnalyticsService({
+    FirebaseAnalytics? analytics,
+    AuthService? authService,
+  })  : _analytics = analytics ?? FirebaseAnalytics.instance,
+        _authService = authService ?? Get.find<AuthService>();
+
+  /// Sets the analytics user identifier.
+  Future<void> setUserId(String? userId) => _analytics.setUserId(id: userId);
+
+  /// Logs a custom [name] event with optional [parameters].
+  Future<void> logEvent(
+    String name, {
+    Map<String, Object?>? parameters,
+  }) async {
+    final params = await _withDefaults(parameters);
+    await _analytics.logEvent(name: name, parameters: params);
+  }
+
+  /// Logs a screen view event with [screenName] and optional [screenClass].
+  Future<void> logScreenView(
+    String screenName, {
+    String? screenClass,
+  }) async {
+    await logEvent('screen_view', parameters: {
+      'screen_name': screenName,
+      if (screenClass != null) 'screen_class': screenClass,
+    });
+  }
+
+  Future<Map<String, Object?>> _withDefaults(
+    Map<String, Object?>? parameters,
+  ) async {
+    _packageInfo ??= await PackageInfo.fromPlatform();
+    final uid = _authService.currentUser?.uid;
+    return {
+      if (uid != null) 'userId': uid,
+      'timestamp': DateTime.now().toIso8601String(),
+      'os': Platform.operatingSystem,
+      'osVersion': Platform.operatingSystemVersion,
+      'appVersion': _packageInfo!.version,
+      'buildNumber': _packageInfo!.buildNumber,
+      ...?parameters,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add AnalyticsService wrapping FirebaseAnalytics with default metadata helpers
- register AnalyticsService in dependency injector for global access

## Testing
- `flutter test` *(fails: No file or variants found for asset: assets/.env)*

------
https://chatgpt.com/codex/tasks/task_e_6897624fd84c832898700218f078007a