### PR TITLE
Add analytics logging to notification and OneSignal services

### DIFF
--- a/lib/services/onesignal_service.dart
+++ b/lib/services/onesignal_service.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get/get.dart';
 import 'package:flutter/widgets.dart';
@@ -5,29 +7,52 @@ import 'package:onesignal_flutter/onesignal_flutter.dart';
 import 'package:hoot/util/routes/app_routes.dart';
 import 'package:hoot/util/routes/args/feed_page_args.dart';
 import 'package:hoot/util/routes/args/profile_args.dart';
+import 'package:hoot/services/analytics_service.dart';
 
 /// Wrapper around the OneSignal SDK.
 class OneSignalService extends GetxService {
   Map<String, dynamic>? _pendingData;
+
+  AnalyticsService? get _analytics => Get.isRegistered<AnalyticsService>()
+      ? Get.find<AnalyticsService>()
+      : null;
 
   /// Initializes the OneSignal SDK.
   Future<void> init() async {
     OneSignal.initialize(dotenv.env['ONESIGNAL_APP_ID']!);
     OneSignal.Notifications.addClickListener((event) {
       _pendingData = event.notification.additionalData;
+      if (_analytics != null) {
+        _analytics!.logEvent('onesignal_notification_click', parameters: {
+          'notificationId': event.notification.notificationId,
+          if (event.notification.additionalData != null)
+            'payload': jsonEncode(event.notification.additionalData),
+        });
+      }
       WidgetsBinding.instance
           .addPostFrameCallback((_) => handlePendingNotification());
     });
   }
 
   /// Logs the user with [uid] into OneSignal.
-  Future<void> login(String uid) {
-    return OneSignal.login(uid);
+  Future<void> login(String uid) async {
+    await OneSignal.login(uid);
+    if (_analytics != null) {
+      await _analytics!.logEvent('onesignal_login', parameters: {
+        'userId': uid,
+      });
+    }
   }
 
   /// Prompts the user for notification permissions.
-  Future<bool> requestPermission() {
-    return OneSignal.Notifications.requestPermission(true);
+  Future<bool> requestPermission() async {
+    final result = await OneSignal.Notifications.requestPermission(true);
+    if (_analytics != null) {
+      await _analytics!.logEvent('onesignal_permission_prompt', parameters: {
+        'accepted': result,
+      });
+    }
+    return result;
   }
 
   /// Returns whether requesting permission will show a prompt.
@@ -36,8 +61,11 @@ class OneSignalService extends GetxService {
   }
 
   /// Clears notifications and resets the app badge.
-  Future<void> clearBadge() {
-    return OneSignal.Notifications.clearAll();
+  Future<void> clearBadge() async {
+    await OneSignal.Notifications.clearAll();
+    if (_analytics != null) {
+      await _analytics!.logEvent('onesignal_clear_badge');
+    }
   }
 
   void handlePendingNotification() {


### PR DESCRIPTION
## Summary
- track notification fetch/read actions with analytics
- log OneSignal permission, login, click and badge clear events

## Testing
- `flutter test test/onesignal_service_test.dart test/notification_service_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_68977934de148328bc205babd6f55065