### PR TITLE
Add analytics route observer for screen logging

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:feedback/feedback.dart';
 import 'package:hoot/theme/theme.dart';
 import 'package:hoot/util/enums/app_colors.dart';
 import 'package:hoot/util/translations/app_translations.dart';
+import 'package:hoot/util/routes/analytics_route_observer.dart';
 import 'package:toastification/toastification.dart';
 import 'package:flutter_tenor_gif_picker/flutter_tenor_gif_picker.dart';
 import 'package:timeago/timeago.dart' as timeago;
@@ -79,6 +80,7 @@ void main() {
                 translations: AppTranslations(),
                 locale: languageService.locale.value,
                 fallbackLocale: const Locale('en', 'US'),
+                navigatorObservers: [AnalyticsRouteObserver()],
                 builder: (context, child) => GestureDetector(
                   behavior: HitTestBehavior.opaque,
                   onTap: () => FocusManager.instance.primaryFocus?.unfocus(),

--- a/lib/pages/terms.dart
+++ b/lib/pages/terms.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:hoot/components/appbar_component.dart';
+import 'package:hoot/services/analytics_service.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class TermsOfService extends StatefulWidget {
@@ -14,10 +16,11 @@ class _TermsOfServiceState extends State<TermsOfService> {
 
   @override
   void initState() {
+    super.initState();
+    Get.find<AnalyticsService>().logScreenView('terms_of_service');
     _controller = WebViewController();
     _controller.loadFlutterAsset('assets/terms/terms.html');
     _controller.platform.enableZoom(true);
-    super.initState();
   }
 
   @override

--- a/lib/util/routes/analytics_route_observer.dart
+++ b/lib/util/routes/analytics_route_observer.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/widgets.dart';
+import 'package:get/get.dart';
+import 'package:hoot/services/analytics_service.dart';
+
+/// A [NavigatorObserver] that logs screen views using [AnalyticsService].
+class AnalyticsRouteObserver extends GetObserver {
+  AnalyticsRouteObserver({AnalyticsService? analytics})
+      : _analytics = analytics ?? Get.find<AnalyticsService>();
+
+  final AnalyticsService _analytics;
+
+  void _log(Route? route) {
+    final name = route?.settings.name;
+    if (name != null && name.isNotEmpty) {
+      _analytics.logScreenView(name);
+    }
+  }
+
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    super.didPush(route, previousRoute);
+    _log(route);
+  }
+
+  @override
+  void didReplace({Route? newRoute, Route? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    _log(newRoute);
+  }
+
+  @override
+  void didPop(Route route, Route? previousRoute) {
+    super.didPop(route, previousRoute);
+    _log(previousRoute);
+  }
+}


### PR DESCRIPTION
## Summary
- add AnalyticsRouteObserver to log screen transitions via AnalyticsService
- hook route observer into GetMaterialApp
- track screen views in stateful TermsOfService widget

## Testing
- `dart analyze`
- `flutter test` *(fails: No Firebase App '[DEFAULT]' has been created)*

------
https://chatgpt.com/codex/tasks/task_e_68976891d56c8328b5f58ab29d4a708b